### PR TITLE
feat(gateway): passthrough TUI user_id via WS handshake to Yuanrong

### DIFF
--- a/jiuwenswarm/common/e2a/gateway_normalize.py
+++ b/jiuwenswarm/common/e2a/gateway_normalize.py
@@ -56,6 +56,7 @@ def message_to_legacy_agent_dict(msg: "Message") -> dict[str, Any]:
         "request_id": msg.id,
         "channel_id": msg.channel_id,
         "session_id": msg.session_id,
+        "user_id": msg.user_id,
         "req_method": rm_val,
         "params": dict(msg.params or {}),
         "is_stream": bool(msg.is_stream),
@@ -103,6 +104,7 @@ def build_fallback_e2a(legacy: dict[str, Any]) -> E2AEnvelope:
         request_id=rid or None,
         channel=str(legacy.get("channel_id") or "") or None,
         session_id=legacy.get("session_id"),
+        user_id=legacy.get("user_id"),
         method=None,
         params={},
         is_stream=bool(legacy.get("is_stream", False)),
@@ -116,6 +118,7 @@ def message_to_e2a(msg: "Message") -> E2AEnvelope:
         "request_id": msg.id,
         "channel_id": msg.channel_id,
         "session_id": msg.session_id,
+        "user_id": msg.user_id,
         "chat_id": msg.chat_id,
         "params": dict(msg.params or {}),
         "is_stream": bool(msg.is_stream),
@@ -197,12 +200,14 @@ def e2a_from_agent_fields(
     is_stream: bool = False,
     timestamp: float = 0.0,
     metadata: dict[str, Any] | None = None,
+    user_id: str | None = None,
 ) -> E2AEnvelope:
     """由与 AgentRequest 相同的字段构造 E2A（heartbeat / cron / app 管理请求等）。"""
     d: dict[str, Any] = {
         "request_id": request_id,
         "channel_id": channel_id,
         "session_id": session_id,
+        "user_id": user_id,
         "params": dict(params or {}),
         "is_stream": is_stream,
         "timestamp": timestamp,

--- a/jiuwenswarm/extensions/yuanrong_frontend_client.py
+++ b/jiuwenswarm/extensions/yuanrong_frontend_client.py
@@ -87,7 +87,14 @@ class YuanrongFrontendAgentClient(AgentServerClient):
         urn = urllib.parse.quote(self._function_version_urn, safe="")
         return f"{self._frontend_endpoint}/serverless/v1/functions/{urn}/invocations"
 
-    def _do_invoke(self, payload: dict[str, Any], session_id: str) -> tuple[int, str]:
+    def _invoke_headers(
+        self,
+        session_id: str,
+        *,
+        user_id: str | None = None,
+        req_method: str | None = None,
+        stream: bool = False,
+    ) -> dict[str, str]:
         headers = {
             "Content-Type": "application/json",
             "X-Instance-Session": json.dumps(
@@ -95,6 +102,42 @@ class YuanrongFrontendAgentClient(AgentServerClient):
                 ensure_ascii=False,
             ),
         }
+        if stream:
+            headers["Accept"] = "text/event-stream"
+        uid = str(user_id or "").strip()
+        if uid:
+            session_context = json.dumps({"sessionCtx": uid}, ensure_ascii=False)
+            headers["X-Session-Context"] = session_context
+            logger.debug(
+                "[YuanrongFrontendAgentClient] invoke headers: method=%s session_id=%s user_id=%s "
+                "X-Session-Context=%s stream=%s",
+                req_method,
+                session_id,
+                uid,
+                session_context,
+                stream,
+            )
+        else:
+            logger.info(
+                "[YuanrongFrontendAgentClient] invoke headers: method=%s session_id=%s "
+                "uid_empty=yes X-Session-Context omitted stream=%s",
+                req_method,
+                session_id,
+                stream,
+            )
+        return headers
+
+    def _do_invoke(
+        self,
+        payload: dict[str, Any],
+        session_id: str,
+        user_id: str | None = None,
+    ) -> tuple[int, str]:
+        headers = self._invoke_headers(
+            session_id,
+            user_id=user_id,
+            req_method=payload.get("req_method"),
+        )
         data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         req = urllib.request.Request(self._invoke_url(), data=data, headers=headers, method="POST")
 
@@ -141,7 +184,12 @@ class YuanrongFrontendAgentClient(AgentServerClient):
             "metadata": request.metadata,
         }
         session_id = request.session_id or ""
