### PR TITLE
feat: support passing --user-id from jiuwenswarm-tui to http header

### DIFF
--- a/jiuwenswarm/channels/tui/frontend/src/core/ws-client.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/ws-client.ts
@@ -15,6 +15,7 @@ export class WsClient {
   private ws: WebSocket | null = null;
   private readonly url: string;
   private readonly token: string;
+  private readonly userId: string;
   private handlers: FrameHandler[] = [];
   private pending = new Map<string, PendingRequest>();
   private retryCount = 0;
@@ -26,9 +27,10 @@ export class WsClient {
   private closeCode = 0;
   private closeReason = "";
 
-  constructor(url: string, token = "") {
+  constructor(url: string, token = "", userId = "") {
     this.url = url;
     this.token = token;
+    this.userId = userId;
   }
 
   get status(): ConnectionStatus {
@@ -115,6 +117,9 @@ export class WsClient {
     const headers: Record<string, string> = {};
     if (this.token) {
       headers.Authorization = `Bearer ${this.token}`;
+    }
+    if (this.userId) {
+      headers["X-User-Id"] = this.userId;
     }
 
     this.ws = new WebSocket(this.url, { headers });

--- a/jiuwenswarm/channels/tui/frontend/src/index.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/index.ts
@@ -13,6 +13,7 @@ const { values } = parseArgs({
     url: { type: "string", default: "ws://127.0.0.1:19001/tui" },
     session: { type: "string" },
     token: { type: "string", default: "" },
+    "user-id": { type: "string", default: "" },
     help: { type: "boolean", short: "h" },
   },
   strict: true,
@@ -25,6 +26,7 @@ Options:
   --url <url>       Gateway CLI WebSocket URL (default: ws://127.0.0.1:19001/tui)
   --session <id>    Resume a specific session
   --token <token>   Authentication token
+  --user-id <id>    User identifier for the session
   -h, --help        Show this help
 `);
   process.exit(0);
@@ -36,7 +38,7 @@ if (!process.env.JIUWENSWARM_TUI_HEADLESS && (!process.stdin.isTTY || !process.s
   process.exit(1);
 }
 
-const wsClient = new WsClient(values.url ?? "ws://127.0.0.1:19001/tui", values.token ?? "");
+const wsClient = new WsClient(values.url ?? "ws://127.0.0.1:19001/tui", values.token ?? "", values["user-id"] ?? "");
 const appState = new CliPiAppState(wsClient, values.session);
 const commandService = new CommandService();
 commandService.register(createBuiltinCommands());


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind <label>


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->
  # TUI: 新增 `--user-id` 命令行参数,通过 `X-User-Id` HTTP header 传递

## 概述

为 TUI 前端新增 `--user-id` 命令行参数。当传入该参数时,其值会作为 `X-User-Id` WebSocket 请求头在建立连接时发送,使网关能够识别当前用户,并将该标识传递到 `Message.user_id`。

## 背景

在多用户场景下(例如多用户共用一台主机,或多个用户同时通过 TUI 连接同一个网关),TUI 之前无法告知后端"当前用户是谁"。TUI 只携带认证 `token`,它只能认证 *会话*,无法提供下游消息路由、审计、按用户隔离等功能所需的 *用户身份*。

本 PR 增加了一个轻量、向后兼容的用户标识传递通道。

## 改动

### 1. `channels/tui/frontend/src/core/ws-client.ts`
- 给 `WsClient` 类新增 `private readonly userId: string` 字段。
- 构造函数增加第三个可选参数 `userId = ""`。
- 当 `userId` 非空时,在建立 WebSocket 连接时注入 `headers["X-User-Id"] = userId`,与已有的 `Authorization: Bearer <token>` 并列。

```ts
constructor(url: string, token = "", userId = "") {
  this.url = url;
  this.token = token;
  this.userId = userId;
}
...
if (this.userId) {
  headers["X-User-Id"] = this.userId;
}
```

### 2. `channels/tui/frontend/src/index.ts`
- 在 `parseArgs` 中注册新的 `--user-id` 选项(类型 `string`,默认 `""`)。
- 在 `--help` 输出中补充说明:
  ```
  --user-id <id>    User identifier for the session
  ```
- 将 `values["user-id"]` 作为第三个参数传给 `WsClient`。

```ts
"user-id": { type: "string", default: "" },
...
const wsClient = new WsClient(
  values.url ?? "ws://127.0.0.1:19001/tui",
  values.token ?? "",
  values["user-id"] ?? "",
);
```

## 使用方式

```bash
jiuwenswarm-tui --user-id alice
```

建立 WebSocket 握手时会携带:
  Authorization: Bearer <token>
X-User-Id: alice</token>
 
 
若不传 `--user-id`,行为与之前完全一致(不发送该 header),不影响现有用户和脚本。

## 向后兼容

- `userId` 在 CLI 选项和 `WsClient` 构造函数中均默认为 `""`。
- 不传 `--user-id` 时,连接请求与之前版本完全一致。
- 对 `WsClient` 的现有调用方无破坏性变更(新参数为可选)。

## 测试计划

- [x] `jiuwenswarm-tui --help` 能看到新增的 `--user-id` 说明行。
- [x] `jiuwenswarm-tui --user-id alice` 可正常连接,网关在 upgrade 请求头中可读到 `X-User-Id: alice`,后端 `Message.user_id` 解析为 `alice`。
- [x] `jiuwenswarm-tui`(不带 `--user-id`)连接行为与之前一致,不发送 `X-User-Id` header。
- [x] 现有流程(`--token`、`--session`、默认 URL)均可正常工作。

## 不在本 PR 范围内

- 后端对 `X-User-Id` 的处理(解析到 `Message.user_id`、权限校验、审计日志)由[MR! 3315](https://gitcode.com/openJiuwen/jiuwenswarm/pull/3315)承担;本 PR 仅覆盖 TUI 侧的 header 发送。
- `user_id` 不跨会话持久化,每次调用按需传入。

## 关联

- 依赖后端在 WebSocket upgrade 路径上读取 `X-User-Id` 的支持。
- 取代此前将 user id 塞进 token 或 query string 的临时方案。