### PR TITLE
Harden the ACP stdio interface for headless / programmatic use

### DIFF
--- a/docs/en/E2A-protocol.md
+++ b/docs/en/E2A-protocol.md
@@ -280,6 +280,52 @@ After parse: `channel`=`feishu`, `method`=`chat.send`, `timestamp` normalized to
 
 After `merge_params_to_acp_prompt`, `params` gains a `prompt` equivalent to `content_blocks` if there was no `prompt` before.
 
+### 11.6 `session/prompt` + per-request `workspace_dir`
+
+External clients (IDE plugins, headless evaluators, MCP drivers) can
+scope one prompt's filesystem root to a per-invocation directory by
+passing `workspace_dir` in `params`. The AgentServer resolves the path,
+creates it on demand (`mkdir -p`), and threads the absolute path through
+to `init_cwd(cwd=workspace_dir, workspace=workspace_dir)` so openjiuwen's
+per-task `CwdState` ContextVar is reseeded for the duration of the
+prompt. Both layers get the override:
+
+- **`get_cwd()`** returns the scratch dir, so tools resolving relative
+  paths land there.
+- **`get_workspace()`** also returns the scratch dir, so
+  `fs_operation`'s sandbox enforcement (which gates absolute-path writes
+  by workspace membership) accepts writes anywhere under it.
+
+Memory files, `.workspace`, and other artifact-root consumers therefore
+land under the scratch dir for that request — useful for hermetic
+evaluators that want one fresh slate per task. Long-lived agents whose
+memory must persist should *not* pass `workspace_dir`; they fall back to
+the agent's instance-level workspace as before.
+
+Precedence and behavior:
+
+- **Precedence:** when `workspace_dir` is set and `mkdir` succeeds, it
+  wins over `params.cwd`. When `workspace_dir` is set but `mkdir` fails
+  (e.g. permission denied), the request degrades to `params.cwd` (if
+  any), then to the agent's global default; a warning is logged.
+- **Path form:** absolute paths are recommended. Relative paths are
+  resolved against the AgentServer process cwd, not the client's.
+
+```json
+{
+  "method": "session/prompt",
+  "session_id": "s1",
+  "jsonrpc_id": 1,
+  "params": {
+    "content": "Create the project under datautils-project/",
+    "workspace_dir": "/tmp/eval-task-42"
+  }
+}
+```
+
+`jiuwenswarm-tui` (the ACP stdio bridge) exposes this as
+`--workspace-dir <path>`.
+
 ---
 
 ## 12. E2A response protocol (`E2AResponse`)

--- a/docs/en/E2A-protocol.md
+++ b/docs/en/E2A-protocol.md
@@ -422,6 +422,21 @@ Runtime list: **`constants.E2A_RESPONSE_KINDS`**; **`body`** is a **dict**. Norm
 
 Cross-reference: request log normalization in **`E2A-AgentRequest-log-migration.md`**; response logging can adopt the same single-line JSON convention later.
 
+### 12.9 Streaming `chat.error` carries `error_type`
+
+When the inner agent loop raises, the streaming aggregator emits a
+`chat.error` event whose payload carries the originating exception class.
+Consumers can group failures structurally instead of regexing the message
+string.
+
+```json
+{"event_type":"chat.error","error":"rate limited (429)","error_type":"RateLimitError"}
+```
+
+The same `error_type` field appears at the top level of the persisted
+`history.json` record. Cancellation (`asyncio.CancelledError`) propagates
+as cancellation rather than being classified as a `chat.error`.
+
 ---
 
 ## 13. Security notes

