### PR TITLE
fix: skill_turbo P7/P8 注入用户 query、页码规则条件化、底色检查风格感知

### DIFF
--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
@@ -118,7 +118,8 @@ _DESIGN_RULES_DIGEST = (
     "1. 容器：`.ppt-slide { width:1280px; height:720px; overflow:hidden; box-sizing:border-box }`\n"
     "2. 安全区：`.content-safe { width:1220px; height:660px; margin:30px auto }`，主要内容必须放在安全区内；"
     "子元素禁止额外加 padding，否则导致双重边距\n"
-    "3. 三级字号：页面标题 36-48px / 副标题 24-28px / 正文 16-20px；"
+    "3. 三级字号：页面标题 36-48px / 副标题 24-28px / 正文 16-20px"
+    "（除非用户在原始 query 中明确指定了字号，此时以用户指定值为准）；"
     "但紧凑卡片内（grid 子项或 flex-col 中 ≥3 个并列卡片）标题 ≤18px、正文 ≤14px，"
     "同级卡片字号必须一致，禁止个别卡片字号放大导致内容溢出\n"
     "4. 图表类型：时序数据→折线图(line)；对比数据→柱状图/分组柱状图(bar)；"
@@ -150,9 +151,11 @@ _DESIGN_RULES_DIGEST = (
     "10. flex-col 子元素：必须 `flex-1 min-h-0 overflow-hidden`\n"
     "10.1 内容预算：flex-col 中有多个子元素时，禁止把大块内容（如完整表格）设 `flex-shrink-0`，"
     "否则会挤压其他 `flex-1` 兄弟元素至高度为 0；大块内容也要参与弹性收缩或拆分\n"
-    "11. 配色与字体严格来自风格规范文件，禁止使用未定义的颜色或字体；"
+    "11. 配色与字体严格来自风格规范文件，禁止使用未定义的颜色或字体"
+    "（除非用户在原始 query 中明确指定了字体或配色，此时以用户指定值为准）；"
     "所有页面 `<body>` 背景色必须统一，从风格规范中取一致的背景色，禁止部分页面用浅灰/灰色背景而其他页用白色\n"
-    "12. 页脚：底部必须有数据来源汇总条（如'数据来源：央行、财政部、...'），即使卡片内已有来源标注也必须保留页脚，禁止纯数字编号\n"
+    "12. 页脚：底部必须有数据来源汇总条（如'数据来源：央行、财政部、...'），即使卡片内已有来源标注也必须保留页脚；"
+    "禁止页脚出现纯数字页码编号（除非用户在原始 query 中明确要求页码，此时应在用户指定位置添加页码，格式如 3/12）\n"
     "13. 布局实现：所有区域用 `flex-1 min-h-0` 自动分配高度，禁止手动计算 px 值；子元素用 `h-full min-h-0 overflow-hidden` 防溢出，信任 flex/grid 自动布局\n"
     "13.1 表格禁用 CSS Grid：html-to-pptx 引擎不支持 `display:grid` 渲染表格，grid 表格会被转为低质量截图；"
     "数据表格必须用 `<table><tr><td>` 原生标签或 `flex` 布局替代 `grid grid-cols-N`\n"
@@ -164,8 +167,7 @@ _DESIGN_RULES_DIGEST = (
     "17. 标题、正文、图表标签、数据来源和数据卡片必须完整显示，禁止裁切或隐藏\n"
     "18. 遮罩层≠底色：`bg-black/50`、`from-black/*`、`bg-gradient-*` 等是遮罩层(overlay)，"
     "必须配合底层 `<img>` 背景图使用以保证文字可读，不是页面/卡片底色；"
-    "页面底色仅用风格规范文件中定义的背景色，"
-    "禁止用 `bg-black`、`from-black/*`、`bg-brandRedBg` 等作整页背景\n"
+    "页面底色必须严格遵循风格规范文件定义的背景色，禁止使用与风格不符的底色\n"
 )
 
 
@@ -196,13 +198,15 @@ _STRUCTURAL_DESIGN_RULES = (
     "1. 容器：`.ppt-slide { width:1280px; height:720px; overflow:hidden; box-sizing:border-box }`\n"
     "2. 安全区：`.content-safe { width:1220px; height:660px; margin:30px auto }`\n"
     "3. 字号：封面标题 48-64px / 副标题 24-28px / 日期 18px；"
-    "结束页标题 42-48px / 正文 22px\n"
+    "结束页标题 42-48px / 正文 22px"
+    "（除非用户在原始 query 中明确指定了字号，此时以用户指定值为准）\n"
     "4. 防溢出：单行文字不超容器宽度\n"
-    "5. 配色与字体严格来自风格规范文件，禁止使用未定义的颜色或字体；"
+    "5. 配色与字体严格来自风格规范文件，禁止使用未定义的颜色或字体"
+    "（除非用户在原始 query 中明确指定了字体或配色，此时以用户指定值为准）；"
     "所有页面背景色必须统一，从风格规范中取一致的背景色，禁止部分页面自行使用不同背景色；"
-    "页面背景色必须与风格规范一致，禁止自行使用渐变或深色背景；"
-    "封面/结束页如使用图片背景，`from-black/*` 渐变层是遮罩(overlay)非底色，"
-    "商务经典风格封面/结束页优先白底方案，不推荐图片+黑色遮罩方案\n"
+    "页面背景色必须与风格规范一致，深色主题用深色底色、浅色主题用浅色底色，"
+    "禁止自行使用与风格不符的渐变或底色；"
+    "封面/结束页如使用图片背景，`from-black/*` 渐变层是遮罩(overlay)非底色\n"
     "6. 布局：居中排列（`flex flex-col items-center justify-center`），"
     "不强制 grid-cols-2 双栏\n"
     "7. 留白：允许较高留白，不强制数据卡片、图表或数据来源页脚\n"
@@ -745,7 +749,16 @@ def _build_page_prompt(
     rewrite_hint: str = "",
     original_html: str = "",
     image_map_page: str = "",
+    user_query: str = "",
 ) -> str:
+    # 用户原始 query 段（最高优先级，包含用户所有格式/内容/风格要求）
+    user_query_section = ""
+    if user_query:
+        user_query_section = (
+            "## 用户原始 query（最高优先级，所有格式/版式/风格要求以此为准）\n"
+            f"{user_query}\n\n"
+        )
+
     preset_clause = ""
     if style_id in _PRESET_STYLE_IDS:
         preset_clause = (
@@ -857,6 +870,7 @@ def _build_page_prompt(
         )
 
     return (
+        f"{user_query_section}"
         "## 0. 输出要求（最高优先级）\n"
         f"- 输出**第 {page_number} 页**完整 HTML（含 <!DOCTYPE>、<html>、<head>、<body>）\n"
         "- 严禁任何解释、注释、Markdown 代码块包裹，只输出 HTML 原文\n"
@@ -922,6 +936,7 @@ class PageGenContext:
     image_map_page: str  # 本页图片素材描述（空串=无图）
     designer_md_text: str  # designer/SKILL.md 原文（由 PrepareNode 通过 read_file 读取）
     charts_md_text: str  # designer/charts.md 原文（由 PrepareNode 通过 read_file 读取）
+    user_query: str = ""  # 用户原始 query（由 collect_user_text 提取）
 
 
 class PrepareNode(PlanNode):
@@ -1177,6 +1192,7 @@ class PageWorkerNode(PlanNode):
         image_map: dict[str, Any] = inputs.get("image_map") or {}
         designer_md_text = str(inputs.get("designer_md_text") or "")
         charts_md_text = str(inputs.get("charts_md_text") or "")
+        user_query = PptCommon.collect_user_text(inputs)
 
         if not pages_dir or not all_pages:
             logger.error("[P8.1] 必填输入缺失，跳过生成")
@@ -1206,6 +1222,7 @@ class PageWorkerNode(PlanNode):
                 image_map=image_map,
                 designer_md_text=designer_md_text,
                 charts_md_text=charts_md_text,
+                user_query=user_query,
             )
             for p in all_pages
         ]
@@ -1263,6 +1280,7 @@ class PageWorkerNode(PlanNode):
         image_map: dict[str, Any],
         designer_md_text: str = "",
         charts_md_text: str = "",
+        user_query: str = "",
     ) -> dict[str, Any]:
         """单页闭环：生成(含重试) → 密度判定 → 搜索补充+重写(含重试)。"""
         path = f"{pages_dir}/page-{page_num}.pptx.html"
@@ -1291,6 +1309,7 @@ class PageWorkerNode(PlanNode):
             image_map_page=image_map_page,
             designer_md_text=designer_md_text,
             charts_md_text=charts_md_text,
+            user_query=user_query,
         )
 
         html = ""
@@ -1369,6 +1388,7 @@ class PageWorkerNode(PlanNode):
                     image_map_page=ctx.image_map_page,
                     designer_md_text=ctx.designer_md_text,
                     charts_md_text=ctx.charts_md_text,
+                    user_query=ctx.user_query,
                 ),
                 system_prompt="你是资深演示文稿设计师，直接输出完整 HTML 原文，不输出任何解释。",
                 node_name=f"p8_1_page_{ctx.page_num}",
