### PR TITLE
fix(web): 发送新 query 时清掉未回答的内联提问卡片 (#2091)

### DIFF
--- a/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
+++ b/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
@@ -992,6 +992,12 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
       userInputVersionRef.current += 1;
       stopAllTts();
 
+      // 用户忽略未回答的提问器、直接发新 query：清掉残留的内联提问卡片。
+      // 否则该卡片作为时间线最后一个元素会一直钉在最底部（issue #2091）。
+      if (useChatStore.getState().pendingQuestion) {
+        useChatStore.getState().setPendingQuestion(null);
+      }
+
       // 添加用户消息
       addMessage({
         id: `user-${Date.now()}`,


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

## 问题

规划模式下 agent 触发提问器（内联卡片）后，用户不回答、直接发送另一条 query，提问卡片会一直钉在时间线最底部无法消失。

Closes #2091

## 根因

`InlineQuestionCard` 不是聊天记录里的一条消息，而是由 store 状态 `pendingQuestion` 驱动、写死渲染在时间线末尾的单例（`ChatPanel/index.tsx`）。`pendingQuestion` 全局只有 3 处会被清空：回答问题（`sendUserAnswer`）、会话重置、`clearMessages`。而用户手输新 query 走的是 `sendMessage`，它从不清理 `pendingQuestion` → 新消息进 `MessageList`（卡片上方），卡片仍是最后一个元素 → 视觉上一直钉底。

纯前端展示问题，与后端无关：新 query 是不带 `request_id/source/answers` 的普通 `chat.send`，后端 `is_interrupt_resume_payload` 判定为 False，按新一轮对话正常处理。

## 改动

在 `sendMessage` 发送前，若存在未回答的 `pendingQuestion` 就清掉它。语义即「用户选择忽略提问、继续新对话，等价于放弃该卡片」。回答问题走的另一条路 `sendUserAnswer`，不受影响。

`jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts`（+6）

## 测试

- 主场景：规划模式触发卡片 → 不答直接发新 query → 卡片立即消失，新对话正常 ✅
- 回归：卡片弹出后正常点选项回答 → 仍能提交、卡片消失 ✅
- `npx tsc --noEmit` 通过 ✅

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->