--- a/jiuwenswarm/channels/acp/app_acp.py
+++ b/jiuwenswarm/channels/acp/app_acp.py
@@ -55,6 +55,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help="ACP 请求使用的 session_id。",
     )
     acp_parser.add_argument(
+        "--workspace-dir",
+        default=None,
+        help=(
+            "Per-request scratch directory. The AgentServer mkdir-p's it and "
+            "scopes the agent's cwd (via openjiuwen's CwdState ContextVar) "
+            "to the path for the duration of the prompt, so filesystem/shell "
+            "tools resolve relative paths against it. See E2A-protocol.md "
+            "section 11.6."
+        ),
+    )
+    acp_parser.add_argument(
         "args",
         nargs=argparse.REMAINDER,
         help="Prompt 内容。",
@@ -69,9 +80,13 @@ def run_acp(args: argparse.Namespace) -> int:
         return 2
 
     request_id = f"acp_cli_{uuid.uuid4().hex[:12]}"
+    params: dict = {"content": prompt}
+    workspace_dir = getattr(args, "workspace_dir", None)
+    if workspace_dir:
+        params["workspace_dir"] = str(workspace_dir)
     env = envelope_from_acp_jsonrpc(
         method="session/prompt",
-        params={"content": prompt},
+        params=params,
         jsonrpc_id=request_id,
         session_id=str(args.session_id or "acp_cli_session"),
         channel="acp",

--- a/jiuwenswarm/channels/acp/app_acp.py
+++ b/jiuwenswarm/channels/acp/app_acp.py
@@ -130,6 +130,12 @@ def run_acp(args: argparse.Namespace) -> int:
                         "id": resp.jsonrpc_id,
                         "result": resp.body,
                     }
+                # The gateway may remap the client-supplied session_id to an
+                # internal id. Surface that resolved id so callers can locate
+                # the written history.json.
+                if isinstance(final_rpc.get("result"), dict):
+                    if not final_rpc["result"].get("session_id") and resp.session_id:
+                        final_rpc["result"]["session_id"] = resp.session_id
                 break
     finally:
         if proc.poll() is None:

--- a/jiuwenswarm/gateway/channel_manager/protocol/acp/acp_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/protocol/acp/acp_connect.py
@@ -801,6 +801,15 @@ class AcpChannel(BaseChannel):
             response_mode="e2a",
             session_id=msg.session_id,
         )
+        # Mirror the JSON-RPC session/prompt path (line ~1168): register the
+        # session→request mapping so gateway events (_message_from_gateway_event)
+        # can resolve their request_id and emit responses. Without this,
+        # streaming events on the envelope path are silently dropped and the
+        # channel hangs waiting for a final frame that never arrives. Scope
+        # this to session/prompt only -- non-prompt envelopes (session/cancel,
+        # session/load, etc.) must not clobber an in-flight prompt's mapping.
+        if msg.session_id and env.method == "session/prompt":
+            self._active_prompt_request_by_session[msg.session_id] = msg.id
 
         await self._dispatch_message(msg)
 

--- a/jiuwenswarm/server/runtime/agent_adapter/interface.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface.py
@@ -15,6 +15,7 @@ import json
 import logging
 import re
 import time
+from pathlib import Path
 from typing import Any, AsyncIterator, Tuple
 
 from datetime import datetime, timedelta, timezone
@@ -446,6 +447,29 @@ class JiuWenClaw:
                 "kind": "cron",
                 "context": {"extra": {"cron": cron}},
             }
+
+        # Per-request workspace_dir scopes one prompt's cwd to the given
+        # directory; threaded into inputs["cwd"] which downstream init_cwd
+        # installs onto openjiuwen's CwdState ContextVar. See E2A-protocol.md
+        # section 11.6 for the wire contract and precedence rules.
+        workspace_dir = request.params.get("workspace_dir")
+        if isinstance(workspace_dir, str) and workspace_dir.strip():
+            expanded = Path(workspace_dir).expanduser().resolve()
+            try:
+                expanded.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "[JiuWenClaw] workspace_dir %s mkdir failed (%s); "
+                    "request falls back to params.cwd or the global default",
+                    workspace_dir, exc,
+                )
+            else:
+                # Scope BOTH cwd and workspace so the agent's tools (which
+                # read get_cwd() for relative-path resolution) AND its
+                # fs_operation sandbox (which gates absolute-path writes by
+                # workspace membership) agree on the per-request root.
+                inputs["cwd"] = str(expanded)
+                inputs["workspace_dir"] = str(expanded)
 
         # 返回原始 query（未经 build_user_prompt 包装）
         # Team 模式需要使用原始 query，而不是 JSON 包装后的 prompt

