### PR TITLE
fix: clean up duplicate and redundant entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,12 @@ ENV/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+*.egg-info/
 .coverage
 .coverage.*
 htmlcov/
 
 # Node.js / Frontend
-node_modules/
 **/node_modules/
 dist/
 build/
@@ -46,11 +46,6 @@ pnpm-debug.log*
 
 # reference
 reference/
-
-# environment
-venv/
-*.egg-info/
-
 
 # logs
 logs/


### PR DESCRIPTION
fix issue https://github.com/openJiuwen-ai/jiuwenclaw/issues/1
- Remove duplicate `venv/` entry (already in Python section)
- Remove redundant `node_modules/` (`**/node_modules/` covers it)
- Move `*.egg-info/` to Python section where it belongs
- Remove empty `# environment` section