-        status, body = await asyncio.to_thread(self._do_invoke, payload, session_id)
+        status, body = await asyncio.to_thread(
+            self._do_invoke,
+            payload,
+            session_id,
+            envelope.user_id,
+        )
         try:
             parsed = json.loads(body) if body else {}
         except Exception:
@@ -180,7 +228,14 @@ class YuanrongFrontendAgentClient(AgentServerClient):
         queue: asyncio.Queue[tuple[str, str | None]] = asyncio.Queue()
         session_id = request.session_id or ""
         reader_task = asyncio.create_task(
-            asyncio.to_thread(self._do_invoke_stream, payload, session_id, queue, loop)
+            asyncio.to_thread(
+                self._do_invoke_stream,
+                payload,
+                session_id,
+                queue,
+                loop,
+                envelope.user_id,
+            )
         )
         try:
             while True:
@@ -229,6 +284,7 @@ class YuanrongFrontendAgentClient(AgentServerClient):
         session_id: str,
         out_queue: asyncio.Queue[tuple[str, str | None]],
         loop: asyncio.AbstractEventLoop,
+        user_id: str | None = None,
     ) -> None:
         """执行流式 HTTP 调用（在线程中运行）.
 
@@ -238,14 +294,12 @@ class YuanrongFrontendAgentClient(AgentServerClient):
             out_queue: 输出队列
             loop: 事件循环
         """
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "text/event-stream",
-            "X-Instance-Session": json.dumps(
-                {"sessionID": session_id, "concurrency": self._concurrency},
-                ensure_ascii=False,
-            ),
-        }
+        headers = self._invoke_headers(
+            session_id,
+            user_id=user_id,
+            req_method=payload.get("req_method"),
+            stream=True,
+        )
         data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         req = urllib.request.Request(self._invoke_url(), data=data, headers=headers, method="POST")
 

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -38,6 +39,7 @@ parse_dotenv_early("jiuwenswarm-gateway")
 # --- Now safe to import jiuwenswarm modules ---
 from jiuwenswarm.gateway.channel_manager.protocol.acp.acp_connect import AcpGatewayBridge
 from jiuwenswarm.gateway.routing.agent_request_timeout import coerce_client_timeout_ms
+from jiuwenswarm.common.security.ws_origin import get_header_value
 from jiuwenswarm.gateway.routing.route_binding import GatewayRouteBinding
 from jiuwenswarm.common.utils import (
     get_cron_jobs_path,
@@ -121,6 +123,7 @@ def _normalize_gateway_message(msg):
         stream_seq=msg.stream_seq,
         stream_id=msg.stream_id,
         metadata=msg.metadata,
+        user_id=getattr(msg, "user_id", None),
     )
 
 
@@ -314,6 +317,15 @@ class GatewayServerConfig:
             self.routes[path] = RouteConfig(path=path, channel_id=channel_id)
 
 