--- a/jiuwenswarm/server/runtime/agent_adapter/interface.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface.py
@@ -1050,6 +1050,17 @@ class JiuWenClaw:
                     if isinstance(data, asyncio.CancelledError):
                         logger.info("[JiuWenClaw] 流式处理被中断: request_id=%s", rid)
                         raise data
+                    # Surface exception class so consumers can classify
+                    # failures structurally instead of regexing the message.
+                    error_type = (
+                        type(data).__name__ if isinstance(data, BaseException) else ""
+                    )
+                    error_payload: dict[str, Any] = {
+                        "event_type": "chat.error",
+                        "error": str(data),
+                    }
+                    if error_type:
+                        error_payload["error_type"] = error_type
                     append_history_record(
                         session_id=session_id,
                         request_id=rid,
@@ -1059,11 +1070,12 @@ class JiuWenClaw:
                         content=str(data),
                         timestamp=time.time(),
                         mode=request.params.get("mode", "unknown"),
+                        extra={"error_type": error_type} if error_type else None,
                     )
                     yield AgentResponseChunk(
                         request_id=rid,
                         channel_id=cid,
-                        payload={"event_type": "chat.error", "error": str(data)},
+                        payload=error_payload,
                         is_complete=False,
                     )
                 else:

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -4909,7 +4909,11 @@ class JiuWenClawDeepAdapter:
             yield AgentResponseChunk(
                 request_id=rid,
                 channel_id=cid,
-                payload={"event_type": "chat.error", "error": str(exc)},
+                payload={
+                    "event_type": "chat.error",
+                    "error": str(exc),
+                    "error_type": type(exc).__name__,
+                },
                 is_complete=False,
             )
         finally:

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -3095,9 +3095,20 @@ class JiuWenClawDeepAdapter:
         if self._instance.deep_config is not None:
             self._instance.deep_config.language = resolved_language
 
-    def _seed_runtime_cwd(self, cwd: str | None = None) -> None:
-        """Seed Core's CwdState holder from the request/runtime cwd."""
-        workspace_root = str(self._workspace_dir or self._project_dir or os.getcwd())
+    def _seed_runtime_cwd(
+        self, cwd: str | None = None, workspace: str | None = None
+    ) -> None:
+        """Seed Core's CwdState holder from the request/runtime cwd.
+
+        ``workspace``: optional per-request workspace override. When set,
+        becomes the workspace anchor for tools that read ``get_workspace()``
+        (notably ``fs_operation``'s sandbox enforcement, which gates
+        absolute-path writes by membership in the workspace tree). When
+        unset, falls back to the agent's instance-level workspace.
+        """
+        workspace_root = str(
+            workspace or self._workspace_dir or self._project_dir or os.getcwd()
+        )
         runtime_cwd = str(cwd or "").strip()
         if not runtime_cwd or not os.path.isdir(runtime_cwd):
             runtime_cwd = str(self._project_dir or "").strip()
@@ -3116,6 +3127,7 @@ class JiuWenClawDeepAdapter:
         request_metadata: dict[str, Any] | None = None
         trusted_dirs: list[str] | None = None
         cwd: str | None = None
+        workspace: str | None = None
         project_dir: str | None = None
 
     async def _update_runtime_config(self, runtime_config: "_RuntimeConfig") -> None:
@@ -3127,7 +3139,8 @@ class JiuWenClawDeepAdapter:
             runtime_config.cwd
             or runtime_config.project_dir
             or self._project_dir
-            or self._workspace_dir
+            or self._workspace_dir,
+            workspace=runtime_config.workspace,
         )
         resolved_language = self._resolve_runtime_language()
         resolved_channel = (
@@ -4481,6 +4494,7 @@ class JiuWenClawDeepAdapter:
                     request_metadata=request.metadata,
                     trusted_dirs=inputs.get("trusted_dirs"),
                     cwd=inputs.get("cwd"),
+                    workspace=inputs.get("workspace_dir"),
                     project_dir=inputs.get("project_dir"),
                 )
             )