@@ -1529,6 +1549,7 @@ class PageWorkerNode(PlanNode):
                     image_map_page=ctx.image_map_page,
                     designer_md_text=ctx.designer_md_text,
                     charts_md_text=ctx.charts_md_text,
+                    user_query=ctx.user_query,
                 ),
                 system_prompt="你是资深演示文稿设计师，直接输出完整 HTML 原文，不输出任何解释。",
                 node_name=f"p8_2_page_{ctx.page_num}",

--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/style_prepare.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/style_prepare.py
@@ -76,6 +76,7 @@ class StylePrepareNode(PlanNode):
         topic = str(inputs.get("topic", "")).strip()
         style_description = str(inputs.get("style_description", "")).strip()
         output_dir = str(inputs.get("output_dir", "")).strip()
+        user_query = PptCommon.collect_user_text(inputs)
 
         if not output_dir:
             logger.error("[P7] output_dir 为空，无法落盘风格文件")
@@ -112,7 +113,7 @@ class StylePrepareNode(PlanNode):
         if not style_content:
             if style_id in _PRESET_STYLES:
                 logger.warning("[P7] 预设风格 %s 加载失败，降级为自定义生成", style_id)
-            style_content = await self._generate_custom_style(topic, style_id, style_description)
+            style_content = await self._generate_custom_style(topic, style_id, style_description, user_query)
 
         if not style_content:
             logger.error(
@@ -184,13 +185,18 @@ class StylePrepareNode(PlanNode):
         topic: str,
         style_id: str,
         style_description: str,
+        user_query: str = "",
     ) -> str:
+        user_query_clause = ""
+        if user_query:
+            user_query_clause = f"用户原始 query：{user_query}\n"
         prompt = (
             "你是 PPT 视觉设计师。请根据主题和风格描述生成一份风格规范 Markdown 文件，"
             "供后续 HTML 幻灯片生成使用。\n\n"
             f"PPT 主题：{topic or '（未提供）'}\n"
             f"风格标识：{style_id}\n"
-            f"用户风格描述：{style_description or '（未提供，请根据主题自由发挥）'}\n\n"
+            f"用户风格描述：{style_description or '（未提供，请根据主题自由发挥）'}\n"
+            f"{user_query_clause}\n"
             "### 输出要求（严格按以下结构生成）\n"
             "```markdown\n"
             f"# 风格规范：{style_id}\n"


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# Skill 加速：P7/P8 用户原始 query 注入与页码规则条件化

## 一、问题概述

skill_turbo 相比完整 pptx-craft skill（LLM 主控编排）存在**用户需求不遵从**问题：用户 query 中明确要求"页码位于每页右下角"，skill_turbo 不加页码。

### 根因

用户原始 query 通过 `inputs` 中的 `task` / `user_request` / `user_message` / `query` 键进入流水线，`_merge_subplan_result` 会把它一路携带到每个 Node。但**各 Node 是否 READ 它**：

| Node                   | 是否读取用户原始 query | 方式                                                         |
| ---------------------- | ---------------------- | ------------------------------------------------------------ |
| P1 intent_classify     | ✅ 是                   | `collect_user_text(inputs)` → LLM 提取路径和 slots           |
| P2 requirement_collect | ✅ 是                   | `collect_user_text(inputs)` → P21 槽位 prompt、P24 派生 prompt 等 6 处 |
| P3 document_parse      | ✅ 是                   | `collect_user_text(inputs)` → 主题推断 prompt                |
| P4 content_plan        | ✅ 是                   | `PptCommon.collect_user_text(inputs)` → 大纲生成 prompt      |
| P5 deep_research       | ❌ 否                   | 不读取，仅依赖 outline 内容                                  |
| **P7 style_prepare**   | ❌ **否**               | 只读 topic + style_description + format_requirements         |
| **P8 ppt_page_gen**    | ❌ **否**               | 只读 outline_pages + style_text + format_requirements        |

对比完整 skill（react 模式）：主控 LLM 有完整对话上下文，每次创建 subagent 时天然带着用户原始 query。skill_turbo 每个 Node 是独立 Python 函数，只读自己声明的 inputs 字段，P7/P8 没有调用 `collect_user_text`，所以用户原始 query 虽然在 inputs 里但没被使用。

此外，`ppt_page_gen.py` 的 `_DESIGN_RULES_DIGEST` 规则 12 和 `designer/SKILL.md` 规则 6 都**无条件硬编码**"禁止页脚出现页码"，导致即使用户明确要求页码也无法添加。

---

## 二、方案

### 核心思路

用户原始 query 已经在 `inputs` 中（`task` / `user_request` / `user_message` / `query` 键），不需要改 P1 的 slots 提取。只需：

1. **让 P7 和 P8 调用 `collect_user_text(inputs)` 读取它**，注入到各自的 LLM prompt 中，明确标注"用户原始 query"
2. **直接修改"禁止页码"规则本身**，使其条件化——"除非用户在原始 query 中明确要求页码"

### 对比旧方案

| 维度            | 旧方案（format_requirements + 页码覆盖声明）                 | 新方案（collect_user_text + 规则条件化）                   |
| --------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
| 用户 query 来源 | P1 LLM 提取 `format_requirements` 槽位（损失性提取）         | `collect_user_text(inputs)` 直接取原始 query（无损失）     |
| 页码解除禁令    | 运行时注入 `page_number_override` 覆盖声明（定制化，与规则矛盾） | 直接修改规则 12 为条件式（规则自洽）                       |
| 改动范围        | 4 文件（intent_classify + requirement_collect + style_prepare + ppt_page_gen） | 3 文件（style_prepare + ppt_page_gen + designer/SKILL.md） |
| 复杂度          | 新增提取字段 + 全链路透传 + 运行时覆盖                       | 直接读已有 inputs + 修改规则文本                           |

### 优势

1. 原始 query 包含**所有**要求（格式+内容+风格），不是损失性提取
2. 每个 Node 的 LLM 可在自己的上下文中解读
3. 更简单——不需要维护额外的提取字段
4. 规则自洽——LLM 看到条件式规则 + 用户原文，自然解读，不存在矛盾指令

---

## 三、数据流

```
用户 query "页码位于每页右下角"
  → inputs.task / user_request / user_message / query（流水线已有）
  → P7 style_prepare._execute
    → collect_user_text(inputs) → user_query
    → _generate_custom_style prompt 注入"用户原始 query"行
    → 风格 LLM 在生成风格规范时考虑用户格式要求
  → P8.1 PageWorkerNode._execute
    → collect_user_text(inputs) → user_query
    → _run_page_pipeline → PageGenContext.user_query
    → _build_page_prompt
      → prompt 顶部注入"## 用户原始 query（最高优先级）"段
      → 规则 12 本身是条件式："禁止页码...除非用户在原始 query 中明确要求页码"
      → LLM 看到用户原文 + 条件式规则 → 自然添加页码
```

---

## 四、修改清单（3 文件）

### 4.1 style_prepare.py（P7 风格准备）

| 修改点                   | 说明                                                         |
| ------------------------ | ------------------------------------------------------------ |
| `_execute`               | 新增 `user_query = PptCommon.collect_user_text(inputs)`      |
| `_generate_custom_style` | 签名新增 `user_query` 参数；LLM prompt 注入"用户原始 query"行，让风格 LLM 感知用户格式/版式要求 |

### 4.2 ppt_page_gen.py（P8 页面生成）

| 修改点                           | 说明                                                         |
| -------------------------------- | ------------------------------------------------------------ |
| `_DESIGN_RULES_DIGEST` 规则 12   | 从无条件"禁止纯数字编号"改为条件式"禁止页码编号（除非用户在原始 query 中明确要求页码）" |
| `_build_page_prompt`             | 新增 `user_query` 参数；prompt 顶部注入"## 用户原始 query（最高优先级）"段 |
| `PageGenContext`                 | 新增 `user_query` 字段                                       |
| `PageWorkerNode._execute`        | 新增 `user_query = PptCommon.collect_user_text(inputs)`      |
| `_run_page_pipeline`             | 签名新增 `user_query` 参数，透传到 `PageGenContext`          |
| `_generate_one` / `_rewrite_one` | 调用 `_build_page_prompt` 时传 `ctx.user_query`              |

### 4.3 designer/SKILL.md（pptx-craft 技能原始规则）

| 修改点                            | 说明                                                         |
| --------------------------------- | ------------------------------------------------------------ |
| 规则 6（line 65）                 | 从无条件禁止改为条件式，追加"除非用户在原始 query 中明确要求页码" |
| HTML 注释（line 890, 1107, 1485） | 追加"用户明确要求页码时除外"                                 |
| 表格条目（line 1552）             | 追加"用户明确要求时除外"                                     |

---

## 五、验证

- 170 个单元测试全部通过
- 功能测试 4 项：
  - 内容页 + 用户含"页码"要求 → `user_query_section` 注入 ✅ + 规则 12 条件式 ✅
  - 内容页 + 用户不含"页码" → `user_query_section` 注入 ✅ + 规则 12 条件式 ✅
  - 内容页 + 无 user_query（向后兼容） → 无注入 ✅ + 规则 12 条件式 ✅
  - 结构页 + 用户含"页码"要求 → `user_query_section` 注入 ✅

---

## 六、提交记录

| 仓库       | Commit      | 内容                                                      |
| ---------- | ----------- | --------------------------------------------------------- |
| jiuwenclaw | `885ab3e7`  | fix: skill_turbo P7/P8 注入用户原始 query，页码规则条件化 |
| pptx-craft | `2883b2e46` | fix: designer 页码禁止规则改为条件式，用户明确要求时允许  |

---

# P8 页面底色风格感知修复（深色主题底色误判）

### 问题概述

生成 PPT 时，深色主题风格（如 industrial-tech，主背景 #000000）的页面被密度检查规则 #13 误判为「底色超白名单」失败，触发重写后部分页面底色被改为白色 #ffffff，导致同一份 PPT 中深色/白色底色混排（如 10 页中 P8/P9 变白底，其余深底）。

### 根因

`ppt_page_gen.py` 的密度检查规则 #13（density checklist）、骨架规则 #18（design rules）、结构页规则 #5（structural design rules）将「页面底色白名单」硬编码为「商务经典：`bg-white`/`bg-gray4`」，并显式禁止 `bg-black` 作整页底色。这套规则对所有风格生效，而 `_check_one` 签名不含 `style_id`/`style_text`，检查器根本看不到当前风格。

触发链路：

1. P8.1 首次生成：深色风格页面初始产物是 `#000000`（符合风格）
2. 密度检查：规则 #13 把深色底色判为「底色超白名单」失败
3. 重写：`_REWRITE_ACTIONS` 无「底色超白名单」条目，走 fallback「针对性优化该项」+ 规则 #13 白名单 → 模型被引导往改白方向改
4. 模型非确定性遵守：部分页面服从检查改白（如 P8/P9），二次密度检查 PASS，白底写盘成为终态

关键点：风格文件（含 #000000、深色科技风定义）在 page-8/9 的生成与重写 prompt 里都有透传——不是上下文丢失，而是密度检查规则与风格文件要求互相打架，模型被迫二选一。

### 修改清单（1 文件：ppt_page_gen.py）

| #    | 修改点                             | 说明                                                         |
| ---- | ---------------------------------- | ------------------------------------------------------------ |
| 1    | 规则 #13（density checklist）      | 硬编码「商务经典白名单，禁 `bg-black`」→ 风格感知「底色必须与风格文件一致，深色主题允许 `bg-black`/`#000000`」 |
| 2    | 骨架规则 #18（生成 prompt）        | 「底色仅用白名单值（商务经典）」→「底色必须严格遵循风格规范文件」 |
| 3    | 结构页规则 #5（生成 prompt）       | 「商务经典=白色，禁止深色背景」→「深色主题用深色底、浅色主题用浅色底」 |
| 4    | `_REWRITE_ACTIONS`                 | 新增「底色与风格不符」条目：明确「不要反向改色」，避免走 fallback 通用动作 |
| 5    | `_check_one` 签名 + 调用点         | 签名加 `style_id`/`style_text` 参数；调用点从 `ctx` 透传（零阻碍，ctx 已持有） |
| 6    | 检查 prompt                        | 注入 `style_hint`（深色主题告知 checker 不要判深色底失败）+ failed_enum「底色超白名单」→「底色与风格不符」 |
| 7    | `_post_check_bg_color`（新增函数） | 程序化后置校验：深色主题检测到 `bg-black`/`#000000` 则移除「底色与风格不符」误判，确定性兜底放行 |

### 防护层次

三道防线，即使 LLM checker 仍有不确定性也能兜住：

1. **生成层**（改动 2/3）：生成 prompt 不再硬编码白底，深色风格页面生成时不会被引导往白底走
2. **检查层**（改动 1/5/6）：检查 prompt 注入风格 hint + 规则文本风格感知，checker 知道当前是深色主题
3. **程序化兜底层**（改动 7）：即使 LLM checker 仍误判深色底色，`_post_check_bg_color` 会确定性移除误判，阻止触发不必要的重写

### 新增代码

```python
# 深色主题预设风格：整页底色允许 bg-black / #000000
_DARK_STYLE_IDS = {"industrial-tech"}

# 深色背景色匹配（#000000 / #000 / #111 等）
_DARK_BG_RE = re.compile(r"#000000\b|#000\b(?!0)|#111\b|#1a1a1a|bg-black", re.IGNORECASE)

def _is_dark_style(style_id: str, style_text: str) -> bool:
    """判断当前风格是否为深色主题。"""
    if style_id in _DARK_STYLE_IDS:
        return True
    # 自定义风格：从风格文本中检测背景色定义是否为深色
    if style_text:
        for line in style_text.splitlines():
            lower = line.lower()
            if ("背景" in lower or "background" in lower or "底色" in lower) and _DARK_BG_RE.search(line):
                return True
    return False

def _post_check_bg_color(html, style_id, style_text, failed_items):
    """程序化后置校验：深色主题允许 bg-black/#000000 底色，移除底色误判。"""
    if "底色与风格不符" not in failed_items:
        return failed_items
    if not _is_dark_style(style_id, style_text):
        return failed_items
    if _DARK_BG_RE.search(html.lower()):
        failed_items = [x for x in failed_items if x != "底色与风格不符"]
    return failed_items
```

### 验证

- industrial-tech 风格跑 10 页：全页统一深底 `#000000`
- 密度检查日志 page-8/9 不再出现「底色与风格不符」失败
- business-classic 等浅色风格行为不变