+@dataclass(frozen=True)
+class _LocalHandlerContext:
+    ws: Any
+    req_id: str
+    params: dict[str, Any]
+    session_id: str
+    user_id: str | None
+
+
 class GatewayServer:
     """通用多路路由 WebSocket Gateway Server。
 
@@ -342,6 +354,38 @@ class GatewayServer:
             idle_finalize_seconds=lambda: _PROMPT_IDLE_FINALIZE_SECONDS,
         )
         self._install_default_route_hooks()
+
+    @staticmethod
+    def _extract_ws_user_id(ws: Any) -> str | None:
+        """从 WebSocket 握手 HTTP Header 读取 X-User-Id（大小写不敏感）。"""
+        headers = (
+            getattr(getattr(ws, "request", None), "headers", None)
+            or getattr(ws, "request_headers", None)
+        )
+        raw = get_header_value(headers, "X-User-Id")
+        if raw is None:
+            return None
+        text = str(raw).strip()
+        return text or None
+
+    @staticmethod
+    def _connection_user_id(ws: Any) -> str | None:
+        """返回连接建立时缓存的 user_id（来自握手 Header）。"""
+        uid = getattr(ws, "_gateway_user_id", None)
+        if uid is None:
+            return None
+        text = str(uid).strip()
+        return text or None
+
+    @staticmethod
+    def _invoke_local_handler(
+        handler: Callable[..., Awaitable[None]],
+        ctx: _LocalHandlerContext,
+    ) -> Awaitable[None]:
+        kwargs: dict[str, Any] = {}
+        if "user_id" in inspect.signature(handler).parameters:
+            kwargs["user_id"] = ctx.user_id
+        return handler(ctx.ws, ctx.req_id, ctx.params, ctx.session_id, **kwargs)
 
     @staticmethod
     def _client_route_key(
@@ -836,6 +880,17 @@ class GatewayServer:
 
         self._clients.add(ws)
 
+        ws_user_id = self._extract_ws_user_id(ws)
+        setattr(ws, "_gateway_user_id", ws_user_id)
+        uid_marker = "" if ws_user_id else " uid_empty=yes"
+        logger.info(
+            "[Gateway] WS handshake X-User-Id: user_id=%r%s channel=%s path=%s",
+            ws_user_id,
+            uid_marker,
+            route.channel_id,
+            matched_path,
+        )
+
         # connection.ack
         try:
             await ws.send(json.dumps({
@@ -979,6 +1034,8 @@ class GatewayServer:
         session_id = (str(params.get("session_id") or "").strip()) or req_id
         session_key = self._client_route_key(route.channel_id, session_id) if explicit_session_id else None
 
+        req_user_id = self._connection_user_id(ws)
+
         # 1. forward 优先：方法在 forward_methods 中则转发到 MessageHandler
         if method in route.forward_methods:
             req_method = None
@@ -1120,6 +1177,7 @@ class GatewayServer:
                 # 阶段2：tui ws_channel route 用合成的 _resolved_agent_ref（与 _register /
                 # GodView 同源）；非 ws_channel route 保留原 _agent_ref。
                 agent_ref=_resolved_agent_ref,
+                user_id=req_user_id,
             )
 
             if self._on_message_cb is not None:
@@ -1143,7 +1201,16 @@ class GatewayServer:
             if session_key is not None:
                 await self._bind_route_session_client(route, session_id, ws)
             try:
-                await local_handler(ws, req_id, params, session_id)
+                await self._invoke_local_handler(
+                    local_handler,
+                    _LocalHandlerContext(
+                        ws=ws,
+                        req_id=req_id,
+                        params=params,
+                        session_id=session_id,
+                        user_id=req_user_id,
+                    ),
+                )
             except Exception as e:
                 ws_closed = bool(getattr(ws, "closed", False))
                 if ws_closed:

--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -423,6 +423,7 @@ class ForwardRewindE2AParams:
     turn_index: int
     req_method: Any
     error_label: str
+    user_id: str | None = None
 
 
 _CLI_CONFIG_SET_ENV_MAP = {
@@ -1188,7 +1189,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             },
         )
 
-    async def _session_list(ws, req_id, params, session_id):
+    async def _session_list(ws, req_id, params, session_id, user_id=None):
         from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
         from jiuwenswarm.common.schema.message import ReqMethod
 
@@ -1215,6 +1216,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             params=params or {},
             is_stream=False,
             timestamp=time.time(),
+            user_id=user_id,
         )
         try:
             resp = await _send_tui_agent_request(
@@ -1386,7 +1388,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             mh.trigger_session_start_hook(target, source="tui")
         await channel.send_response(ws, req_id, ok=True, payload={"session_id": target})
 
-    async def _session_delete(ws, req_id, params, session_id):
+    async def _session_delete(ws, req_id, params, session_id, user_id=None):
         from jiuwenswarm.common.utils import get_agent_sessions_dir
         from jiuwenswarm.server.runtime.session.session_metadata import get_session_metadata
         from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
@@ -1418,6 +1420,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                     params=params,
                     is_stream=False,
                     timestamp=time.time(),
+                    user_id=user_id,
                 )
                 resp = await _send_tui_agent_request(
                     real_client, env, label="session.delete",
@@ -1492,6 +1495,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 params={"session_id": params.target_sid, "turn_index": params.turn_index},
                 is_stream=False,
                 timestamp=time.time(),
+                user_id=params.user_id,
             )
             resp = await _send_tui_agent_request(
                 real_client, env, label=params.error_label,
@@ -1508,7 +1512,12 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             logger.warning("[cli %s] forward to agent failed, fallback local: %s", params.error_label, e)
             return False
 
-    async def _compact_partial_via_e2a(target_sid: str, turn_index: int, direction: str) -> tuple[Optional[str], int]:
+    async def _compact_partial_via_e2a(
+        target_sid: str,
+        turn_index: int,
+        direction: str,
+        user_id: str | None = None,
+    ) -> tuple[Optional[str], int]:
         """通过 E2A 转发 LLM 摘要请求到 AgentServer。返回 (summary, summarized_count)。"""
         from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
         from jiuwenswarm.common.schema.message import ReqMethod
@@ -1530,6 +1539,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 },
                 is_stream=False,
                 timestamp=time.time(),
+                user_id=user_id,
             )
             resp = await _send_tui_agent_request(
                 real_client, env, label="command.compact_partial",
@@ -1545,7 +1555,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
 
         return None, 0
 
-    async def _session_rewind(ws, req_id, params, session_id):
+    async def _session_rewind(ws, req_id, params, session_id, user_id=None):
         """session.rewind: E2A → AgentServer（权威写入者），fallback 本地."""
         from jiuwenswarm.agents.harness.common.session_ops_service import rewind_session
         from jiuwenswarm.common.schema.message import ReqMethod
@@ -1583,6 +1593,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 turn_index=turn_index,
                 req_method=ReqMethod.SESSION_REWIND,
                 error_label="session.rewind failed",
+                user_id=user_id,
             )
         ):
             return
@@ -1612,7 +1623,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
         except Exception as e:
             await channel.send_response(ws, req_id, ok=False, error=str(e), code="INTERNAL_ERROR")
 
-    async def _session_rewind_and_restore(ws, req_id, params, session_id):
+    async def _session_rewind_and_restore(ws, req_id, params, session_id, user_id=None):
         """session.rewind_and_restore: E2A → AgentServer（权威写入者），fallback 本地."""
         from jiuwenswarm.agents.harness.common.session_ops_service import (
             restore_session_files,
@@ -1653,6 +1664,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 turn_index=turn_index,
                 req_method=ReqMethod.SESSION_REWIND_AND_RESTORE,
                 error_label="session.rewind_and_restore failed",
+                user_id=user_id,
             )
         ):
             return
@@ -1708,7 +1720,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
         except Exception as e:
             await channel.send_response(ws, req_id, ok=False, error=str(e), code="INTERNAL_ERROR")
 
-    async def _command_rewind_compact(ws, req_id, params, session_id):
+    async def _command_rewind_compact(ws, req_id, params, session_id, user_id=None):
         """command.rewind_compact: LLM 摘要(E2A→AgentServer) + 截断 + 记录写入(AgentServer E2A)。"""
         if not isinstance(params, dict):
             await channel.send_response(
@@ -1742,7 +1754,9 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             return
 
         try:
-            llm_summary, summarized_count = await _compact_partial_via_e2a(target_sid, turn_index, direction)
+            llm_summary, summarized_count = await _compact_partial_via_e2a(
+                target_sid, turn_index, direction, user_id=user_id
+            )
         except Exception as e:
             logger.warning("[cli command.rewind_compact] LLM summary failed: %s", e)
             llm_summary = None
@@ -1773,6 +1787,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                     },
                     is_stream=False,
                     timestamp=time.time(),
+                    user_id=user_id,
                 )
                 resp = await _send_tui_agent_request(
                     real_client, env, label="command.rewind_compact",
@@ -1805,7 +1820,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             logger.exception("[cli command.rewind_compact] %s", e)
             await channel.send_response(ws, req_id, ok=False, error=str(e), code="INTERNAL_ERROR")
 
-    async def _session_rename(ws, req_id, params, session_id):
+    async def _session_rename(ws, req_id, params, session_id, user_id=None):
         """优先经 E2A 转发至 AgentWebSocketServer._handle_session_rename；无 agent 或转发失败时本地回退。"""
         from jiuwenswarm.server.runtime.session.session_rename import apply_session_rename
         from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
@@ -1822,6 +1837,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                     params=params if isinstance(params, dict) else {},
                     is_stream=False,
                     timestamp=time.time(),
+                    user_id=user_id,
                 )
                 resp = await _send_tui_agent_request(
                     real_client, env, label="session.rename",
@@ -2042,7 +2058,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 payload["page_idx"] = params.get("page_idx")
         await channel.send_response(ws, req_id, ok=True, payload=payload)
 
-    async def _command_model(ws, req_id, params, session_id):
+    async def _command_model(ws, req_id, params, session_id, user_id=None):
         from jiuwenswarm.common.e2a.gateway_normalize import e2a_from_agent_fields
         from jiuwenswarm.common.schema.message import ReqMethod
 
@@ -2072,6 +2088,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 params={"config": config_payload, "env": {}},
                 is_stream=False,
                 timestamp=time.time(),
+                user_id=user_id,
             )
             try:
                 await _send_tui_agent_request(
@@ -2590,6 +2607,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                 },
                 is_stream=False,
                 timestamp=time.time(),
+                user_id=user_id,
             )
             try:
                 await _send_tui_agent_request(

--- a/tests/unit_tests/e2a/test_gateway_normalize.py
+++ b/tests/unit_tests/e2a/test_gateway_normalize.py
@@ -80,6 +80,33 @@ def test_e2a_to_agent_request_roundtrip():
     assert req.metadata == {"wecom_req_id": "abc"}
 
 
+def test_message_to_e2a_or_fallback_preserves_user_id():
+    msg = Message(
+        id="r-user",
+        type="req",
+        channel_id="tui",
+        session_id="s1",
+        params={"content": "hi"},
+        timestamp=time.time(),
+        ok=True,
+        req_method=ReqMethod.CHAT_SEND,
+        user_id="alice",
+    )
+    env = message_to_e2a_or_fallback(msg)
+    assert env.user_id == "alice"
+
+
+def test_e2a_from_agent_fields_user_id():
+    env = e2a_from_agent_fields(
+        request_id="r1",
+        channel_id="tui",
+        session_id="s1",
+        req_method=ReqMethod.CHAT_SEND,
+        user_id="bob",
+    )
+    assert env.user_id == "bob"
+
+
 def test_channel_context_for_channel_reply_strips_internal():
     env = e2a_from_agent_fields(
         request_id="x",

--- a/tests/unit_tests/extensions/test_yuanrong_frontend_client.py
+++ b/tests/unit_tests/extensions/test_yuanrong_frontend_client.py
@@ -1,0 +1,117 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from jiuwenswarm.common.e2a.models import E2AEnvelope
+from jiuwenswarm.extensions.yuanrong_frontend_client import YuanrongFrontendAgentClient
+
+
+class YuanrongFrontendAgentClientProbe(YuanrongFrontendAgentClient):
+    """Subclass exposing protected helpers for unit tests (G.CLS.11)."""
+
+    def invoke_headers(
+        self,
+        session_id: str,
+        *,
+        user_id: str | None = None,
+        req_method: str | None = None,
+        stream: bool = False,
+    ) -> dict[str, str]:
+        return self._invoke_headers(
+            session_id,
+            user_id=user_id,
+            req_method=req_method,
+            stream=stream,
+        )
+
+
+@pytest.fixture
+def client() -> YuanrongFrontendAgentClientProbe:
+    return YuanrongFrontendAgentClientProbe(
+        frontend_endpoint="http://127.0.0.1:8080",
+        function_version_urn="urn:test:function:1",
+        concurrency=2,
+    )
+
+
+def test_invoke_headers_without_user_id(client: YuanrongFrontendAgentClientProbe):
+    headers = client.invoke_headers("sess-1")
+
+    assert "X-Session-Context" not in headers
+    instance = json.loads(headers["X-Instance-Session"])
+    assert instance == {"sessionID": "sess-1", "concurrency": 2}
+
+
+def test_invoke_headers_with_user_id(client: YuanrongFrontendAgentClientProbe):
+    headers = client.invoke_headers("sess-1", user_id="alice")
+
+    assert json.loads(headers["X-Session-Context"]) == {"sessionCtx": "alice"}
+    assert json.loads(headers["X-Instance-Session"]) == {"sessionID": "sess-1", "concurrency": 2}
+
+
+def test_invoke_headers_stream_accepts_sse(client: YuanrongFrontendAgentClientProbe):
+    headers = client.invoke_headers("sess-1", user_id="bob", stream=True)
+
+    assert headers["Accept"] == "text/event-stream"
+    assert json.loads(headers["X-Session-Context"]) == {"sessionCtx": "bob"}
+
+
+@pytest.mark.asyncio
+async def test_send_request_passes_user_id_in_session_context(client: YuanrongFrontendAgentClientProbe):
+    await client.connect("http://127.0.0.1:8080")
+
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured.update(dict(req.header_items()))
+        resp = MagicMock()
+        resp.status = 200
+        resp.read.return_value = b'{"ok": true}'
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    envelope = E2AEnvelope(
+        request_id="req-1",
+        channel="tui",
+        session_id="sess-1",
+        method="chat.send",
+        user_id="alice",
+    )
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        response = await client.send_request(envelope)
+
+    assert response.ok is True
+    assert json.loads(captured["X-session-context"]) == {"sessionCtx": "alice"}
+
+
+@pytest.mark.asyncio
+async def test_send_request_omits_session_context_without_user_id(client: YuanrongFrontendAgentClientProbe):
+    await client.connect("http://127.0.0.1:8080")
+
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured.update(dict(req.header_items()))
+        resp = MagicMock()
+        resp.status = 200
+        resp.read.return_value = b'{}'
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    envelope = E2AEnvelope(
+        request_id="req-2",
+        channel="tui",
+        session_id="sess-2",
+        method="chat.send",
+    )
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        await client.send_request(envelope)
+
+    assert "X-session-context" not in {k.lower() for k in captured}

--- a/tests/unit_tests/gateway/test_app_gateway_acp.py
+++ b/tests/unit_tests/gateway/test_app_gateway_acp.py
@@ -21,10 +21,25 @@ class DummyBus:
         return None
 
 
+class _FakeRequestHeaders:
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._mapping = {k.lower(): v for k, v in mapping.items()}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._mapping.get(key.lower(), default)
+
+
 class FakeWebSocket:
-    def __init__(self):
+    def __init__(self, *, user_id: str | None = None) -> None:
         self.sent_frames = []
         self.closed = False
+        if user_id is not None:
+            self._gateway_user_id = user_id
+            self.request = type(
+                "Request",
+                (),
+                {"headers": _FakeRequestHeaders({"X-User-Id": user_id})},
+            )()
 
     async def send(self, data):
         self.sent_frames.append(json.loads(data))
@@ -89,6 +104,11 @@ class GatewayServerProbe(GatewayServer):
     def get_acp_pending_request_contexts_for_test(self) -> list[Any]:
         return list(self._acp_bridge.request_contexts)
 
+    @classmethod
+    def extract_ws_user_id_for_test(cls, ws: Any) -> str | None:
+        """Expose _extract_ws_user_id for unit tests (G.CLS.11: subclass wrapper)."""
+        return cls._extract_ws_user_id(ws)
+
 
 def build_server() -> GatewayServerProbe:
     config = GatewayServerConfig(
@@ -129,6 +149,25 @@ def test_normalize_gateway_message_maps_chat_resume_to_interrupt_resume():
     assert normalized.req_method == ReqMethod.CHAT_CANCEL
     assert normalized.params["intent"] == "resume"
     assert normalized.session_id == "sess-1"
+
+
+def test_normalize_gateway_message_preserves_user_id():
+    msg = Message(
+        id="req-chat",
+        type="req",
+        channel_id="tui",
+        session_id="sess-1",
+        params={"session_id": "sess-1", "content": "hi"},
+        timestamp=time.time(),
+        ok=True,
+        req_method=ReqMethod.CHAT_SEND,
+        user_id="testuser",
+    )
+
+    normalized = _normalize_gateway_message(msg)
+
+    assert normalized.user_id == "testuser"
+    assert normalized.is_stream is True
 
 
 @pytest.mark.asyncio
@@ -1903,3 +1942,114 @@ async def test_gateway_server_routes_by_params_session_id_when_payload_empty():
 
     assert len(ws.sent_frames) == 1
     assert ws.sent_frames[0]["payload"].get("session_id") is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_server_handle_raw_message_uses_connection_user_id():
+    server = build_server()
+    ws = FakeWebSocket(user_id="alice")
+    seen = []
+
+    async def on_message(msg):
+        seen.append(msg)
+
+    server.on_message(on_message)
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-user",
+                "method": "chat.send",
+                "params": {
+                    "session_id": "sess-user",
+                    "content": "hello",
+                },
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert len(seen) == 1
+    assert seen[0].user_id == "alice"
+
+
+def test_gateway_server_extract_ws_user_id_case_insensitive():
+    ws_lower = type(
+        "Ws",
+        (),
+        {"request_headers": _FakeRequestHeaders({"x-user-id": "bob"})},
+    )()
+    ws_upper = type(
+        "Ws",
+        (),
+        {"request": type("Request", (), {"headers": _FakeRequestHeaders({"X-User-Id": "  carol  "})})()},
+    )()
+    ws_empty = type("Ws", (), {"request_headers": _FakeRequestHeaders({})})()
+
+    assert GatewayServerProbe.extract_ws_user_id_for_test(ws_lower) == "bob"
+    assert GatewayServerProbe.extract_ws_user_id_for_test(ws_upper) == "carol"
+    assert GatewayServerProbe.extract_ws_user_id_for_test(ws_empty) is None
+
+
+@pytest.mark.asyncio
+async def test_gateway_server_local_handler_receives_connection_user_id():
+    captured_user_ids = []
+
+    async def _session_list(ws, req_id, params, session_id, user_id=None):
+        captured_user_ids.append(user_id)
+
+    server = build_server()
+    server.config.routes["/tui"].local_handlers["session.list"] = _session_list
+    ws = FakeWebSocket(user_id="alice")
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-sess",
+                "method": "session.list",
+                "params": {},
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert captured_user_ids == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_server_ignores_frame_x_user_id_without_handshake_header():
+    server = build_server()
+    ws = FakeWebSocket()
+    seen = []
+
+    async def on_message(msg):
+        seen.append(msg)
+
+    server.on_message(on_message)
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-user",
+                "method": "chat.send",
+                "X-User-Id": "alice",
+                "params": {
+                    "session_id": "sess-user",
+                    "content": "hello",
+                },
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert len(seen) == 1
+    assert seen[0].user_id is None


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind feature

## Summary

在 Gateway 侧实现 TUI `user_id` 透传至 Yuanrong：从 WebSocket 握手 HTTP Header `X-User-Id` 读取用户标识（连接级），经 `Message.user_id` → E2A → Yuanrong HTTP `X-Session-Context`（`{"sessionCtx": "<uid>"}`）全链路透传。

本 PR **仅改 Gateway / E2A / Yuanrong 客户端**，不改 TUI 前端；需配合 [MR !3156](https://gitcode.com/openJiuwen/jiuwenswarm/pull/3156) 的 `--user-id` 与握手 Header 发送。

## 主要改动

- **Gateway**：握手时解析 `X-User-Id` 并缓存至 `ws._gateway_user_id`；forward / 本地 handler 统一使用该连接级 `user_id`；`_normalize_gateway_message` 保留 `user_id` 避免转发丢失
- **E2A**：`message_to_e2a` / `e2a_from_agent_fields` / fallback 路径透传 `user_id`
- **Yuanrong**：`YuanrongFrontendAgentClient` 在 invoke 时设置 `X-Session-Context`；补充 `uid_empty=yes`、`method` 等调试日志
- **tui_connect**：部分本地 RPC（如 `session.list`、`command.model`）调用 Agent 时传入 `user_id`

## 数据流

TUI 握手 Header: X-User-Id → Gateway ws._gateway_user_id → MessageHandler / E2AEnvelope → Yuanrong X-Session-Context


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->