@@ -4682,6 +4696,7 @@ class JiuWenClawDeepAdapter:
                     request_metadata=request.metadata,
                     trusted_dirs=inputs.get("trusted_dirs"),
                     cwd=inputs.get("cwd"),
+                    workspace=inputs.get("workspace_dir"),
                     project_dir=inputs.get("project_dir"),
                 )
             )

--- a/tests/unit/agentserver/test_interface_chat_error.py
+++ b/tests/unit/agentserver/test_interface_chat_error.py
@@ -1,0 +1,198 @@
+"""Regression test for chat.error stream events carrying ``error_type``.
+
+The streaming error aggregator in ``JiuWenClaw.process_message_stream``
+classifies the exception class on each chat.error event so that downstream
+consumers (log indexers, dashboards, external evaluators) can group failures
+without regexing the message text. This pins the contract on both the
+yielded ``AgentResponseChunk`` and the persisted history record.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, AsyncIterator, List
+
+import pytest
+
+from jiuwenswarm.server.runtime.agent_adapter import interface as interface_module
+from jiuwenswarm.server.runtime.agent_adapter.interface import JiuWenClaw
+from jiuwenswarm.common.schema.agent import AgentRequest, AgentResponseChunk
+
+
+class _RaisingAdapter:
+    """Fake AgentAdapter whose stream impl raises immediately."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def create_instance(self, config: dict[str, Any] | None = None) -> None:
+        return None
+
+    async def reload_agent_config(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def process_message_impl(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise self._exc
+
+    async def process_message_stream_impl(
+        self, _request: AgentRequest, _inputs: dict[str, Any]
+    ) -> AsyncIterator[AgentResponseChunk]:
+        # Force an exception to flow through the JiuWenClaw error aggregator.
+        raise self._exc
+        yield  # pragma: no cover  # make this a generator
+
+    async def process_interrupt(self, *_args: Any, **_kwargs: Any) -> Any:
+        return None
+
+    async def handle_user_answer(self, *_args: Any, **_kwargs: Any) -> Any:
+        return None
+
+    async def handle_heartbeat(self, *_args: Any, **_kwargs: Any) -> Any:
+        return None
+
+
+def _patch_facade(monkeypatch: pytest.MonkeyPatch, facade: JiuWenClaw, adapter: _RaisingAdapter, recorded: List[dict[str, Any]]) -> None:
+    facade._adapter = adapter  # type: ignore[attr-defined]
+    facade._sdk_name = "harness"  # type: ignore[attr-defined]
+
+    def _capture_history(**kwargs: Any) -> None:
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(interface_module, "append_history_record", _capture_history)
+    monkeypatch.setattr(interface_module, "get_config", lambda: {"preferred_language": "zh"})
+    monkeypatch.setattr(interface_module, "get_memory_mode", lambda _cfg: "off")
+    # Bypass the user prompt builder; the test only cares about the error
+    # aggregator after the inner stream raises.
+    monkeypatch.setattr(interface_module, "build_user_prompt", lambda q, **_kw: q)
+
+
+@pytest.mark.asyncio
+async def test_chat_error_chunk_includes_error_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    facade = JiuWenClaw()
+    adapter = _RaisingAdapter(ValueError("boom from agent"))
+    history: List[dict[str, Any]] = []
+    _patch_facade(monkeypatch, facade, adapter, history)
+
+    request = AgentRequest(
+        request_id="req-err-1",
+        channel_id="acp",
+        session_id="acp_test_sess",
+        params={"query": "hello", "mode": "agent.plan"},
+    )
+
+    chunks: List[AgentResponseChunk] = []
+    async for chunk in facade.process_message_stream(request):
+        chunks.append(chunk)
+
+    error_chunks = [
+        c for c in chunks
+        if isinstance(c.payload, dict) and c.payload.get("event_type") == "chat.error"
+    ]
+    assert len(error_chunks) == 1, f"expected 1 chat.error chunk, got {len(error_chunks)}"
+    payload = error_chunks[0].payload
+    assert payload["error_type"] == "ValueError"
+    assert "boom from agent" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_chat_error_history_record_carries_error_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    facade = JiuWenClaw()
+    adapter = _RaisingAdapter(RuntimeError("rate limited"))
+    history: List[dict[str, Any]] = []
+    _patch_facade(monkeypatch, facade, adapter, history)
+
+    request = AgentRequest(
+        request_id="req-err-2",
+        channel_id="acp",
+        session_id="acp_test_sess",
+        params={"query": "hi", "mode": "agent.plan"},
+    )
+    async for _chunk in facade.process_message_stream(request):
+        pass
+
+    error_records = [
+        r for r in history if r.get("event_type") == "chat.error"
+    ]
+    assert len(error_records) == 1
+    extra = error_records[0].get("extra")
+    assert isinstance(extra, dict)
+    assert extra.get("error_type") == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_chat_error_history_record_persists_error_type_at_top_level(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Pin the doc claim that ``error_type`` ends up on the persisted record's
+    top level (via ``append_history_record``'s ``extra`` flattening). Drives
+    the real ``append_history_record`` against a tempdir sessions root and
+    reads the resulting JSON."""
+    from jiuwenswarm.server.runtime.session import session_history
+    from jiuwenswarm.server.runtime.session import session_metadata
+
+    facade = JiuWenClaw()
+    adapter = _RaisingAdapter(LookupError("token bucket exhausted"))
+    facade._adapter = adapter  # type: ignore[attr-defined]
+    facade._sdk_name = "harness"  # type: ignore[attr-defined]
+
+    # Redirect session_history's sessions dir into the tempdir; do NOT mock
+    # append_history_record itself — we want the real flatten-and-write path.
+    # session_metadata.py imports get_agent_sessions_dir into its own module
+    # namespace and is invoked transitively by append_history_record, so it
+    # needs the same redirect or it writes metadata.json to the real
+    # ~/.jiuwenswarm sessions dir.
+    sessions_root = tmp_path / "sessions"
+    sessions_root.mkdir()
+    monkeypatch.setattr(session_history, "get_agent_sessions_dir", lambda: sessions_root)
+    monkeypatch.setattr(session_metadata, "get_agent_sessions_dir", lambda: sessions_root)
+    monkeypatch.setattr(interface_module, "get_config", lambda: {"preferred_language": "zh"})
+    monkeypatch.setattr(interface_module, "get_memory_mode", lambda _cfg: "off")
+    monkeypatch.setattr(interface_module, "build_user_prompt", lambda q, **_kw: q)
+
+    sid = "tempsess1"
+    request = AgentRequest(
+        request_id="req-err-disk",
+        channel_id="acp",
+        session_id=sid,
+        params={"query": "hi", "mode": "agent.plan"},
+    )
+    async for _chunk in facade.process_message_stream(request):
+        pass
+
+    # Drain async writer queue so the file is actually flushed before we read.
+    session_history._WRITE_QUEUE.join()
+
+    history_file = sessions_root / sid / "history.json"
+    assert history_file.exists(), f"history.json not written at {history_file}"
+    persisted = json.loads(history_file.read_text(encoding="utf-8"))
+    chat_errors = [r for r in persisted if r.get("event_type") == "chat.error"]
+    assert len(chat_errors) == 1
+    # The doc claims this field is at the top level (not nested under
+    # event_payload or extra). Pin it.
+    assert chat_errors[0].get("error_type") == "LookupError"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_propagates_without_chat_error_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """asyncio.CancelledError must propagate as cancellation, not be classified
+    and yielded as a chat.error event."""
+    facade = JiuWenClaw()
+    adapter = _RaisingAdapter(asyncio.CancelledError())
+    history: List[dict[str, Any]] = []
+    _patch_facade(monkeypatch, facade, adapter, history)
+
+    request = AgentRequest(
+        request_id="req-cancel",
+        channel_id="acp",
+        session_id="acp_test_sess",
+        params={"query": "hi", "mode": "agent.plan"},
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _chunk in facade.process_message_stream(request):
+            pass
+
+    # No history record for cancellation
+    assert not [r for r in history if r.get("event_type") == "chat.error"]

--- a/tests/unit/channel/test_acp_channel_envelope_path.py
+++ b/tests/unit/channel/test_acp_channel_envelope_path.py
@@ -1,0 +1,104 @@
+"""Regression test for envelope-path session→request mapping.
+
+The JSON-RPC `session/prompt` handler registers
+``_active_prompt_request_by_session[session_id] = msg.id`` so that
+``_message_from_gateway_event`` can route streamed events back to the
+originating prompt request. The envelope path used by ``app_cli`` (and
+any external stdio driver speaking E2AEnvelope) historically forgot
+that registration -- the channel would then drop every gateway event
+and the client's ``proc.stdout`` reader would hang waiting for a final
+frame that never arrives.
+
+This test pins the contract: after ``_handle_raw_line`` processes an
+envelope with ``session_id``, the mapping must be populated.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from jiuwenswarm.gateway.channel_manager.protocol.acp.acp_connect import (
+    AcpChannel,
+    AcpChannelConfig,
+)
+
+
+class _NoopBus:
+    @staticmethod
+    async def publish_user_messages(_msg: Any) -> None:
+        return None
+
+
+def _build_channel() -> AcpChannel:
+    return AcpChannel(
+        AcpChannelConfig(
+            enabled=True,
+            channel_id="acp",
+            default_session_id="acp_cli_session",
+            metadata={},
+        ),
+        router=_NoopBus(),
+        gateway_url=None,
+    )
+
+
+def _envelope(session_id: str, *, request_id: str = "req-1") -> str:
+    """Minimal session/prompt envelope as written to acp_channel stdin."""
+    return json.dumps({
+        "protocol_version": "1.0",
+        "request_id": request_id,
+        "method": "session/prompt",
+        "params": {"content": "hi"},
+        "channel": "acp",
+        "session_id": session_id,
+        "is_stream": True,
+        "jsonrpc_id": request_id,
+    })
+
+
+@pytest.mark.asyncio
+async def test_handle_raw_line_registers_session_to_request_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = _build_channel()
+    # Skip dispatch (no gateway available in unit tests); we only care about
+    # what state `_handle_raw_line` itself leaves behind.
+    async def _noop(_msg: Any) -> None:
+        return None
+    monkeypatch.setattr(channel, "_dispatch_message", _noop)
+
+    sid = "session-xyz"
+    await channel._handle_raw_line(_envelope(sid))
+
+    mapped_request_id = channel._active_prompt_request_by_session.get(sid)
+    assert mapped_request_id is not None, (
+        "envelope path must register session→request mapping so gateway events"
+        " can be routed back to the originating prompt"
+    )
+    assert mapped_request_id in channel._request_ctx
+
+
+@pytest.mark.asyncio
+async def test_handle_raw_line_skips_mapping_when_session_id_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Envelope with empty session_id falls back to default; mapping is keyed by
+    whatever session_id the message carries (the default in this case)."""
+    channel = _build_channel()
+    async def _noop(_msg: Any) -> None:
+        return None
+    monkeypatch.setattr(channel, "_dispatch_message", _noop)
+
+    env = json.dumps({
+        "protocol_version": "1.0",
+        "request_id": "req-2",
+        "method": "session/prompt",
+        "params": {"content": "hi"},
+        "channel": "acp",
+        # session_id intentionally absent — _envelope_to_message falls back
+        # to channel default
+        "is_stream": True,
+        "jsonrpc_id": "req-2",
+    })
+    await channel._handle_raw_line(env)
+    # Default session id from config (not None), so mapping IS populated.
+    # The contract is "if msg.session_id, register" — falsy session_id skips.
+    assert channel._active_prompt_request_by_session.get("acp_cli_session") is not None

--- a/tests/unit_tests/agentserver/test_agentserver_modes.py
+++ b/tests/unit_tests/agentserver/test_agentserver_modes.py
@@ -306,6 +306,152 @@ def test_deep_adapter_handle_user_answer_ignores_team_plan_approval_compat(monke
     assert response.payload["resolved"] is False
 
 
+def test_build_inputs_threads_workspace_dir_into_cwd(monkeypatch, tmp_path):
+    """``params.workspace_dir`` scopes a single prompt's cwd AND workspace to
+    the supplied directory and creates it on demand. Threaded into BOTH
+    ``inputs["cwd"]`` (so tools that read ``get_cwd()`` resolve relative paths
+    against it) and ``inputs["workspace_dir"]`` (so the deep adapter forwards
+    it as the workspace override on ``init_cwd``, which controls
+    ``fs_operation``'s sandbox enforcement for absolute-path writes). Used by
+    external drivers (IDE plugins, headless evaluators) that allocate a
+    per-invocation scratch dir.
+    """
+    from jiuwenswarm.server.runtime.agent_adapter import interface as interface_module
+
+    class FakeSkillManager:
+        def __init__(self, workspace_dir=None):
+            self.workspace_dir = workspace_dir
+            self.hook = None
+
+        def set_skillnet_install_complete_hook(self, hook):
+            self.hook = hook
+
+    class FakeSessionManager:
+        @staticmethod
+        def get_session_id(session_id):
+            return session_id or "default"
+
+        async def submit_and_wait(self, _session_id, task_func):
+            return await task_func()
+
+    class FakeAdapter:
+        def __init__(self):
+            self.seen_inputs = None
+            self.skill_manager = None
+
+        def set_skill_manager(self, skill_manager):
+            self.skill_manager = skill_manager
+
+        async def handle_heartbeat(self, _request):
+            return None
+
+        async def process_message_impl(self, request, inputs):
+            self.seen_inputs = inputs
+            return AgentResponse(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                payload={"content": "ok"},
+            )
+
+    fake_adapter = FakeAdapter()
+
+    monkeypatch.setattr(interface_module, "get_config", lambda: {"preferred_language": "zh"})
+    monkeypatch.setattr(interface_module, "get_memory_mode", lambda _config: "disabled")
+    monkeypatch.setattr(interface_module, "SkillManager", FakeSkillManager)
+    monkeypatch.setattr(interface_module, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(interface_module, "append_history_record", lambda **_kwargs: None)
+    monkeypatch.setattr(interface_module, "resolve_sdk_choice", lambda: "harness")
+    monkeypatch.setattr(interface_module, "create_adapter", lambda _sdk, mode="agent": fake_adapter)
+
+    scratch = tmp_path / "scoped-run-001"  # does NOT exist yet
+    assert not scratch.exists()
+
+    request = AgentRequest(
+        request_id="req-ws",
+        channel_id="acp",
+        session_id="acp_session",
+        params={"query": "hello", "workspace_dir": str(scratch)},
+    )
+
+    asyncio.run(interface_module.JiuWenClaw().process_message(request))
+
+    inputs = fake_adapter.seen_inputs
+    # Path is resolved (symlinks followed, absolute form) before threading.
+    resolved = str(scratch.resolve())
+    assert inputs["cwd"] == resolved, "workspace_dir must thread into inputs.cwd"
+    assert inputs["workspace_dir"] == resolved, (
+        "workspace_dir must also thread into inputs.workspace_dir so the deep "
+        "adapter forwards it as the workspace override on init_cwd"
+    )
+    assert scratch.is_dir(), "_build_inputs must mkdir the scratch dir"
+
+
+def test_build_inputs_omits_cwd_when_workspace_dir_unset(monkeypatch):
+    """When ``params.workspace_dir`` is absent or empty, ``_build_inputs``
+    does not overwrite ``inputs.cwd`` -- letting the explicit ``params.cwd``
+    (or the downstream default) win.
+    """
+    from jiuwenswarm.server.runtime.agent_adapter import interface as interface_module
+
+    class FakeSkillManager:
+        def __init__(self, workspace_dir=None):
+            self.workspace_dir = workspace_dir
+            self.hook = None
+
+        def set_skillnet_install_complete_hook(self, hook):
+            self.hook = hook
+
+    class FakeSessionManager:
+        @staticmethod
+        def get_session_id(session_id):
+            return session_id or "default"
+
+        async def submit_and_wait(self, _session_id, task_func):
+            return await task_func()
+
+    class FakeAdapter:
+        def __init__(self):
+            self.seen_inputs = None
+            self.skill_manager = None
+
+        def set_skill_manager(self, skill_manager):
+            self.skill_manager = skill_manager
+
+        async def handle_heartbeat(self, _request):
+            return None
+
+        async def process_message_impl(self, request, inputs):
+            self.seen_inputs = inputs
+            return AgentResponse(
+                request_id=request.request_id,
+                channel_id=request.channel_id,
+                payload={"content": "ok"},
+            )
+
+    fake_adapter = FakeAdapter()
+
+    monkeypatch.setattr(interface_module, "get_config", lambda: {"preferred_language": "zh"})
+    monkeypatch.setattr(interface_module, "get_memory_mode", lambda _config: "disabled")
+    monkeypatch.setattr(interface_module, "SkillManager", FakeSkillManager)
+    monkeypatch.setattr(interface_module, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(interface_module, "append_history_record", lambda **_kwargs: None)
+    monkeypatch.setattr(interface_module, "resolve_sdk_choice", lambda: "harness")
+    monkeypatch.setattr(interface_module, "create_adapter", lambda _sdk, mode="agent": fake_adapter)
+
+    request = AgentRequest(
+        request_id="req-nows",
+        channel_id="acp",
+        session_id="acp_session",
+        params={"query": "hello", "cwd": "/tmp/explicit-cwd"},  # no workspace_dir
+    )
+
+    asyncio.run(interface_module.JiuWenClaw().process_message(request))
+
+    inputs = fake_adapter.seen_inputs
+    # params.cwd is preserved untouched
+    assert inputs["cwd"] == "/tmp/explicit-cwd"
+
+
 def test_handle_stream_accepts_team_mode_without_sub_mode(monkeypatch):
     class FakeAgent:
         def __init__(self):


### PR DESCRIPTION
jiuwenswarm exposes a programmatic entry point — `app_acp` over E2A envelope JSON-RPC — intended for non-interactive callers (IDE plugins, headless evaluators, CI, MCP clients). The interface is documented in the E2A protocol spec, but four concrete gaps make it impractical to use today:

1. **The envelope path hangs.** Any client that sends `session/prompt` as an `E2AEnvelope` (the documented non-JSON-RPC entry) never sees streamed events — the channel forgets to register the session→request routing entry, so every gateway event for that prompt is dropped and the client blocks forever waiting for a final frame that never arrives.
2. **You can't find your own conversation.** jiuwenswarm remaps the client's `session_id` to an internal `acp_*` id before writing `history.json`, but the wire response only echoes the original id. Programmatic callers cannot locate their own output on disk without a workaround (snapshot-diffing the `sessions/` directory pre/post).
3. **No per-invocation isolation.** The agent is bound to a single home-dir workspace at sidecar boot. Embedders that allocate per-invocation directories — IDE plugin scoped to the current project, multi-tenant server with one session per user, headless evaluator with hermetic task dirs — have no way to scope one prompt to its own filesystem root; everything shares state.
4. **Errors are unstructured.** `chat.error` carries only a free-text message. Anyone running jiuwenswarm in production who wants to monitor failure rates by category has to regex the message text.

## Tests

New unit tests under `tests/unit/channel/`, `tests/unit/agentserver/`, and additions to `tests/unit_tests/agentserver/test_agentserver_modes.py`. 53 tests pass in the touched areas on top of latest `develop`.

## Limitations (out of scope)

- `workspace_dir` scopes the parent agent's `CwdState`. Subagent `Workspace.root_path` is built at sidecar boot and isn't per-request, so a code/research subagent still resolves under the global workspace.
- The static system prompt in `prompt_builder.py` still names the home-dir workspace. A model that emits absolute paths from it can bypass the per-request scope (writes then fail the fs sandbox).
- Five other `chat.error` emission sites (team errors, auto_harness, agent_ws_server, etc.) still lack `error_type` — same pattern, easy follow-up.
