### PR TITLE
fix: skill_turbo PPT 视觉效果问题修复

### DIFF
--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
@@ -157,7 +157,7 @@ _CDN_HEAD_SNIPPET = (
 
 
 _DESIGN_RULES_DIGEST = (
-    "### 视觉与布局硬约束（精选 26 条）\n"
+    "### 视觉与布局硬约束（精选 23 条）\n"
     "1. 容器：`.ppt-slide { width:1280px; height:720px; overflow:hidden; box-sizing:border-box }`\n"
     "2. 安全区：`.content-safe { width:1220px; height:660px; margin:30px auto }`，主要内容必须放在安全区内；"
     "子元素禁止额外加 padding，否则导致双重边距\n"
@@ -197,8 +197,9 @@ _DESIGN_RULES_DIGEST = (
     "留白 > 30% 判定为'空白率过高'；通过增加卡片、图表、列表项填充内容，而非放大字号\n"
     "7. 防溢出：单行文字不超容器宽度；连续段落 ≤ 100 字（超过必须拆列表）；"
     "文本容器（p、span、div）必须加 `break-words` 类防止中英混排时英文/数字处不换行溢出\n"
-    "8. 布局结构：严格遵循标准 HTML 骨架——main 用 `flex gap-3`，"
-    "恰好 2 个 `<section>` 子元素；header/main/footer 纵向排列在 content-safe 内\n"
+    "8. 布局结构：严格遵循标准 HTML 骨架——main 用 `flex`，"
+    "恰好 2 个 `<section>` 子元素，间距用 `pr-[12px]`/`pl-[12px]` 替代 gap；"
+    "header/main/footer 纵向排列在 content-safe 内\n"
     "8.1 禁止使用 CSS Grid：html-to-pptx 转换器不支持 `display:grid`（Grid 仅检测不转换，视为非文本容器），"
     "所有布局必须用 Flexbox（`flex`、`flex-col`、`flex-[N]`）替代 `grid grid-cols-*`；"
     "左右分栏用 `flex` + `flex-[3]` / `flex-[2]` 比例分配，不用 `grid grid-cols-[3fr_2fr]`\n"
@@ -231,33 +232,20 @@ _DESIGN_RULES_DIGEST = (
     "18. 遮罩层≠底色：`bg-black/50`、`from-black/*`、`bg-gradient-*` 等是遮罩层(overlay)，"
     "必须配合底层 `<img>` 背景图使用以保证文字可读，不是页面/卡片底色；"
     "页面底色必须严格遵循风格规范文件定义的背景色，禁止使用与风格不符的底色\n"
+    "\n"
+    "### html-to-pptx 转换器限制（以下规则源于转换器实际能力，非设计偏好）\n"
     "19. 图表分割线：`splitLine` 建议使用 `type:'dashed'` 虚线，避免实线分割线在 PPTX 中过于突兀；"
     "颜色用 `#DDDDDD`，禁止用深色实线\n"
     "20. padding/border 转换缩放：html-to-pptx 转换器对 padding 缩放 0.85（减少 15%）、border-width 缩放 0.65（减少 35%），"
     "生成 HTML 时需预留余量，避免 PPTX 中内容因缩放溢出或边框过细\n"
-    "21. 文本换行（强制）：`break-words`（`overflow-wrap:break-word`）在 PPTX 转换中不生效，"
+    "21. 文本换行：`break-words`（`overflow-wrap:break-word`）在 PPTX 转换中不生效，"
     "长文本不会在 PPTX 中自动换行而会溢出右边界；"
-    "必须将长段落拆分为多个 `<p>` 标签或用 `<br>` 手动换行，单行文字不超过容器宽度；"
-    "案例/说明文字控制在 40 字以内一行，超过时用 `<br>` 分行\n"
-    "22. 间距控制（强制）："
-    "禁止使用 `justify-between` 分布列表项（无论数量多少，因为项的高度不一时 gap 相等但视觉间距不一致）；"
-    "列表项间距统一用 `mt-[10px]` 或 `mt-[12px]` 逐项递增，确保每个项之间的视觉间距一致；"
-    "正确写法：`<div class=\"flex flex-col\"><div class=\"mt-[10px]\">项1</div><div class=\"mt-[10px]\">项2</div></div>`；"
-    "禁止使用 `leading-[2]` 或 `leading-loose`（行高 2 倍），行高上限 `leading-[1.6]`；"
-    "图标与文字间距不超过 `mr-[8px]`，禁止用 `mr-[28px]` 或更大的图标边距；"
-    "ECharts SVG 图例在 PPTX 转换后图标和文字可能不对齐（转换器限制），"
-    "图例项之间留足间距，图例文字用 `fontSize:12` 确保字号统一\n"
-    "23. ECharts 数据一致性（强制）：xAxis.data 数组的长度必须与 series[].data 数组的长度完全一致，"
-    "禁止 x 轴标签数量与数据点数量不匹配；双轴图必须确保两个 yAxis 的数据点一一对应\n"
-    "24. 容器高度（强制）：文本容器的固定高度必须大于等于其内文字行高，"
-    "例如 `h-[28px]` 的容器不能放 `text-[26px] leading-[1.1]`（行高 28.6px > 28px），"
-    "否则 PPTX 中文字会向上溢出与上方元素重叠；"
-    "正确做法：容器高度 ≥ 字号 × 行高系数 + 4px 余量\n"
-    "25. 文本宽度约束（强制）：`flex justify-between` 布局中的文本元素必须加 `max-w-[Npx]` 或 `w-[Npx]` 约束宽度，"
-    "否则 PPTX 中文本不自动换行会溢出右边界；"
-    "英文/数字混合文本（如 'GMTN Programme · Carbon Neutral Green Bond'）必须加 `break-words` + `max-w-[200px]`\n"
-    "26. ECharts 图例与轴标题防重叠（强制）：图例项 ≥3 个时必须设 `legend.top: 'bottom'` 或 `legend.orient: 'vertical'`，"
-    "避免图例水平排列时与 Y 轴标题重叠；双轴图的右 Y 轴标题（`yAxis.name`）必须设置 `yAxis.nameLocation: 'end'` 且 `grid.right` 留足 ≥60px 空间\n"
+    "必须将长段落拆分为多个 `<p>` 标签或用 `<br>` 手动换行；"
+    "flex 布局中的文本元素应加 `max-w-[Npx]` 约束宽度，防止 PPTX 中溢出\n"
+    "22. 行高限制：禁止使用 `leading-[2]` 或 `leading-loose`（行高 2 倍），行高上限 `leading-[1.6]`\n"
+    "23. ECharts SVG 图例：PPTX 转换后图例图标和文字可能不对齐（转换器限制），"
+    "图例项之间留足间距，图例文字用 `fontSize:12` 确保字号统一；"
+    "图例项 ≥3 个时设 `legend.top:'bottom'` 或 `legend.orient:'vertical'`，避免与 Y 轴标题重叠\n"
 )
 
 
@@ -450,7 +438,7 @@ _DENSITY_CHECKLIST_DIGEST = (
     "5. 数据来源：页脚有标注（机构名 / 资料名）\n"
     "6. 无大段文字：无连续 > 100 字段落\n"
     "7. 视觉层级：标题 → 副标题 → 正文 → 注释 层级清晰\n"
-    "8. 布局正确：main 元素采用双区域布局（如 `flex gap-4`、`flex` + `flex-[3]`/`flex-[2]` 等），"
+    "8. 布局正确：main 元素采用双区域布局（如 `flex` + `flex-[3]`/`flex-[2]` 等），"
     "且恰好 2 个直接子元素（`<section>` 或 `<div>`）；"
     "禁止使用 `grid grid-cols-*`（html-to-pptx 不支持 CSS Grid）；"
     "禁止所有页面使用相同布局，需根据内容叙事选择不同布局比例和方向\n"
@@ -487,6 +475,43 @@ def _is_valid_html(text: str) -> bool:
         return False
     lower = text.lower()
     return ("<html" in lower or "<!doctype html" in lower) and "ppt-slide" in lower
+
+
+# 匹配含 ppt-slide 的 div 开始标签
+_PPT_SLIDE_DIV_RE = re.compile(r'<div[^>]*\bclass="[^"]*ppt-slide[^"]*"', re.IGNORECASE)
+
+
+def _truncate_to_single_slide(html: str) -> str:
+    """如果 HTML 包含多个 ppt-slide 容器，截取第一个并保留 HTML 骨架。
+
+    LLM 偶尔会忽略单页约束，将全部页面写入一个 HTML 文件。
+    此函数检测到多 slide 时截取第一个，丢弃其余，并补全闭合标签。
+    """
+    matches = list(_PPT_SLIDE_DIV_RE.finditer(html))
+    if len(matches) <= 1:
+        return html
+
+    # 从第二个 ppt-slide div 往前找 <div 起始位置
+    second_match = matches[1]
+    div_start = html.rfind("<div", 0, second_match.start())
+    if div_start == -1:
+        div_start = second_match.start()
+
+    # 还需要往回找注释标记（如 <!-- P2 ... -->）
+    comment_pos = html.rfind("<!--", 0, div_start)
+    cut_pos = min(comment_pos, div_start) if comment_pos != -1 else div_start
+
+    truncated = html[:cut_pos].rstrip()
+    # 补全闭合标签
+    if "</body>" not in truncated.lower():
+        truncated += "\n</body>\n</html>\n"
+
+    logger.warning(
+        "[P8.1] 检测到 %d 个 ppt-slide 容器，已截取第一个 slide，丢弃其余 %d 个",
+        len(matches),
+        len(matches) - 1,
+    )
+    return truncated
 
 
 # 匹配 <h1>/<h2> 中「第X页」占位符（X 为数字或中文数字）
@@ -667,15 +692,21 @@ def _post_check_layout_issues(html: str, failed_items: list[str]) -> list[str]:
     # 检测 leading-[2] 或 leading-loose（行高过大导致空白）
     if re.search(r'leading-\[2\]|leading-loose', html) and "行高过大导致空白" not in failed_items:
         failed_items.append("行高过大导致空白")
-    # 检测 justify-between 用于列表项（项高度不一时视觉间距不一致）
-    # 匹配任何使用 justify-between 的 flex-col 容器
-    if re.search(r'class="[^"]*flex[^"]*flex-col[^"]*justify-between', html) and "间距过大" not in failed_items:
+    # 检测 justify-between + flex-col 组合（项高度不一时视觉间距不一致）
+    # 使用先行断言确保三个关键词同时出现在同一 class 属性中，不依赖顺序
+    if re.search(
+        r'class="(?=[^"]*\bflex\b)(?=[^"]*\bflex-col\b)(?=[^"]*\bjustify-between\b)[^"]*"',
+        html,
+    ) and "间距过大" not in failed_items:
         failed_items.append("间距过大")
-    elif re.search(r'class="[^"]*justify-between[^"]*flex[^"]*flex-col', html) and "间距过大" not in failed_items:
-        failed_items.append("间距过大")
-    # 检测过大的图标边距（mr-[28px] 或更大）
-    if re.search(r'mr-\[(?:[3-9]\d|2[89])px\]', html) and "图标边距过大" not in failed_items:
-        failed_items.append("图标边距过大")
+    # 检测图标元素（class 含 fa-）上过大的右边距（mr-[28px] 或更大）
+    # 仅检查图标场景，避免误杀普通布局边距
+    for m in re.finditer(r'class="([^"]*\bfa-[^"]*)"', html):
+        mr_match = re.search(r'mr-\[(\d+)px\]', m.group(1))
+        if mr_match and int(mr_match.group(1)) >= 28:
+            if "图标边距过大" not in failed_items:
+                failed_items.append("图标边距过大")
+            break
     # 检测容器高度不足（h-[Npx] 容器内放 text-[Mpx] leading-[L]，N < M*L）
     # 简化检测：h-[Npx] 且同级有 text-[Mpx] leading-[1.1]，若 N < M*1.1+2 则标记
     for m in re.finditer(r'h-\[(\d+)px\][^>]*>.*?text-\[(\d+)px\].*?leading-\[1\.[01]\]', html, re.DOTALL):
@@ -686,7 +717,11 @@ def _post_check_layout_issues(html: str, failed_items: list[str]) -> list[str]:
             break
     # 检测 flex justify-between 中的文本无宽度约束
     # 匹配 justify-between 容器中的文本元素（p/span/div）没有 max-w 或 w- 约束
-    if re.search(r'class="[^"]*justify-between[^"]*"[^>]*>.*?<(?:p|span|div)[^>]*class="[^"]*text-\[\d+px\][^"]*"[^>]*>[^<]{20,}', html, re.DOTALL):
+    _jb_text_re = (
+        r'class="[^"]*justify-between[^"]*"[^>]*>.*?'
+        r'<(?:p|span|div)[^>]*class="[^"]*text-\[\d+px\][^"]*"[^>]*>[^<]{20,}'
+    )
+    if re.search(_jb_text_re, html, re.DOTALL):
         if not re.search(r'class="[^"]*justify-between[^"]*"[^>]*>.*?max-w-\[', html, re.DOTALL):
             if "文本无宽度约束" not in failed_items:
                 failed_items.append("文本无宽度约束")
@@ -724,15 +759,25 @@ _REWRITE_ACTIONS = {
     "缺数据来源": "在页脚标注'数据来源：XXX'（机构名或资料名）",
     "大段文字": "拆分为多个列表项/小节，添加小标题",
     "视觉层级混乱": "调整字号梯度，建立明确的标题→副标题→正文→注释层级",
-    "布局错误": "main 改为 `flex gap-3`，恰好 2 个 `<section>` 子元素；header/footer 放在 main 外部的 content-safe 内",
+    "布局错误": (
+        "main 改为 `flex`（左右分栏用 `flex-[N]` 比例，间距用 `pr-[12px]`/`pl-[12px]` 替代 gap），"
+        "恰好 2 个 `<section>` 子元素；header/footer 放在 main 外部的 content-safe 内"
+    ),
     "内容被隐藏": "移除 line-clamp、text-overflow:ellipsis、overflow:auto/scroll、max-height 限制等隐藏手段，确保核心内容完整可见",
     "核心内容缺失": "检查标题、正文、图表标签、数据来源和数据卡片是否全部完整显示，补充缺失的内容元素",
     "使用了不支持的Grid布局": "将所有 `grid grid-cols-*` 改为 Flexbox 布局（`flex` + `flex-[N]` 比例分配），因为 html-to-pptx 转换器不支持 CSS Grid",
-    "核心内容被overflow-hidden裁切": "移除核心内容容器（div/section/main 等）上的 `overflow-hidden` 类，仅保留 `.ppt-slide` 画布边界上的 overflow-hidden",
+    "核心内容被overflow-hidden裁切": (
+        "移除核心内容容器（div/section/main 等）上的 `overflow-hidden` 类，"
+        "仅保留 `.ppt-slide` 画布边界上的 overflow-hidden"
+    ),
     "字号不一致": "统一同级别卡片/模块的字号，使用风格文件定义的字号值，确保同级元素字号一致",
     "行高过大导致空白": "将 `leading-[2]` 或 `leading-loose` 改为 `leading-[1.5]` 或 `leading-[1.6]`，消除过大行高导致的空白",
-    "间距过大": "将 `justify-between` 改为 `justify-start`，用 `mt-[10px]` 逐项递增间距",
-    "图标边距过大": "将 `mr-[28px]` 或更大的图标边距缩小为 `mr-[8px]`，图标和文字之间保持紧凑",
+    "间距过大": (
+        "如果是 flex-col 列表项使用 justify-between 导致间距不均，"
+        "改为 justify-start + mt-[10px] 逐项递增间距；"
+        "header/footer 的 justify-between 可保留"
+    ),
+    "图标边距过大": "将图标（fa- 元素）上 `mr-[28px]` 或更大的边距缩小为 `mr-[8px]`，图标和文字之间保持紧凑",
     "容器高度不足": "增大容器高度使 ≥ 字号×行高系数+4px，或减小字号/行高",
     "文本无宽度约束": "在 flex 布局的文本元素上加 `max-w-[Npx]` 约束宽度，防止 PPTX 中溢出右边界",
     "图例与轴标题重叠": "设 `legend.top:'bottom'` 或 `legend.orient:'vertical'`，双轴图 `grid.right` 留足 ≥60px",
@@ -852,22 +897,24 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
     2: (
         "### 图片布局（2 张图）\n"
         "- 推荐左右对半分或一大一小\n"
+        "- 左右间距用 `pr-[6px]`/`pl-[6px]` 替代 gap（gap 在 PPTX 中不生效）\n"
         "```html\n"
-        '<div class="flex gap-3 flex-1 min-h-0">\n'
-        '  <img src="..." class="flex-1 h-full object-contain" />\n'
-        '  <img src="..." class="flex-1 h-full object-contain" />\n'
+        '<div class="flex flex-1 min-h-0">\n'
+        '  <div class="flex-1 h-full pr-[6px]"><img src="..." class="w-full h-full object-contain" /></div>\n'
+        '  <div class="flex-1 h-full pl-[6px]"><img src="..." class="w-full h-full object-contain" /></div>\n'
         '</div>\n'
         "```\n"
     ),
     3: (
         "### 图片布局（3 张图）\n"
         "- 推荐「左 1 右 2」：左侧大图，右侧上下两小图\n"
+        "- 左右间距用 `pr-[6px]`/`pl-[6px]`，上下间距用 `pb-[4px]`/`pt-[4px]` 替代 gap\n"
         "```html\n"
-        '<div class="flex gap-3 flex-1 min-h-0">\n'
-        '  <div class="flex-[2] h-full"><img src="..." class="w-full h-full object-contain" /></div>\n'
-        '  <div class="flex-1 flex flex-col min-h-0">\n'
-        '    <img src="..." class="w-full flex-1 min-h-0 object-contain" />\n'
-        '    <img src="..." class="w-full flex-1 min-h-0 object-contain" />\n'
+        '<div class="flex flex-1 min-h-0">\n'
+        '  <div class="flex-[2] h-full pr-[6px]"><img src="..." class="w-full h-full object-contain" /></div>\n'
+        '  <div class="flex-1 flex flex-col min-h-0 pl-[6px]">\n'
+        '    <img src="..." class="w-full flex-1 min-h-0 pb-[4px] object-contain" />\n'
+        '    <img src="..." class="w-full flex-1 min-h-0 pt-[4px] object-contain" />\n'
         '  </div>\n'
         '</div>\n'
         "```\n"
@@ -875,11 +922,12 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
     4: (
         "### 图片布局（4 张图）\n"
         "- 推荐 2×2 布局（用 flex flex-wrap 替代 grid）\n"
+        "- 间距用 margin（`mr-[2%]`/`mb-[2%]`）替代 gap\n"
         "```html\n"
-        '<div class="flex flex-wrap gap-3 flex-1 min-h-0">\n'
-        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
-        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
-        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
+        '<div class="flex flex-wrap flex-1 min-h-0">\n'
+        '  <img src="..." class="w-[48%] h-[48%] mr-[2%] mb-[2%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] mb-[2%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] mr-[2%] object-contain" />\n'
         '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
         '</div>\n'
         "```\n"
@@ -889,9 +937,10 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
 _IMAGE_LAYOUT_TEMPLATE_MANY = (
     "### 图片布局（{n} 张图）\n"
     "- 推荐用 flex flex-wrap 布局，每行 3-4 张（禁止使用 grid grid-cols-N）\n"
+    "- 间距用 margin（每行最后一张不加 mr，每列最后一行不加 mb）替代 gap\n"
     "```html\n"
-    '<div class="flex flex-wrap gap-3 flex-1 min-h-0">\n'
-    '  <!-- {n} 张图片，每张 w-[31%] object-contain -->\n'
+    '<div class="flex flex-wrap flex-1 min-h-0">\n'
+    '  <!-- {n} 张图片，每张 w-[31%] mb-[8px] mr-[8px] object-contain（行末/列末项不加对应 margin）-->\n'
     '</div>\n'
     "```\n"
 )
@@ -938,12 +987,14 @@ def _build_page_prompt(
     image_map_page: str = "",
     user_query: str = "",
 ) -> str:
-    # 用户原始 query 段（最高优先级，包含用户所有格式/内容/风格要求）
+    # 用户原始 query 段（用于指导内容方向/格式/风格，不改变本任务的页面范围）
     user_query_section = ""
     if user_query:
         user_query_section = (
-            "## 用户原始 query（最高优先级，所有格式/版式/风格要求以此为准）\n"
-            f"{user_query}\n\n"
+            "## 用户原始 query（用于指导内容方向和视觉风格要求）\n"
+            f"{user_query}\n"
+            "⚠️ 用户 query 中的页数/总量要求已由大纲规划完成，本步骤**仅生成第 "
+            f"{page_number} 页**，不生成其他页面。\n\n"
         )
 
     preset_clause = ""
@@ -1054,8 +1105,8 @@ def _build_page_prompt(
     if not is_structural:
         diversity_rule = (
             "\n### 布局多样性约束\n"
-            "- 禁止连续两页使用完全相同的 main 布局结构（grid 列数、子元素数量、比例分配）\n"
-            "- 主动使用不同的布局比例（如 `flex-[3]_flex-[2]`、`grid-cols-[3fr_2fr]`、`flex-[5]_flex-[4]` 等）\n"
+            "- 禁止连续两页使用完全相同的 main 布局结构（flex 比例、子元素数量、分栏方向）\n"
+            "- 主动使用不同的布局比例（如 `flex-[3]`/`flex-[2]`、`flex-[5]`/`flex-[4]`、`flex-[2]`/`flex-[3]` 等）\n"
             "- 根据内容叙事选择布局，而非机械套用模板\n"
         )
 
@@ -1106,6 +1157,8 @@ def _build_page_prompt(
         "\n"
         "## 5. 任务\n"
         f"你负责生成**第 {page_number} 页** HTML。仅生成该页，直接输出 HTML 原文。"
+        "**HTML 中必须只包含 1 个 `<div class=\"ppt-slide\">` 容器**，"
+        "禁止生成多个 slide 页面。"
         "先产出可运行 HTML，再按密度检查清单做小步修正；禁止在写文件前反复做像素级完整规划。"
         "生成时必须同时满足上述「内容密度检查（12 项）」全部要求，"
         "确保首次生成即通过密度检查，避免后续重写。"
@@ -1512,6 +1565,9 @@ class PageWorkerNode(PlanNode):
         if not html:
             return {"missing": True, "low_density": False, "report": {}}
 
+        # 防御：LLM 偶尔忽略单页约束，生成多个 slide，截取第一个
+        html = _truncate_to_single_slide(html)
+
         ok = await self._write_file(path, html)
         if not ok:
             return {"missing": True, "low_density": False, "report": {}}
@@ -1551,6 +1607,8 @@ class PageWorkerNode(PlanNode):
                 low_density = True
                 logger.info("[P8.1] 页面 %d 重写失败，保留当前 HTML，进 low_density", page_num)
                 break
+            # 防御：重写产物也可能包含多个 slide
+            rewritten = _truncate_to_single_slide(rewritten)
             write_ok = await self._write_file(path, rewritten)
             if not write_ok:
                 low_density = True

--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
@@ -28,35 +28,78 @@ _CHART_CANDIDATE_TYPES = {"data", "comparison", "technology", "trend"}
 
 
 def _extract_designer_section(text: str) -> str:
-    """从 designer/SKILL.md 原文提取防溢出约束 + 语义区域指南章节。
+    """从 designer/SKILL.md 原文提取布局约束、视觉规范等关键章节。
 
     文件 IO 由 PrepareNode 通过 read_file 工具完成后传入 text，
     skill_code 中禁止直接做文件 IO（校验器禁止 open/read_text 等）。
     """
     if not text:
         return ""
-    # 提取「防溢出硬性约束」章节到代码块结束
-    start = text.find("### 防溢出硬性约束")
-    if start == -1:
-        return ""
-    # 取到下一个 --- 分隔线或文件末尾
-    end = text.find("\n---", start)
-    if end == -1:
-        end = len(text)
-    css_section = text[start:end]
 
-    # 提取「语义区域」相关内容（main 直接子元素规则）
-    # 限定在 CSS 章节之前搜索，避免误匹配 CSS 章节之后的不相关内容
-    search_end = start  # CSS 章节开始位置作为语义区域搜索上界
+    sections: list[str] = []
+
+    def _extract_section(header: str, alt_header: str = "") -> str:
+        """提取从 header 开始到下一个 --- 分隔线或文件末尾的内容。"""
+        start = text.find(header)
+        if start == -1 and alt_header:
+            start = text.find(alt_header)
+        if start == -1:
+            return ""
+        end = text.find("\n---", start)
+        if end == -1:
+            end = len(text)
+        return text[start:end]
+
+    # 1. 防溢出硬性约束（全局 CSS 约束、图表容器约束等）
+    css_section = _extract_section("### 防溢出硬性约束")
+    if css_section:
+        sections.append(css_section)
+
+    # 2. 弹性布局约束（Grid/Flex 子元素撑满规则、快速决策表格）
+    flex_section = _extract_section(
+        "### 一、弹性布局约束",
+        "弹性布局约束",
+    )
+    if flex_section:
+        sections.append("\n\n### 弹性布局约束（完整）\n" + flex_section)
+
+    # 3. 固定尺寸约束
+    size_section = _extract_section(
+        "### 二、固定尺寸约束",
+        "固定尺寸约束",
+    )
+    if size_section:
+        sections.append("\n\n### 固定尺寸约束\n" + size_section)
+
+    # 4. 文本重叠避免 + 元素遮挡避免
+    overlap_section = _extract_section("### 三、文本重叠避免")
+    if overlap_section:
+        sections.append("\n\n### 文本重叠避免\n" + overlap_section)
+
+    occlusion_section = _extract_section("### 四、元素遮挡避免")
+    if occlusion_section:
+        sections.append("\n\n### 元素遮挡避免\n" + occlusion_section)
+
+    # 5. 色彩系统
+    color_section = _extract_section("### 色彩系统")
+    if color_section:
+        sections.append("\n\n### 色彩系统\n" + color_section)
+
+    # 6. 字体系统
+    font_section = _extract_section("### 字体系统")
+    if font_section:
+        sections.append("\n\n### 字体系统\n" + font_section)
+
+    # 7. 语义区域划分指南
+    search_end = text.find("### 防溢出硬性约束") if "### 防溢出硬性约束" in text else len(text)
     sem_start = text.find("✅ 正确示例 - 单一主视觉页面可只有一个语义区域", 0, search_end)
     if sem_start == -1:
         sem_start = text.find("main 的直接子元素数量由页面叙事决定", 0, search_end)
     sem_end = text.find("---", sem_start) if sem_start != -1 else -1
-    sem_section = ""
     if sem_start != -1 and sem_end != -1:
-        sem_section = "\n\n### 语义区域划分指南\n" + text[sem_start:sem_end]
+        sections.append("\n\n### 语义区域划分指南\n" + text[sem_start:sem_end])
 
-    return css_section + sem_section
+    return "\n".join(sections) if sections else ""
 
 
 _PRESET_STYLE_IDS = {"business-classic", "tech-minimal", "elegant-narrative", "industrial-tech"}
@@ -114,13 +157,12 @@ _CDN_HEAD_SNIPPET = (
 
 
 _DESIGN_RULES_DIGEST = (
-    "### 视觉与布局硬约束（精选 18 条）\n"
+    "### 视觉与布局硬约束（精选 26 条）\n"
     "1. 容器：`.ppt-slide { width:1280px; height:720px; overflow:hidden; box-sizing:border-box }`\n"
     "2. 安全区：`.content-safe { width:1220px; height:660px; margin:30px auto }`，主要内容必须放在安全区内；"
     "子元素禁止额外加 padding，否则导致双重边距\n"
-    "3. 三级字号：页面标题 36-48px / 副标题 24-28px / 正文 16-20px"
-    "（除非用户在原始 query 中明确指定了字号，此时以用户指定值为准）；"
-    "但紧凑卡片内（grid 子项或 flex-col 中 ≥3 个并列卡片）标题 ≤18px、正文 ≤14px，"
+    "3. 字号：严格使用风格规范文件中定义的字号值（如 business-classic.md 定义主标题 37px、正文 19px 等），"
+    "不自行调整字号范围（除非用户在原始 query 中明确指定了字号，此时以用户指定值为准）；"
     "同级卡片字号必须一致，禁止个别卡片字号放大导致内容溢出\n"
     "4. 图表类型：时序数据→折线图(line)；对比数据→柱状图/分组柱状图(bar)；"
     "占比数据→饼图(pie)；多维能力对比→雷达图(radar)；禁止用图片占位\n"
@@ -131,6 +173,16 @@ _DESIGN_RULES_DIGEST = (
     "4.2 图表最小高度（强制）：图表容器实际渲染高度必须 ≥ 250px（内联 SVG 的 viewBox height ≥ 250），"
     "否则 Y 轴名称/图例/标签会溢出重叠；"
     "用 `min-h-[250px]` 或 `flex-1` 确保图表区域有足够空间；禁止把图表挤在高度 < 200px 的容器里\n"
+    "4.3 图表数据标签防重叠（强制，所有含图表的页面都必须遵守）："
+    "用 echarts.init 时每个 series 都必须设 `labelLayout:{moveOverlap:'shiftY'}`；"
+    "双轴图中柱状图标签放柱顶上方（position:'top'），折线图标签放数据点下方（position:'bottom'），"
+    "两组标签垂直间距 ≥15px；"
+    "用内联 SVG 时折线图 text 的 transform translate y = 数据点 y + 12（向下偏移），柱状图 text 的 y = 柱顶 y - 8（向上偏移）\n"
+    "4.4 图例防叠字（强制，所有含图表的页面都必须遵守）："
+    "图例项 ≥3 个时，用 echarts.init 设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`；"
+    "用内联 SVG 时确保图例文字间距 ≥ 每项文字宽度+20px，排不下就换行或竖排；禁止水平挤排叠字\n"
+    "4.5 图表颜色（强制）：图表数据系列颜色必须来自风格文件的图表配色优先级表，禁止使用相近色；"
+    "坐标轴标签用 `#555757` 或 `#000000`，分割线用 `#DDDDDD`，禁止用浅灰色作为文字颜色\n"
     "5. 步骤/流程页 → 用 HTML/CSS 绘制节点+连线+文字，禁止纯文字描述\n"
     "6. 关键数字必须有放大数字卡片，结论必须有摘要高亮；"
     "数据可视化量化阈值：内容页必须 ≥1 个 ECharts 图表 或 ≥3 个数据卡片"
@@ -139,16 +191,24 @@ _DESIGN_RULES_DIGEST = (
     "6.1 核心要点量化：内容页必须有 6-10 个列表项或卡片（含数据卡片、论点卡片、要点列表），"
     "低于 6 个判定为'核心要点不足'，超过 10 个需合并精简\n"
     "6.2 装饰图标量化：内容页必须 ≥3 个 FontAwesome 图标（class 含 `fa-`），"
-    "用于辅助视觉表达（如卡片标题前缀、数据来源标注等），低于 3 个判定为'缺装饰图标'\n"
+    "用于辅助视觉表达（如卡片标题前缀等），低于 3 个判定为'缺装饰图标'\n"
     "6.3 空白率量化：内容页估算空白率必须 < 30%，"
     "即 1220×660px 内容区内实际有内容（文字/图表/卡片/图标）的面积占比 ≥ 70%；"
     "留白 > 30% 判定为'空白率过高'；通过增加卡片、图表、列表项填充内容，而非放大字号\n"
     "7. 防溢出：单行文字不超容器宽度；连续段落 ≤ 100 字（超过必须拆列表）；"
     "文本容器（p、span、div）必须加 `break-words` 类防止中英混排时英文/数字处不换行溢出\n"
-    "8. 布局结构：严格遵循标准 HTML 骨架——main 用 `grid grid-cols-2 gap-3`，"
+    "8. 布局结构：严格遵循标准 HTML 骨架——main 用 `flex gap-3`，"
     "恰好 2 个 `<section>` 子元素；header/main/footer 纵向排列在 content-safe 内\n"
-    "9. grid 子元素：必须 `h-full min-h-0 overflow-hidden`\n"
-    "10. flex-col 子元素：必须 `flex-1 min-h-0 overflow-hidden`\n"
+    "8.1 禁止使用 CSS Grid：html-to-pptx 转换器不支持 `display:grid`（Grid 仅检测不转换，视为非文本容器），"
+    "所有布局必须用 Flexbox（`flex`、`flex-col`、`flex-[N]`）替代 `grid grid-cols-*`；"
+    "左右分栏用 `flex` + `flex-[3]` / `flex-[2]` 比例分配，不用 `grid grid-cols-[3fr_2fr]`\n"
+    "8.2 gap 属性限制（强制）：`gap-*` 类在 PPTX 转换中**完全不生效**，"
+    "左右分栏时必须在子元素上用 `pl-[Npx]`/`pr-[Npx]` 或 `ml-[Npx]`/`mr-[Npx]` 替代 gap 做间距；"
+    "例如左右两栏不用 `flex gap-3`，而是左栏加 `pr-[12px]`、右栏加 `pl-[12px]`；"
+    "在 HTML 预览中 gap 正常，但 PPTX 中间距会完全丢失导致左右栏文本重叠遮挡\n"
+    "9. flex 子元素：必须 `flex-1 min-h-0 min-w-0`（水平布局）或 `flex-1 min-h-0`（垂直布局）；"
+    "禁止使用 `overflow-hidden` 隐藏核心内容\n"
+    "10. flex-col 子元素：必须 `flex-1 min-h-0`；禁止使用 `overflow-hidden` 隐藏核心内容\n"
     "10.1 内容预算：flex-col 中有多个子元素时，禁止把大块内容（如完整表格）设 `flex-shrink-0`，"
     "否则会挤压其他 `flex-1` 兄弟元素至高度为 0；大块内容也要参与弹性收缩或拆分\n"
     "11. 配色与字体严格来自风格规范文件，禁止使用未定义的颜色或字体"
@@ -156,7 +216,9 @@ _DESIGN_RULES_DIGEST = (
     "所有页面 `<body>` 背景色必须统一，从风格规范中取一致的背景色，禁止部分页面用浅灰/灰色背景而其他页用白色\n"
     "12. 页脚：底部必须有数据来源汇总条（如'数据来源：央行、财政部、...'），即使卡片内已有来源标注也必须保留页脚；"
     "禁止页脚出现纯数字页码编号（除非用户在原始 query 中明确要求页码，此时应在用户指定位置添加页码，格式如 3/12）\n"
-    "13. 布局实现：所有区域用 `flex-1 min-h-0` 自动分配高度，禁止手动计算 px 值；子元素用 `h-full min-h-0 overflow-hidden` 防溢出，信任 flex/grid 自动布局\n"
+    "13. 布局实现：所有区域用 `flex-1 min-h-0` 自动分配高度，禁止手动计算 px 值；"
+    "子元素用 `flex-1 min-h-0` 弹性填充，禁止使用 `overflow-hidden` 隐藏核心内容（标题/正文/图表/数据卡片等），"
+    "信任 flex 自动布局\n"
     "13.1 表格禁用 CSS Grid：html-to-pptx 引擎不支持 `display:grid` 渲染表格，grid 表格会被转为低质量截图；"
     "数据表格必须用 `<table><tr><td>` 原生标签或 `flex` 布局替代 `grid grid-cols-N`\n"
     "14. 全局禁止 `rounded-*` 类，所有元素 border-radius:0（饼图/环形图的圆形不受此限制）\n"
@@ -164,10 +226,38 @@ _DESIGN_RULES_DIGEST = (
     "`data-page-role` 不是旧 `type` 属性的替代品，两者并存\n"
     "16. 标题栏、页脚为跨页锚点片段（见风格文件「四、组件样式库」开头的「跨页锚点片段」说明），"
     "必须逐字复用 HTML 结构/class/间距，只改文字内容，禁止自行重新设计\n"
-    "17. 标题、正文、图表标签、数据来源和数据卡片必须完整显示，禁止裁切或隐藏\n"
+    "17. 标题、正文、图表标签、数据来源和数据卡片必须完整显示，禁止裁切或隐藏；"
+    "禁止在核心内容容器上使用 `overflow-hidden`（仅允许在 `.ppt-slide` 画布边界使用）\n"
     "18. 遮罩层≠底色：`bg-black/50`、`from-black/*`、`bg-gradient-*` 等是遮罩层(overlay)，"
     "必须配合底层 `<img>` 背景图使用以保证文字可读，不是页面/卡片底色；"
     "页面底色必须严格遵循风格规范文件定义的背景色，禁止使用与风格不符的底色\n"
+    "19. 图表分割线：`splitLine` 建议使用 `type:'dashed'` 虚线，避免实线分割线在 PPTX 中过于突兀；"
+    "颜色用 `#DDDDDD`，禁止用深色实线\n"
+    "20. padding/border 转换缩放：html-to-pptx 转换器对 padding 缩放 0.85（减少 15%）、border-width 缩放 0.65（减少 35%），"
+    "生成 HTML 时需预留余量，避免 PPTX 中内容因缩放溢出或边框过细\n"
+    "21. 文本换行（强制）：`break-words`（`overflow-wrap:break-word`）在 PPTX 转换中不生效，"
+    "长文本不会在 PPTX 中自动换行而会溢出右边界；"
+    "必须将长段落拆分为多个 `<p>` 标签或用 `<br>` 手动换行，单行文字不超过容器宽度；"
+    "案例/说明文字控制在 40 字以内一行，超过时用 `<br>` 分行\n"
+    "22. 间距控制（强制）："
+    "禁止使用 `justify-between` 分布列表项（无论数量多少，因为项的高度不一时 gap 相等但视觉间距不一致）；"
+    "列表项间距统一用 `mt-[10px]` 或 `mt-[12px]` 逐项递增，确保每个项之间的视觉间距一致；"
+    "正确写法：`<div class=\"flex flex-col\"><div class=\"mt-[10px]\">项1</div><div class=\"mt-[10px]\">项2</div></div>`；"
+    "禁止使用 `leading-[2]` 或 `leading-loose`（行高 2 倍），行高上限 `leading-[1.6]`；"
+    "图标与文字间距不超过 `mr-[8px]`，禁止用 `mr-[28px]` 或更大的图标边距；"
+    "ECharts SVG 图例在 PPTX 转换后图标和文字可能不对齐（转换器限制），"
+    "图例项之间留足间距，图例文字用 `fontSize:12` 确保字号统一\n"
+    "23. ECharts 数据一致性（强制）：xAxis.data 数组的长度必须与 series[].data 数组的长度完全一致，"
+    "禁止 x 轴标签数量与数据点数量不匹配；双轴图必须确保两个 yAxis 的数据点一一对应\n"
+    "24. 容器高度（强制）：文本容器的固定高度必须大于等于其内文字行高，"
+    "例如 `h-[28px]` 的容器不能放 `text-[26px] leading-[1.1]`（行高 28.6px > 28px），"
+    "否则 PPTX 中文字会向上溢出与上方元素重叠；"
+    "正确做法：容器高度 ≥ 字号 × 行高系数 + 4px 余量\n"
+    "25. 文本宽度约束（强制）：`flex justify-between` 布局中的文本元素必须加 `max-w-[Npx]` 或 `w-[Npx]` 约束宽度，"
+    "否则 PPTX 中文本不自动换行会溢出右边界；"
+    "英文/数字混合文本（如 'GMTN Programme · Carbon Neutral Green Bond'）必须加 `break-words` + `max-w-[200px]`\n"
+    "26. ECharts 图例与轴标题防重叠（强制）：图例项 ≥3 个时必须设 `legend.top: 'bottom'` 或 `legend.orient: 'vertical'`，"
+    "避免图例水平排列时与 Y 轴标题重叠；双轴图的右 Y 轴标题（`yAxis.name`）必须设置 `yAxis.nameLocation: 'end'` 且 `grid.right` 留足 ≥60px 空间\n"
 )
 
 
@@ -175,11 +265,11 @@ _HTML_SKELETON = (
     "### 标准 HTML 骨架（所有页面必须遵循，禁止改动结构）\n"
     "```html\n"
     '<div class="ppt-slide" type="content" data-page-role="content">\n'
-    '  <div class="content-safe flex flex-col gap-3 h-full">\n'
+    '  <div class="content-safe flex flex-col h-full">\n'
     '    <header class="flex-shrink-0">标题区</header>\n'
-    '    <main class="flex-1 min-h-0 grid grid-cols-2 gap-3">\n'
-    '      <section class="h-full min-h-0 overflow-hidden">左侧内容</section>\n'
-    '      <section class="h-full min-h-0 overflow-hidden">右侧内容</section>\n'
+    '    <main class="flex-1 min-h-0 flex">\n'
+    '      <section class="flex-1 min-h-0 min-w-0 pr-[12px]">左侧内容</section>\n'
+    '      <section class="flex-1 min-h-0 min-w-0 pl-[12px]">右侧内容</section>\n'
     '    </main>\n'
     '    <footer class="flex-shrink-0">数据来源页脚</footer>\n'
     '  </div>\n'
@@ -188,8 +278,9 @@ _HTML_SKELETON = (
     "规则：\n"
     "- 根节点必须同时携带 `class=\"ppt-slide\"`、`type=\"content\"`、`data-page-role=\"content\"`\n"
     "- `content-safe` 用 `flex flex-col` 纵向排列 header/main/footer 三段\n"
-    "- `main` 用 `grid grid-cols-2` 左右分列，恰好 2 个 `<section>` 直接子元素\n"
+    "- `main` 用 `flex` 左右分列（禁止使用 `grid grid-cols-*`，html-to-pptx 转换器不支持 CSS Grid），恰好 2 个 `<section>` 直接子元素\n"
     "- 禁止把 header/footer 放进 main 内部；禁止 main 只有 1 个子元素\n"
+    "- 禁止在子元素上使用 `overflow-hidden` 隐藏核心内容（标题/正文/图表标签/数据卡片等）；overflow-hidden 仅允许用于 `.ppt-slide` 画布边界\n"
 )
 
 
@@ -234,39 +325,41 @@ _PAGE_LAYOUT_TEMPLATES = {
     "data": (
         "### 参考布局（data 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
-        '<div class="content-safe flex flex-col gap-3 h-full">\n'
-        '  <header class="flex-shrink-0">4-6 个关键数字卡片，grid grid-cols-6</header>\n'
-        '  <main class="flex-1 min-h-0 grid grid-cols-[3fr_2fr] gap-3">\n'
-        '    <section class="h-full min-h-0 overflow-hidden">6 个核心论点卡片，grid grid-cols-2 grid-rows-3 gap-2</section>\n'
-        '    <section class="h-full min-h-0 overflow-hidden">ECharts 图表 + 对比表格</section>\n'
+        '<div class="content-safe flex flex-col h-full">\n'
+        '  <header class="flex-shrink-0">4-6 个关键数字卡片，flex</header>\n'
+        '  <main class="flex-1 min-h-0 flex">\n'
+        '    <section class="flex-[3] min-h-0 min-w-0 pr-[12px]">6 个核心论点卡片，flex flex-col</section>\n'
+        '    <section class="flex-[2] min-h-0 min-w-0 pl-[12px]">ECharts 图表 + 对比表格</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">数据来源汇总条</footer>\n'
         '</div>\n'
         "```\n"
         "- ECharts 图表类型根据数据形态选择（柱状图/饼图/雷达图）\n"
+        "- 左右分栏间距用 `pr-[12px]`/`pl-[12px]` 替代 gap（gap 在 PPTX 中不生效）\n"
     ),
     "trend": (
         "### 参考布局（trend 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
-        '<div class="content-safe flex flex-col gap-3 h-full">\n'
+        '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">3 个关键数字卡片</header>\n'
-        '  <main class="flex-1 min-h-0 flex gap-3 overflow-hidden">\n'
-        '    <section class="flex-1 min-h-0 overflow-hidden">ECharts 折线图（趋势数据）</section>\n'
-        '    <section class="w-[40%] min-h-0 overflow-hidden">4-6 个核心论点卡片，flex-col gap-2</section>\n'
+        '  <main class="flex-1 min-h-0 flex">\n'
+        '    <section class="flex-1 min-h-0 min-w-0 pr-[12px]">ECharts 折线图（趋势数据）</section>\n'
+        '    <section class="w-[40%] min-h-0 min-w-0 pl-[12px]">4-6 个核心论点卡片，flex-col</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">数据来源汇总条</footer>\n'
         '</div>\n'
         "```\n"
         "- ECharts 默认折线图(line)，数据形态更适合其他类型时可切换\n"
+        "- 左右分栏间距用 `pr-[12px]`/`pl-[12px]` 替代 gap\n"
     ),
     "comparison": (
         "### 参考布局（comparison 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
-        '<div class="content-safe flex flex-col gap-3 h-full">\n'
-        '  <main class="flex-1 min-h-0 flex flex-col gap-3 overflow-hidden">\n'
-        '    <div class="flex gap-3 flex-1 min-h-0">\n'
-        '      <section class="flex-1 min-h-0 overflow-hidden">对比对象 A 的卡片（grid grid-cols-2 grid-rows-3）</section>\n'
-        '      <section class="flex-1 min-h-0 overflow-hidden">对比对象 B 的卡片（grid grid-cols-2 grid-rows-3）</section>\n'
+        '<div class="content-safe flex flex-col h-full">\n'
+        '  <main class="flex-1 min-h-0 flex flex-col">\n'
+        '    <div class="flex flex-1 min-h-0">\n'
+        '      <section class="flex-1 min-h-0 min-w-0 pr-[6px]">对比对象 A 的卡片（flex flex-col）</section>\n'
+        '      <section class="flex-1 min-h-0 min-w-0 pl-[6px]">对比对象 B 的卡片（flex flex-col）</section>\n'
         '    </div>\n'
         '    <section class="flex-shrink-0">对比表格</section>\n'
         '  </main>\n'
@@ -274,15 +367,16 @@ _PAGE_LAYOUT_TEMPLATES = {
         '</div>\n'
         "```\n"
         "- ECharts 默认分组柱状图(grouped bar)，占比数据用饼图\n"
+        "- 左右分栏间距用 `pr-[6px]`/`pl-[6px]` 替代 gap\n"
     ),
     "case": (
         "### 参考布局（case 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
-        '<div class="content-safe flex flex-col gap-3 h-full">\n'
+        '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">3 个关键数字卡片</header>\n'
-        '  <main class="flex-1 min-h-0 grid grid-cols-[2fr_3fr] gap-3">\n'
-        '    <section class="h-full min-h-0 overflow-hidden">6 个核心论点卡片，flex-col gap-2</section>\n'
-        '    <section class="h-full min-h-0 overflow-hidden">ECharts 图表 + 关键数据表格</section>\n'
+        '  <main class="flex-1 min-h-0 flex">\n'
+        '    <section class="flex-[2] min-h-0 min-w-0 pr-[12px]">6 个核心论点卡片，flex-col</section>\n'
+        '    <section class="flex-[3] min-h-0 min-w-0 pl-[12px]">ECharts 图表 + 关键数据表格</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">案例素材详细描述 + 数据来源页脚</footer>\n'
         '</div>\n'
@@ -291,11 +385,11 @@ _PAGE_LAYOUT_TEMPLATES = {
     "technology": (
         "### 参考布局（technology 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
-        '<div class="content-safe flex flex-col gap-3 h-full">\n'
+        '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">4 个关键数字卡片</header>\n'
-        '  <main class="flex-1 min-h-0 flex flex-col gap-3 overflow-hidden">\n'
-        '    <section class="flex-1 min-h-0 overflow-hidden">ECharts 图表 + 对比表格</section>\n'
-        '    <section class="flex-1 min-h-0 overflow-hidden">6 个核心论点卡片，grid grid-cols-3 grid-rows-2 gap-2</section>\n'
+        '  <main class="flex-1 min-h-0 flex flex-col">\n'
+        '    <section class="flex-1 min-h-0 min-w-0 pb-[8px]">ECharts 图表 + 对比表格</section>\n'
+        '    <section class="flex-1 min-h-0 min-w-0 pt-[8px]">6 个核心论点卡片，flex flex-wrap</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">数据来源汇总条</footer>\n'
         '</div>\n'
@@ -305,17 +399,6 @@ _PAGE_LAYOUT_TEMPLATES = {
         "多维数据比较→雷达图(radar)；两变量关系→散点图(scatter)；"
         "单一变量分布→直方图(histogram)；数据分布/离群值→箱线图(boxplot)；"
         "层次结构→树状图(treemap)；矩阵数据→热力图(heatmap)\n"
-        "- 双轴图标签防重叠（无论用 echarts.init 还是内联 SVG 都必须遵守）："
-        "柱状图标签放柱顶上方（y 坐标减小），折线图标签放数据点下方（y 坐标增大），"
-        "两组标签垂直间距 ≥15px，禁止两组标签都在数据点上方；"
-        "用 echarts.init 时【强制】每个 series 都必须设 labelLayout:{moveOverlap:'shiftY'}，"
-        "同时配合 label.position:'top'/'bottom' 错开（两者并存，不可二选一）；"
-        "原因：双轴图两轴量程独立，仅靠 position 错开无法保证标签不重叠（数据点屏幕坐标过近时 top/bottom 标签仍会撞），"
-        "moveOverlap:'shiftY' 是 ECharts 原生运行时防重叠算法，渲染时自动检测并向 Y 方向错开重叠标签；"
-        "用内联 SVG 时折线图 text 的 transform translate y = 数据点 y + 12（向下偏移），柱状图 text 的 y = 柱顶 y - 8（向上偏移）\n"
-        "- 图例防叠字（无论用 echarts.init 还是内联 SVG 都必须遵守）："
-        "图例项 ≥3 个时，用 echarts.init 设 legend:{type:'scroll'} 或 legend:{orient:'vertical'}；"
-        "用内联 SVG 时确保图例文字间距 ≥ 每项文字宽度+20px，排不下就换行或竖排；禁止水平挤排叠字\n"
     ),
     "cover": (
         "### 推荐布局（cover 类型，封面页）\n"
@@ -326,7 +409,7 @@ _PAGE_LAYOUT_TEMPLATES = {
         '  <p class="text-[18px] text-center mt-2">日期</p>\n'
         '</div>\n'
         "```\n"
-        "- 低密度页面，允许较高留白，不要求 grid-cols-2、数据卡片或图表\n"
+        "- 低密度页面，允许较高留白，不要求双栏、数据卡片或图表\n"
     ),
     "ending": (
         "### 推荐布局（ending 类型，结束页）\n"
@@ -336,7 +419,7 @@ _PAGE_LAYOUT_TEMPLATES = {
         '  <p class="text-[22px] text-center mt-4">联系方式（可选）</p>\n'
         '</div>\n'
         "```\n"
-        "- 低密度页面，允许较高留白，不要求 grid-cols-2、数据卡片或图表\n"
+        "- 低密度页面，允许较高留白，不要求双栏、数据卡片或图表\n"
     ),
 }
 
@@ -359,7 +442,7 @@ _STRUCTURAL_DENSITY_CHECKLIST = (
 )
 
 _DENSITY_CHECKLIST_DIGEST = (
-    "### 内容密度检查（12 项，全部必须通过）\n"
+    "### 内容密度检查（15 项，全部必须通过）\n"
     "1. 数据可视化：≥1 个 ECharts 图表 或 ≥3 个数据卡片（no_search 模式且页面为'数据有限'时可降至 2 个数据卡片）\n"
     "2. 核心要点：6-10 个列表项或卡片\n"
     "3. 装饰图标：≥3 个 FontAwesome 图标（class 含 `fa-`）\n"
@@ -367,15 +450,20 @@ _DENSITY_CHECKLIST_DIGEST = (
     "5. 数据来源：页脚有标注（机构名 / 资料名）\n"
     "6. 无大段文字：无连续 > 100 字段落\n"
     "7. 视觉层级：标题 → 副标题 → 正文 → 注释 层级清晰\n"
-    "8. 布局正确：main 元素采用双区域布局（如 `grid grid-cols-2`、`grid grid-cols-[3fr_2fr]`、"
-    "`flex gap-4` 等），且恰好 2 个直接子元素（`<section>` 或 `<div>`）；"
+    "8. 布局正确：main 元素采用双区域布局（如 `flex gap-4`、`flex` + `flex-[3]`/`flex-[2]` 等），"
+    "且恰好 2 个直接子元素（`<section>` 或 `<div>`）；"
+    "禁止使用 `grid grid-cols-*`（html-to-pptx 不支持 CSS Grid）；"
     "禁止所有页面使用相同布局，需根据内容叙事选择不同布局比例和方向\n"
-    "9. 完整显示：核心内容未使用 line-clamp、省略号、滚动或折叠隐藏\n"
+    "9. 完整显示：核心内容未使用 line-clamp、省略号、滚动或折叠隐藏；"
+    "核心内容容器（div/section/main 等）禁止使用 `overflow-hidden`（仅 `.ppt-slide` 画布边界允许）\n"
     "10. 内容完整：标题、正文、图表标签、数据来源和数据卡片全部完整显示，无裁切\n"
     "11. ECharts SVG 检查：所有 echarts.init 调用必须包含 `{renderer:'svg'}` 参数，"
     "且使用 `document.getElementById('xxx')` 直接传参，禁止变量赋值\n"
-    "12. grid-cols 合法性：所有 `grid-cols-[...]` 必须为合法 CSS，不存在无单位裸数字"
-    "（正确：`grid-cols-[3fr_2fr]` `grid-cols-[320px_1fr]`，错误：`grid-cols-[3_2]` `grid-cols-[1.2_1]`）\n"
+    "12. grid-cols 合法性：禁止使用 `grid-cols-*`（CSS Grid 不被转换器支持，改用 Flexbox）\n"
+    "13. 字号一致性：同级别卡片/模块必须使用相同字号，字号值来自风格文件\n"
+    "14. 图表标签防重叠：所有 ECharts series 必须设 `labelLayout:{moveOverlap:'shiftY'}`；"
+    "图例项 ≥3 个时设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`\n"
+    "15. 图表颜色：数据系列颜色来自风格文件图表配色表，坐标轴标签用深色，分割线用浅色虚线\n"
 )
 
 
@@ -503,15 +591,105 @@ def _has_empty_chart_svg(html: str) -> bool:
     return False
 
 
+# 检测 CSS Grid 布局使用（html-to-pptx 不支持 Grid）
+_GRID_USAGE_RE = re.compile(r'\bgrid\s+grid-cols-\S+', re.IGNORECASE)
+
+
+def _has_grid_layout(html: str) -> bool:
+    """检测是否使用了 CSS Grid 布局（html-to-pptx 转换器不支持 Grid）。"""
+    return bool(_GRID_USAGE_RE.search(html))
+
+
+# 检测核心内容容器上的 overflow-hidden（不应裁切核心内容）
+_OVERFLOW_HIDDEN_RE = re.compile(
+    r'<(?:div|section|main|article|aside|header|footer)[^>]*\boverflow-hidden\b[^>]*>',
+    re.IGNORECASE,
+)
+
+
+def _has_overflow_hidden_on_content(html: str) -> bool:
+    """检测核心内容容器（div/section/main 等）上是否使用了 overflow-hidden。
+
+    overflow-hidden 仅允许用于 .ppt-slide 画布边界，不应用于核心内容容器。
+    """
+    # 排除 .ppt-slide 容器本身（画布边界 overflow-hidden 是允许的）
+    matches = _OVERFLOW_HIDDEN_RE.findall(html)
+    for m in matches:
+        if 'ppt-slide' not in m.lower():
+            return True
+    return False
+
+
+# 检测字号一致性：提取所有 text-[Npx] 值
+_FONT_SIZE_RE = re.compile(r'text-\[(\d+)px\]')
+
+
+def _check_font_size_consistency(html: str) -> bool:
+    """检测同页字号是否一致。返回 True 表示不一致。
+
+    规则：同级别的卡片/模块应使用相同字号。
+    如果同页出现 >3 种不同正文字号，判定为不一致。
+    """
+    sizes = [int(m) for m in _FONT_SIZE_RE.findall(html)]
+    if not sizes:
+        return False
+    # 过滤出正文字号范围（14-24px），标题字号（37px+）不参与一致性检查
+    body_sizes = [s for s in sizes if 14 <= s <= 24]
+    if len(set(body_sizes)) > 3:
+        return True
+    return False
+
+
 def _post_check_data_viz(html: str, failed_items: list[str], search_mode: str) -> list[str]:
     """程序化后置校验：对 LLM 判定的'缺数据可视化'做二次确认，移除误判。"""
     if "缺数据可视化" not in failed_items:
         return failed_items
     has_echarts = "echarts" in html.lower()
-    card_count = html.lower().count("card")
+    # 改进卡片计数：只匹配 class 属性中的 card，不匹配文本内容
+    card_count = len(re.findall(r'class="[^"]*\bcard\b[^"]*"', html, re.IGNORECASE))
     threshold = 2 if search_mode == "no_search" else 3
     if has_echarts or card_count >= threshold:
         failed_items = [x for x in failed_items if x != "缺数据可视化"]
+    return failed_items
+
+
+def _post_check_layout_issues(html: str, failed_items: list[str]) -> list[str]:
+    """程序化后置校验：检测 Grid 布局、overflow-hidden 等布局问题。"""
+    # 检测 CSS Grid 使用
+    if _has_grid_layout(html) and "使用了不支持的Grid布局" not in failed_items:
+        failed_items.append("使用了不支持的Grid布局")
+    # 检测核心内容容器上的 overflow-hidden
+    if _has_overflow_hidden_on_content(html) and "核心内容被overflow-hidden裁切" not in failed_items:
+        failed_items.append("核心内容被overflow-hidden裁切")
+    # 检测字号不一致
+    if _check_font_size_consistency(html) and "字号不一致" not in failed_items:
+        failed_items.append("字号不一致")
+    # 检测 leading-[2] 或 leading-loose（行高过大导致空白）
+    if re.search(r'leading-\[2\]|leading-loose', html) and "行高过大导致空白" not in failed_items:
+        failed_items.append("行高过大导致空白")
+    # 检测 justify-between 用于列表项（项高度不一时视觉间距不一致）
+    # 匹配任何使用 justify-between 的 flex-col 容器
+    if re.search(r'class="[^"]*flex[^"]*flex-col[^"]*justify-between', html) and "间距过大" not in failed_items:
+        failed_items.append("间距过大")
+    elif re.search(r'class="[^"]*justify-between[^"]*flex[^"]*flex-col', html) and "间距过大" not in failed_items:
+        failed_items.append("间距过大")
+    # 检测过大的图标边距（mr-[28px] 或更大）
+    if re.search(r'mr-\[(?:[3-9]\d|2[89])px\]', html) and "图标边距过大" not in failed_items:
+        failed_items.append("图标边距过大")
+    # 检测容器高度不足（h-[Npx] 容器内放 text-[Mpx] leading-[L]，N < M*L）
+    # 简化检测：h-[Npx] 且同级有 text-[Mpx] leading-[1.1]，若 N < M*1.1+2 则标记
+    for m in re.finditer(r'h-\[(\d+)px\][^>]*>.*?text-\[(\d+)px\].*?leading-\[1\.[01]\]', html, re.DOTALL):
+        h_val, font_val = int(m.group(1)), int(m.group(2))
+        if h_val < font_val * 1.1 + 2:
+            if "容器高度不足" not in failed_items:
+                failed_items.append("容器高度不足")
+            break
+    # 检测 flex justify-between 中的文本无宽度约束
+    # 匹配 justify-between 容器中的文本元素（p/span/div）没有 max-w 或 w- 约束
+    if re.search(r'class="[^"]*justify-between[^"]*"[^>]*>.*?<(?:p|span|div)[^>]*class="[^"]*text-\[\d+px\][^"]*"[^>]*>[^<]{20,}', html, re.DOTALL):
+        if not re.search(r'class="[^"]*justify-between[^"]*"[^>]*>.*?max-w-\[', html, re.DOTALL):
+            if "文本无宽度约束" not in failed_items:
+                failed_items.append("文本无宽度约束")
     return failed_items
 
 
@@ -546,9 +724,18 @@ _REWRITE_ACTIONS = {
     "缺数据来源": "在页脚标注'数据来源：XXX'（机构名或资料名）",
     "大段文字": "拆分为多个列表项/小节，添加小标题",
     "视觉层级混乱": "调整字号梯度，建立明确的标题→副标题→正文→注释层级",
-    "布局错误": "main 改为 `grid grid-cols-2 gap-3`，恰好 2 个 `<section>` 子元素；header/footer 放在 main 外部的 content-safe 内",
+    "布局错误": "main 改为 `flex gap-3`，恰好 2 个 `<section>` 子元素；header/footer 放在 main 外部的 content-safe 内",
     "内容被隐藏": "移除 line-clamp、text-overflow:ellipsis、overflow:auto/scroll、max-height 限制等隐藏手段，确保核心内容完整可见",
     "核心内容缺失": "检查标题、正文、图表标签、数据来源和数据卡片是否全部完整显示，补充缺失的内容元素",
+    "使用了不支持的Grid布局": "将所有 `grid grid-cols-*` 改为 Flexbox 布局（`flex` + `flex-[N]` 比例分配），因为 html-to-pptx 转换器不支持 CSS Grid",
+    "核心内容被overflow-hidden裁切": "移除核心内容容器（div/section/main 等）上的 `overflow-hidden` 类，仅保留 `.ppt-slide` 画布边界上的 overflow-hidden",
+    "字号不一致": "统一同级别卡片/模块的字号，使用风格文件定义的字号值，确保同级元素字号一致",
+    "行高过大导致空白": "将 `leading-[2]` 或 `leading-loose` 改为 `leading-[1.5]` 或 `leading-[1.6]`，消除过大行高导致的空白",
+    "间距过大": "将 `justify-between` 改为 `justify-start`，用 `mt-[10px]` 逐项递增间距",
+    "图标边距过大": "将 `mr-[28px]` 或更大的图标边距缩小为 `mr-[8px]`，图标和文字之间保持紧凑",
+    "容器高度不足": "增大容器高度使 ≥ 字号×行高系数+4px，或减小字号/行高",
+    "文本无宽度约束": "在 flex 布局的文本元素上加 `max-w-[Npx]` 约束宽度，防止 PPTX 中溢出右边界",
+    "图例与轴标题重叠": "设 `legend.top:'bottom'` 或 `legend.orient:'vertical'`，双轴图 `grid.right` 留足 ≥60px",
 }
 
 
@@ -666,9 +853,9 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
         "### 图片布局（2 张图）\n"
         "- 推荐左右对半分或一大一小\n"
         "```html\n"
-        '<div class="grid grid-cols-2 gap-3 flex-1 min-h-0">\n'
-        '  <img src="..." class="w-full h-full object-contain" />\n'
-        '  <img src="..." class="w-full h-full object-contain" />\n'
+        '<div class="flex gap-3 flex-1 min-h-0">\n'
+        '  <img src="..." class="flex-1 h-full object-contain" />\n'
+        '  <img src="..." class="flex-1 h-full object-contain" />\n'
         '</div>\n'
         "```\n"
     ),
@@ -676,9 +863,9 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
         "### 图片布局（3 张图）\n"
         "- 推荐「左 1 右 2」：左侧大图，右侧上下两小图\n"
         "```html\n"
-        '<div class="grid grid-cols-3 gap-3 flex-1 min-h-0">\n'
-        '  <div class="col-span-2"><img src="..." class="w-full h-full object-contain" /></div>\n'
-        '  <div class="flex flex-col gap-2">\n'
+        '<div class="flex gap-3 flex-1 min-h-0">\n'
+        '  <div class="flex-[2] h-full"><img src="..." class="w-full h-full object-contain" /></div>\n'
+        '  <div class="flex-1 flex flex-col min-h-0">\n'
         '    <img src="..." class="w-full flex-1 min-h-0 object-contain" />\n'
         '    <img src="..." class="w-full flex-1 min-h-0 object-contain" />\n'
         '  </div>\n'
@@ -687,13 +874,13 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
     ),
     4: (
         "### 图片布局（4 张图）\n"
-        "- 推荐 2×2 宫格\n"
+        "- 推荐 2×2 布局（用 flex flex-wrap 替代 grid）\n"
         "```html\n"
-        '<div class="grid grid-cols-2 grid-rows-2 gap-3 flex-1 min-h-0">\n'
-        '  <img src="..." class="w-full h-full object-contain" />\n'
-        '  <img src="..." class="w-full h-full object-contain" />\n'
-        '  <img src="..." class="w-full h-full object-contain" />\n'
-        '  <img src="..." class="w-full h-full object-contain" />\n'
+        '<div class="flex flex-wrap gap-3 flex-1 min-h-0">\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
         '</div>\n'
         "```\n"
     ),
@@ -701,10 +888,10 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
 
 _IMAGE_LAYOUT_TEMPLATE_MANY = (
     "### 图片布局（{n} 张图）\n"
-    "- 推荐网格布局，每行 3-4 张\n"
+    "- 推荐用 flex flex-wrap 布局，每行 3-4 张（禁止使用 grid grid-cols-N）\n"
     "```html\n"
-    '<div class="grid grid-cols-{cols} gap-3 flex-1 min-h-0">\n'
-    '  <!-- {n} 张图片，每张 object-contain -->\n'
+    '<div class="flex flex-wrap gap-3 flex-1 min-h-0">\n'
+    '  <!-- {n} 张图片，每张 w-[31%] object-contain -->\n'
     '</div>\n'
     "```\n"
 )
@@ -730,7 +917,7 @@ def _build_image_section(image_map_page: str) -> str:
         "- `usage=content` → 用作内容配图："
         "`<img src=\"...\" class=\"w-full h-full object-contain\">`\n"
         "- 使用 `<img>` 标签引用 `path` 字段指定的路径（相对路径，直接使用）\n"
-        "- 图片容器用 `min-h-0 overflow-hidden` 防溢出\n"
+        "- 图片容器用 `min-h-0` 防溢出（禁止使用 `overflow-hidden`，图片内容需完整显示）\n"
         f"\n{layout}"
     )
 
@@ -779,7 +966,10 @@ def _build_page_prompt(
         rewrite_constraints = (
             "⚠️ **重写约束**：\n"
             "- 仅修复上述不通过项，不要改动其他正常部分\n"
-            "- 布局结构（grid/flex-col、子元素数量）如果上次已正确，严禁改动\n"
+            "- 如果布局使用了 CSS Grid（`grid grid-cols-*`），必须改为 Flexbox（`flex`）布局，"
+            "因为 html-to-pptx 转换器不支持 CSS Grid\n"
+            "- 如果子元素使用了 `overflow-hidden`，且该元素包含核心内容（标题/正文/图表/数据卡片），"
+            "必须移除 `overflow-hidden`\n"
             "- 已通过的检查项对应的代码不要修改\n"
             "- 只在不通过项相关的代码区域做修改，其余部分保持原样\n"
         )
@@ -1436,7 +1626,10 @@ class PageWorkerNode(PlanNode):
             failed_enum = (
                 "缺数据可视化 / 核心要点不足 / 缺装饰图标 / 空白率过高 / "
                 "缺数据来源 / 大段文字 / 视觉层级混乱 / 布局错误 / "
-                "内容被隐藏 / 核心内容缺失 / grid-cols 非法"
+                "内容被隐藏 / 核心内容缺失 / grid-cols 非法 / "
+                "使用了不支持的Grid布局 / 核心内容被overflow-hidden裁切 / 字号不一致 / "
+                "行高过大导致空白 / 间距过大 / 图标边距过大 / "
+                "容器高度不足 / 文本无宽度约束 / 图例与轴标题重叠"
             )
 
         prompt = (
@@ -1470,6 +1663,12 @@ class PageWorkerNode(PlanNode):
                 if _has_empty_chart_svg(html) and "缺数据可视化" not in failed_items:
                     failed_items.append("缺数据可视化")
                     logger.info("[P8.1] 页面 %d 检测到空SVG图表，标记缺数据可视化", page_num)
+                # 程序化布局检查：Grid 使用、overflow-hidden 裁切、字号不一致
+                before_count = len(failed_items)
+                failed_items = _post_check_layout_issues(html, failed_items)
+                new_issues = failed_items[before_count:]
+                if new_issues:
+                    logger.info("[P8.1] 页面 %d 程序化布局检查发现问题: %s", page_num, new_issues)
             if len(failed_items) < len(llm_failed):
                 removed = [x for x in llm_failed if x not in failed_items]
                 logger.info(

--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
@@ -157,7 +157,7 @@ _CDN_HEAD_SNIPPET = (
 
 
 _DESIGN_RULES_DIGEST = (
-    "### 视觉与布局硬约束（精选 23 条）\n"
+    "### 视觉与布局硬约束（精选 22 条）\n"
     "1. 容器：`.ppt-slide { width:1280px; height:720px; overflow:hidden; box-sizing:border-box }`\n"
     "2. 安全区：`.content-safe { width:1220px; height:660px; margin:30px auto }`，主要内容必须放在安全区内；"
     "子元素禁止额外加 padding，否则导致双重边距\n"
@@ -170,19 +170,14 @@ _DESIGN_RULES_DIGEST = (
     "单行初始化，禁止用变量赋值（如 `var chartDom=...; echarts.init(chartDom)`），"
     "禁止 Canvas 渲染器（会导致转 PPTX 后变位图）；"
     "初始化脚本必须写在目标图表容器之后、紧邻 `</body>`，禁止写入 `<head>`（否则 getElementById 得到 null）\n"
-    "4.2 图表最小高度（强制）：图表容器实际渲染高度必须 ≥ 250px（内联 SVG 的 viewBox height ≥ 250），"
-    "否则 Y 轴名称/图例/标签会溢出重叠；"
-    "用 `min-h-[250px]` 或 `flex-1` 确保图表区域有足够空间；禁止把图表挤在高度 < 200px 的容器里\n"
-    "4.3 图表数据标签防重叠（强制，所有含图表的页面都必须遵守）："
-    "用 echarts.init 时每个 series 都必须设 `labelLayout:{moveOverlap:'shiftY'}`；"
-    "双轴图中柱状图标签放柱顶上方（position:'top'），折线图标签放数据点下方（position:'bottom'），"
-    "两组标签垂直间距 ≥15px；"
-    "用内联 SVG 时折线图 text 的 transform translate y = 数据点 y + 12（向下偏移），柱状图 text 的 y = 柱顶 y - 8（向上偏移）\n"
-    "4.4 图例防叠字（强制，所有含图表的页面都必须遵守）："
-    "图例项 ≥3 个时，用 echarts.init 设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`；"
-    "用内联 SVG 时确保图例文字间距 ≥ 每项文字宽度+20px，排不下就换行或竖排；禁止水平挤排叠字\n"
-    "4.5 图表颜色（强制）：图表数据系列颜色必须来自风格文件的图表配色优先级表，禁止使用相近色；"
-    "坐标轴标签用 `#555757` 或 `#000000`，分割线用 `#DDDDDD`，禁止用浅灰色作为文字颜色\n"
+    "4.2 图表最小高度（强制）：图表容器实际渲染高度必须 ≥ 160px（防塌缩下限），"
+    "用 `min-h-[160px]` 或 `flex-1` 确保图表区域能初始化渲染；"
+    "建议图表可读高度 ≥ 300px，由页面预算保证\n"
+    "4.3 图表颜色（强制）：图表数据系列颜色必须来自风格文件的图表配色表，禁止使用相近色；"
+    "坐标轴标签用深色，分割线用浅色\n"
+    "4.4 图表标签防重叠：建议为 ECharts series 设置 `labelLayout:{moveOverlap:'shiftY'}` 防止数据标签重叠\n"
+    "4.5 图例防叠字：图例项 ≥5 个时建议设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`，避免水平挤排叠字\n"
+    "4.6 图表分割线：`splitLine` 建议使用浅色虚线，避免实线在 PPTX 中过于突兀；颜色由风格文件决定\n"
     "5. 步骤/流程页 → 用 HTML/CSS 绘制节点+连线+文字，禁止纯文字描述\n"
     "6. 关键数字必须有放大数字卡片，结论必须有摘要高亮；"
     "数据可视化量化阈值：内容页必须 ≥1 个 ECharts 图表 或 ≥3 个数据卡片"
@@ -197,16 +192,12 @@ _DESIGN_RULES_DIGEST = (
     "留白 > 30% 判定为'空白率过高'；通过增加卡片、图表、列表项填充内容，而非放大字号\n"
     "7. 防溢出：单行文字不超容器宽度；连续段落 ≤ 100 字（超过必须拆列表）；"
     "文本容器（p、span、div）必须加 `break-words` 类防止中英混排时英文/数字处不换行溢出\n"
-    "8. 布局结构：严格遵循标准 HTML 骨架——main 用 `flex`，"
-    "恰好 2 个 `<section>` 子元素，间距用 `pr-[12px]`/`pl-[12px]` 替代 gap；"
+    "8. 布局结构：严格遵循标准 HTML 骨架——main 用 `flex gap-3`，"
+    "恰好 2 个 `<section>` 子元素；"
     "header/main/footer 纵向排列在 content-safe 内\n"
     "8.1 禁止使用 CSS Grid：html-to-pptx 转换器不支持 `display:grid`（Grid 仅检测不转换，视为非文本容器），"
     "所有布局必须用 Flexbox（`flex`、`flex-col`、`flex-[N]`）替代 `grid grid-cols-*`；"
     "左右分栏用 `flex` + `flex-[3]` / `flex-[2]` 比例分配，不用 `grid grid-cols-[3fr_2fr]`\n"
-    "8.2 gap 属性限制（强制）：`gap-*` 类在 PPTX 转换中**完全不生效**，"
-    "左右分栏时必须在子元素上用 `pl-[Npx]`/`pr-[Npx]` 或 `ml-[Npx]`/`mr-[Npx]` 替代 gap 做间距；"
-    "例如左右两栏不用 `flex gap-3`，而是左栏加 `pr-[12px]`、右栏加 `pl-[12px]`；"
-    "在 HTML 预览中 gap 正常，但 PPTX 中间距会完全丢失导致左右栏文本重叠遮挡\n"
     "9. flex 子元素：必须 `flex-1 min-h-0 min-w-0`（水平布局）或 `flex-1 min-h-0`（垂直布局）；"
     "禁止使用 `overflow-hidden` 隐藏核心内容\n"
     "10. flex-col 子元素：必须 `flex-1 min-h-0`；禁止使用 `overflow-hidden` 隐藏核心内容\n"
@@ -234,18 +225,8 @@ _DESIGN_RULES_DIGEST = (
     "页面底色必须严格遵循风格规范文件定义的背景色，禁止使用与风格不符的底色\n"
     "\n"
     "### html-to-pptx 转换器限制（以下规则源于转换器实际能力，非设计偏好）\n"
-    "19. 图表分割线：`splitLine` 建议使用 `type:'dashed'` 虚线，避免实线分割线在 PPTX 中过于突兀；"
-    "颜色用 `#DDDDDD`，禁止用深色实线\n"
-    "20. padding/border 转换缩放：html-to-pptx 转换器对 padding 缩放 0.85（减少 15%）、border-width 缩放 0.65（减少 35%），"
+    "19. padding/border 转换缩放：html-to-pptx 转换器对 padding 缩放 0.85（减少 15%）、border-width 缩放 0.65（减少 35%），"
     "生成 HTML 时需预留余量，避免 PPTX 中内容因缩放溢出或边框过细\n"
-    "21. 文本换行：`break-words`（`overflow-wrap:break-word`）在 PPTX 转换中不生效，"
-    "长文本不会在 PPTX 中自动换行而会溢出右边界；"
-    "必须将长段落拆分为多个 `<p>` 标签或用 `<br>` 手动换行；"
-    "flex 布局中的文本元素应加 `max-w-[Npx]` 约束宽度，防止 PPTX 中溢出\n"
-    "22. 行高限制：禁止使用 `leading-[2]` 或 `leading-loose`（行高 2 倍），行高上限 `leading-[1.6]`\n"
-    "23. ECharts SVG 图例：PPTX 转换后图例图标和文字可能不对齐（转换器限制），"
-    "图例项之间留足间距，图例文字用 `fontSize:12` 确保字号统一；"
-    "图例项 ≥3 个时设 `legend.top:'bottom'` 或 `legend.orient:'vertical'`，避免与 Y 轴标题重叠\n"
 )
 
 
@@ -255,9 +236,9 @@ _HTML_SKELETON = (
     '<div class="ppt-slide" type="content" data-page-role="content">\n'
     '  <div class="content-safe flex flex-col h-full">\n'
     '    <header class="flex-shrink-0">标题区</header>\n'
-    '    <main class="flex-1 min-h-0 flex">\n'
-    '      <section class="flex-1 min-h-0 min-w-0 pr-[12px]">左侧内容</section>\n'
-    '      <section class="flex-1 min-h-0 min-w-0 pl-[12px]">右侧内容</section>\n'
+    '    <main class="flex-1 min-h-0 flex gap-3">\n'
+    '      <section class="flex-1 min-h-0 min-w-0">左侧内容</section>\n'
+    '      <section class="flex-1 min-h-0 min-w-0">右侧内容</section>\n'
     '    </main>\n'
     '    <footer class="flex-shrink-0">数据来源页脚</footer>\n'
     '  </div>\n'
@@ -315,39 +296,37 @@ _PAGE_LAYOUT_TEMPLATES = {
         "```html\n"
         '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">4-6 个关键数字卡片，flex</header>\n'
-        '  <main class="flex-1 min-h-0 flex">\n'
-        '    <section class="flex-[3] min-h-0 min-w-0 pr-[12px]">6 个核心论点卡片，flex flex-col</section>\n'
-        '    <section class="flex-[2] min-h-0 min-w-0 pl-[12px]">ECharts 图表 + 对比表格</section>\n'
+        '  <main class="flex-1 min-h-0 flex gap-3">\n'
+        '    <section class="flex-[3] min-h-0 min-w-0">6 个核心论点卡片，flex flex-col</section>\n'
+        '    <section class="flex-[2] min-h-0 min-w-0">ECharts 图表 + 对比表格</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">数据来源汇总条</footer>\n'
         '</div>\n'
         "```\n"
         "- ECharts 图表类型根据数据形态选择（柱状图/饼图/雷达图）\n"
-        "- 左右分栏间距用 `pr-[12px]`/`pl-[12px]` 替代 gap（gap 在 PPTX 中不生效）\n"
     ),
     "trend": (
         "### 参考布局（trend 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
         '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">3 个关键数字卡片</header>\n'
-        '  <main class="flex-1 min-h-0 flex">\n'
-        '    <section class="flex-1 min-h-0 min-w-0 pr-[12px]">ECharts 折线图（趋势数据）</section>\n'
-        '    <section class="w-[40%] min-h-0 min-w-0 pl-[12px]">4-6 个核心论点卡片，flex-col</section>\n'
+        '  <main class="flex-1 min-h-0 flex gap-3">\n'
+        '    <section class="flex-1 min-h-0 min-w-0">ECharts 折线图（趋势数据）</section>\n'
+        '    <section class="w-[40%] min-h-0 min-w-0">4-6 个核心论点卡片，flex-col</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">数据来源汇总条</footer>\n'
         '</div>\n'
         "```\n"
         "- ECharts 默认折线图(line)，数据形态更适合其他类型时可切换\n"
-        "- 左右分栏间距用 `pr-[12px]`/`pl-[12px]` 替代 gap\n"
     ),
     "comparison": (
         "### 参考布局（comparison 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
         '<div class="content-safe flex flex-col h-full">\n'
         '  <main class="flex-1 min-h-0 flex flex-col">\n'
-        '    <div class="flex flex-1 min-h-0">\n'
-        '      <section class="flex-1 min-h-0 min-w-0 pr-[6px]">对比对象 A 的卡片（flex flex-col）</section>\n'
-        '      <section class="flex-1 min-h-0 min-w-0 pl-[6px]">对比对象 B 的卡片（flex flex-col）</section>\n'
+        '    <div class="flex flex-1 min-h-0 gap-3">\n'
+        '      <section class="flex-1 min-h-0 min-w-0">对比对象 A 的卡片（flex flex-col）</section>\n'
+        '      <section class="flex-1 min-h-0 min-w-0">对比对象 B 的卡片（flex flex-col）</section>\n'
         '    </div>\n'
         '    <section class="flex-shrink-0">对比表格</section>\n'
         '  </main>\n'
@@ -355,16 +334,15 @@ _PAGE_LAYOUT_TEMPLATES = {
         '</div>\n'
         "```\n"
         "- ECharts 默认分组柱状图(grouped bar)，占比数据用饼图\n"
-        "- 左右分栏间距用 `pr-[6px]`/`pl-[6px]` 替代 gap\n"
     ),
     "case": (
         "### 参考布局（case 类型，可根据内容调整布局比例和区域数量）\n"
         "```html\n"
         '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">3 个关键数字卡片</header>\n'
-        '  <main class="flex-1 min-h-0 flex">\n'
-        '    <section class="flex-[2] min-h-0 min-w-0 pr-[12px]">6 个核心论点卡片，flex-col</section>\n'
-        '    <section class="flex-[3] min-h-0 min-w-0 pl-[12px]">ECharts 图表 + 关键数据表格</section>\n'
+        '  <main class="flex-1 min-h-0 flex gap-3">\n'
+        '    <section class="flex-[2] min-h-0 min-w-0">6 个核心论点卡片，flex-col</section>\n'
+        '    <section class="flex-[3] min-h-0 min-w-0">ECharts 图表 + 关键数据表格</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">案例素材详细描述 + 数据来源页脚</footer>\n'
         '</div>\n'
@@ -375,9 +353,9 @@ _PAGE_LAYOUT_TEMPLATES = {
         "```html\n"
         '<div class="content-safe flex flex-col h-full">\n'
         '  <header class="flex-shrink-0">4 个关键数字卡片</header>\n'
-        '  <main class="flex-1 min-h-0 flex flex-col">\n'
-        '    <section class="flex-1 min-h-0 min-w-0 pb-[8px]">ECharts 图表 + 对比表格</section>\n'
-        '    <section class="flex-1 min-h-0 min-w-0 pt-[8px]">6 个核心论点卡片，flex flex-wrap</section>\n'
+        '  <main class="flex-1 min-h-0 flex flex-col gap-3">\n'
+        '    <section class="flex-1 min-h-0 min-w-0">ECharts 图表 + 对比表格</section>\n'
+        '    <section class="flex-1 min-h-0 min-w-0">6 个核心论点卡片，flex flex-wrap</section>\n'
         '  </main>\n'
         '  <footer class="flex-shrink-0">数据来源汇总条</footer>\n'
         '</div>\n'
@@ -449,9 +427,9 @@ _DENSITY_CHECKLIST_DIGEST = (
     "且使用 `document.getElementById('xxx')` 直接传参，禁止变量赋值\n"
     "12. grid-cols 合法性：禁止使用 `grid-cols-*`（CSS Grid 不被转换器支持，改用 Flexbox）\n"
     "13. 字号一致性：同级别卡片/模块必须使用相同字号，字号值来自风格文件\n"
-    "14. 图表标签防重叠：所有 ECharts series 必须设 `labelLayout:{moveOverlap:'shiftY'}`；"
-    "图例项 ≥3 个时设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`\n"
-    "15. 图表颜色：数据系列颜色来自风格文件图表配色表，坐标轴标签用深色，分割线用浅色虚线\n"
+    "14. 图表颜色：数据系列颜色来自风格文件图表配色表，坐标轴标签用深色，分割线用浅色\n"
+    "15. 图表标签防重叠：建议为 ECharts series 设置 `labelLayout:{moveOverlap:'shiftY'}`；"
+    "图例项 ≥5 个时建议设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`\n"
 )
 
 
@@ -689,42 +667,6 @@ def _post_check_layout_issues(html: str, failed_items: list[str]) -> list[str]:
     # 检测字号不一致
     if _check_font_size_consistency(html) and "字号不一致" not in failed_items:
         failed_items.append("字号不一致")
-    # 检测 leading-[2] 或 leading-loose（行高过大导致空白）
-    if re.search(r'leading-\[2\]|leading-loose', html) and "行高过大导致空白" not in failed_items:
-        failed_items.append("行高过大导致空白")
-    # 检测 justify-between + flex-col 组合（项高度不一时视觉间距不一致）
-    # 使用先行断言确保三个关键词同时出现在同一 class 属性中，不依赖顺序
-    if re.search(
-        r'class="(?=[^"]*\bflex\b)(?=[^"]*\bflex-col\b)(?=[^"]*\bjustify-between\b)[^"]*"',
-        html,
-    ) and "间距过大" not in failed_items:
-        failed_items.append("间距过大")
-    # 检测图标元素（class 含 fa-）上过大的右边距（mr-[28px] 或更大）
-    # 仅检查图标场景，避免误杀普通布局边距
-    for m in re.finditer(r'class="([^"]*\bfa-[^"]*)"', html):
-        mr_match = re.search(r'mr-\[(\d+)px\]', m.group(1))
-        if mr_match and int(mr_match.group(1)) >= 28:
-            if "图标边距过大" not in failed_items:
-                failed_items.append("图标边距过大")
-            break
-    # 检测容器高度不足（h-[Npx] 容器内放 text-[Mpx] leading-[L]，N < M*L）
-    # 简化检测：h-[Npx] 且同级有 text-[Mpx] leading-[1.1]，若 N < M*1.1+2 则标记
-    for m in re.finditer(r'h-\[(\d+)px\][^>]*>.*?text-\[(\d+)px\].*?leading-\[1\.[01]\]', html, re.DOTALL):
-        h_val, font_val = int(m.group(1)), int(m.group(2))
-        if h_val < font_val * 1.1 + 2:
-            if "容器高度不足" not in failed_items:
-                failed_items.append("容器高度不足")
-            break
-    # 检测 flex justify-between 中的文本无宽度约束
-    # 匹配 justify-between 容器中的文本元素（p/span/div）没有 max-w 或 w- 约束
-    _jb_text_re = (
-        r'class="[^"]*justify-between[^"]*"[^>]*>.*?'
-        r'<(?:p|span|div)[^>]*class="[^"]*text-\[\d+px\][^"]*"[^>]*>[^<]{20,}'
-    )
-    if re.search(_jb_text_re, html, re.DOTALL):
-        if not re.search(r'class="[^"]*justify-between[^"]*"[^>]*>.*?max-w-\[', html, re.DOTALL):
-            if "文本无宽度约束" not in failed_items:
-                failed_items.append("文本无宽度约束")
     return failed_items
 
 
@@ -759,10 +701,7 @@ _REWRITE_ACTIONS = {
     "缺数据来源": "在页脚标注'数据来源：XXX'（机构名或资料名）",
     "大段文字": "拆分为多个列表项/小节，添加小标题",
     "视觉层级混乱": "调整字号梯度，建立明确的标题→副标题→正文→注释层级",
-    "布局错误": (
-        "main 改为 `flex`（左右分栏用 `flex-[N]` 比例，间距用 `pr-[12px]`/`pl-[12px]` 替代 gap），"
-        "恰好 2 个 `<section>` 子元素；header/footer 放在 main 外部的 content-safe 内"
-    ),
+    "布局错误": "main 改为 `flex gap-3`，恰好 2 个 `<section>` 子元素；header/footer 放在 main 外部的 content-safe 内",
     "内容被隐藏": "移除 line-clamp、text-overflow:ellipsis、overflow:auto/scroll、max-height 限制等隐藏手段，确保核心内容完整可见",
     "核心内容缺失": "检查标题、正文、图表标签、数据来源和数据卡片是否全部完整显示，补充缺失的内容元素",
     "使用了不支持的Grid布局": "将所有 `grid grid-cols-*` 改为 Flexbox 布局（`flex` + `flex-[N]` 比例分配），因为 html-to-pptx 转换器不支持 CSS Grid",
@@ -771,16 +710,7 @@ _REWRITE_ACTIONS = {
         "仅保留 `.ppt-slide` 画布边界上的 overflow-hidden"
     ),
     "字号不一致": "统一同级别卡片/模块的字号，使用风格文件定义的字号值，确保同级元素字号一致",
-    "行高过大导致空白": "将 `leading-[2]` 或 `leading-loose` 改为 `leading-[1.5]` 或 `leading-[1.6]`，消除过大行高导致的空白",
-    "间距过大": (
-        "如果是 flex-col 列表项使用 justify-between 导致间距不均，"
-        "改为 justify-start + mt-[10px] 逐项递增间距；"
-        "header/footer 的 justify-between 可保留"
-    ),
-    "图标边距过大": "将图标（fa- 元素）上 `mr-[28px]` 或更大的边距缩小为 `mr-[8px]`，图标和文字之间保持紧凑",
-    "容器高度不足": "增大容器高度使 ≥ 字号×行高系数+4px，或减小字号/行高",
-    "文本无宽度约束": "在 flex 布局的文本元素上加 `max-w-[Npx]` 约束宽度，防止 PPTX 中溢出右边界",
-    "图例与轴标题重叠": "设 `legend.top:'bottom'` 或 `legend.orient:'vertical'`，双轴图 `grid.right` 留足 ≥60px",
+    "图例与轴标题重叠": "图例项过多时设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`，避免与坐标轴标题重叠",
 }
 
 
@@ -897,24 +827,22 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
     2: (
         "### 图片布局（2 张图）\n"
         "- 推荐左右对半分或一大一小\n"
-        "- 左右间距用 `pr-[6px]`/`pl-[6px]` 替代 gap（gap 在 PPTX 中不生效）\n"
         "```html\n"
-        '<div class="flex flex-1 min-h-0">\n'
-        '  <div class="flex-1 h-full pr-[6px]"><img src="..." class="w-full h-full object-contain" /></div>\n'
-        '  <div class="flex-1 h-full pl-[6px]"><img src="..." class="w-full h-full object-contain" /></div>\n'
+        '<div class="flex gap-3 flex-1 min-h-0">\n'
+        '  <img src="..." class="flex-1 h-full object-contain" />\n'
+        '  <img src="..." class="flex-1 h-full object-contain" />\n'
         '</div>\n'
         "```\n"
     ),
     3: (
         "### 图片布局（3 张图）\n"
         "- 推荐「左 1 右 2」：左侧大图，右侧上下两小图\n"
-        "- 左右间距用 `pr-[6px]`/`pl-[6px]`，上下间距用 `pb-[4px]`/`pt-[4px]` 替代 gap\n"
         "```html\n"
-        '<div class="flex flex-1 min-h-0">\n'
-        '  <div class="flex-[2] h-full pr-[6px]"><img src="..." class="w-full h-full object-contain" /></div>\n'
-        '  <div class="flex-1 flex flex-col min-h-0 pl-[6px]">\n'
-        '    <img src="..." class="w-full flex-1 min-h-0 pb-[4px] object-contain" />\n'
-        '    <img src="..." class="w-full flex-1 min-h-0 pt-[4px] object-contain" />\n'
+        '<div class="flex gap-3 flex-1 min-h-0">\n'
+        '  <div class="flex-[2] h-full"><img src="..." class="w-full h-full object-contain" /></div>\n'
+        '  <div class="flex-1 flex flex-col min-h-0 gap-2">\n'
+        '    <img src="..." class="w-full flex-1 min-h-0 object-contain" />\n'
+        '    <img src="..." class="w-full flex-1 min-h-0 object-contain" />\n'
         '  </div>\n'
         '</div>\n'
         "```\n"
@@ -922,12 +850,11 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
     4: (
         "### 图片布局（4 张图）\n"
         "- 推荐 2×2 布局（用 flex flex-wrap 替代 grid）\n"
-        "- 间距用 margin（`mr-[2%]`/`mb-[2%]`）替代 gap\n"
         "```html\n"
-        '<div class="flex flex-wrap flex-1 min-h-0">\n'
-        '  <img src="..." class="w-[48%] h-[48%] mr-[2%] mb-[2%] object-contain" />\n'
-        '  <img src="..." class="w-[48%] h-[48%] mb-[2%] object-contain" />\n'
-        '  <img src="..." class="w-[48%] h-[48%] mr-[2%] object-contain" />\n'
+        '<div class="flex flex-wrap gap-3 flex-1 min-h-0">\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
+        '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
         '  <img src="..." class="w-[48%] h-[48%] object-contain" />\n'
         '</div>\n'
         "```\n"
@@ -937,10 +864,9 @@ _IMAGE_LAYOUT_TEMPLATES: dict[int, str] = {
 _IMAGE_LAYOUT_TEMPLATE_MANY = (
     "### 图片布局（{n} 张图）\n"
     "- 推荐用 flex flex-wrap 布局，每行 3-4 张（禁止使用 grid grid-cols-N）\n"
-    "- 间距用 margin（每行最后一张不加 mr，每列最后一行不加 mb）替代 gap\n"
     "```html\n"
-    '<div class="flex flex-wrap flex-1 min-h-0">\n'
-    '  <!-- {n} 张图片，每张 w-[31%] mb-[8px] mr-[8px] object-contain（行末/列末项不加对应 margin）-->\n'
+    '<div class="flex flex-wrap gap-3 flex-1 min-h-0">\n'
+    '  <!-- {n} 张图片，每张 w-[31%] object-contain -->\n'
     '</div>\n'
     "```\n"
 )
@@ -1160,7 +1086,7 @@ def _build_page_prompt(
         "**HTML 中必须只包含 1 个 `<div class=\"ppt-slide\">` 容器**，"
         "禁止生成多个 slide 页面。"
         "先产出可运行 HTML，再按密度检查清单做小步修正；禁止在写文件前反复做像素级完整规划。"
-        "生成时必须同时满足上述「内容密度检查（12 项）」全部要求，"
+        "生成时必须同时满足上述「内容密度检查」全部要求，"
         "确保首次生成即通过密度检查，避免后续重写。"
     )
 
@@ -1686,8 +1612,7 @@ class PageWorkerNode(PlanNode):
                 "缺数据来源 / 大段文字 / 视觉层级混乱 / 布局错误 / "
                 "内容被隐藏 / 核心内容缺失 / grid-cols 非法 / "
                 "使用了不支持的Grid布局 / 核心内容被overflow-hidden裁切 / 字号不一致 / "
-                "行高过大导致空白 / 间距过大 / 图标边距过大 / "
-                "容器高度不足 / 文本无宽度约束 / 图例与轴标题重叠"
+                "图例与轴标题重叠"
             )
 
         prompt = (


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# skill_turbo PPT 视觉效果问题定位与修复总结（最终版）

> **修复提交 1**: `cbd69f721b8d9c735744beb6fc5d76d852981894`（fix: skill_turbo PPT 视觉效果问题修复）
> **修复提交 2**: `08bb75d5d7be707337f6465a0f467fa5db7210e3`（fix: skill_turbo PPT prompt 约束精简与程序化检查修正）
> **修改文件**: `jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py`
> **变更规模**: 基线 263+/-93 → 修复1 292+/-93 → 修复2 49+/-51

---

## 一、问题概述

用户反馈 25 项 PPT 视觉效果问题，经代码分析确认：

| 分类                 | 数量  | 说明                    |
| -------------------- | ----- | ----------------------- |
| skill_turbo 独有根因 | 20 项 | prompt 和代码逻辑缺陷   |
| 与 pptx-craft 共性   | 5 项  | html-to-pptx 转换器限制 |

---

## 二、根因分析

### 2.1 skill_turbo 独有根因（12 项）

#### 根因 A：`_HTML_SKELETON` 和 `_PAGE_LAYOUT_TEMPLATES` 硬编码 CSS Grid

**问题**：`_HTML_SKELETON` 硬编码 `grid grid-cols-2 gap-3`，`_PAGE_LAYOUT_TEMPLATES` 的 data/comparison/case/technology 模板全部使用 `grid grid-cols-N`，`_IMAGE_LAYOUT_TEMPLATES` 也全部使用 grid。`_DESIGN_RULES_DIGEST` 规则 8 把 grid-cols-2 作为硬约束注入。

**根因**：html-to-pptx 转换器不支持 CSS Grid（`css-whitelist.md` 第 58 行："Grid 仅检测不转换，视为非文本容器"）。skill_turbo 强制 LLM 用 Grid，但 Grid 在转 PPTX 时被跳过，导致布局错乱。

**影响问题**：#3(溢出)、#10(文本框大小不一致)、#11(左右版式未对齐)、#14(右侧文本格式不一致)、#16(排版间距不一致)

#### 根因 B：`gap` 属性不在 CSS 白名单

**问题**：所有 prompt 常量大量使用 `gap-3`、`gap-2`，但 CSS 白名单不支持 gap。HTML 预览中间距正常，PPTX 中间距全部丢失。

**影响问题**：#4(小标题跟正文间距大)、#12(图表间距不一致)、#16(排版间距不一致)、#22(模块/表格边界不清晰)

#### 根因 C：三套字号来源互相冲突

**问题**：`_DESIGN_RULES_DIGEST` 规则 3 注入"36-48px"，`_STRUCTURAL_DESIGN_RULES` 注入"48-64px"，business-classic.md 定义"37px"。LLM 看到多个范围后取下限，导致字号偏小。

**影响问题**：#6(字体偏小导致留白)、#9(不同模块缺少小标题)、#20(小图标大小不一致)

#### 根因 D：图表防重叠规则只在 technology 页面类型注入

**问题**：`labelLayout:{moveOverlap:'shiftY'}` 和 `legend:{type:'scroll'}` 只在 `_PAGE_LAYOUT_TEMPLATES["technology"]` 中定义，data/trend/comparison 页面完全不知道这些规则。

**影响问题**：#18(图例跟文本没有对齐/重叠)、#25(图表数据标签文字重叠)

#### 根因 E：`_extract_designer_section` 只提取了 designer 规范的一小部分

**问题**：函数只提取"防溢出硬性约束"和"语义区域划分指南"2 个章节，缺少弹性布局约束、固定尺寸约束、文本重叠避免、元素遮挡避免、色彩系统、字体系统等关键章节。

**影响问题**：#5(文本被遮挡)、#7(黑色遮挡罩)、#21(模块配色布局不美观)

#### 根因 F：密度检查缺少程序化校验

**问题**：12 项密度检查几乎全靠 LLM 主观判断，只有 2 项有粗糙的程序化校验（其中 `_post_check_data_viz` 用 `html.lower().count("card")` 计数，会把 CSS class 名、JS 变量名中的 "card" 全部计入）。

**影响问题**：#1(序号对齐)、#6(字体偏小)、#9(缺少小标题)、#10(文本框大小不一致)、#16(排版间距不一致)、#20(小图标大小不一致)、#21(模块配色)、#22(模块/表格边界)

#### 根因 G：重写约束阻止修复系统性布局问题

**问题**：重写 prompt 说"布局结构如果上次已正确，严禁改动"。LLM 在 HTML 预览中看到 Grid 渲染正常（浏览器支持 Grid），认为"已正确"，永远不会把 Grid 改成 Flex。

**影响问题**：#3(溢出)、#11(左右版式未对齐)、#16(排版间距不一致)

#### 根因 H：结构页检测基于字符串匹配

**问题**：用 `"✅" in outline_page and ("页研究查询" in outline_page or "数据需求" in outline_page or "研究需求" in outline_page)` 判断是否结构页。如果 LLM 生成大纲时措辞略有不同，页面会被误判为结构页，用 4 项检查代替 12 项检查。

#### 根因 I：`_fix_echarts_svg_renderer` 正则遗漏常见写法

**问题**：正则只匹配 `echarts.init(变量名)` 和 `echarts.init(document.getElementById('xxx'))` 两种形式，不匹配 `querySelector`、多行写法等。SVG 渲染器不会被自动补充，图表用 Canvas 渲染，转 PPTX 后变位图。

**影响问题**：#19(折线图未连接)、#8(图表元素颜色接近)

#### 根因 J：`overflow-hidden` 与"禁止裁切"矛盾

**问题**：规则 9/10 强制子元素加 `overflow-hidden`，规则 17 又说"禁止裁切"。`.content-safe` CSS 也用了 `overflow-hidden`。内容溢出时被隐藏而非触发修复。

**影响问题**：#3(内容溢出页面)、#5(文本被遮挡)、#7(黑色遮挡罩遮挡文本)

#### 根因 K：footer 和图标规则导致数据来源单独占行且配图标

**问题**：规则 12 强制页脚有数据来源条，规则 6.2 明确说图标可用于"数据来源标注"。LLM 把数据来源做成单独一行并加图标。

**影响问题**：#15(数据来源单独占一行，且给配了图标)

#### 根因 L：padding/border 系数缩放导致布局偏差

**问题**：转换器对 padding 缩放 0.85（减 15%）、border-width 缩放 0.65（减 35%），prompt 未提及此缩放。

**影响问题**：#3(内容溢出)、#22(模块/表格边界不清晰)、#23(图表横线实线很突兀)

### 2.2 与 pptx-craft 共性问题（5 项）

| 问题             | 说明                                    |
| ---------------- | --------------------------------------- |
| #1 序号对齐      | CSS 白名单不支持 flex/grid 的 `<li>`    |
| #2 换行错误      | `line-height`/`break-words` 不映射 PPTX |
| #13 数据单位重复 | charts.md formatter 规则不够细          |
| #22 边界不清晰   | border 缩放 35%                         |
| #23 横线突兀     | charts.md 示例没指定 dashed             |

### 2.3 实际产物验证发现的追加问题

通过对 3 轮实际生成产物的逐页分析，发现以下追加问题：

| 问题                                                       | 根因                                             | 发现来源         |
| ---------------------------------------------------------- | ------------------------------------------------ | ---------------- |
| `break-words` 不被转换器支持，长文本溢出右边界             | PPTX 中 `overflow-wrap` 不生效，长文本不自动换行 | 第一轮 P3 页     |
| `justify-between` 在项高度不一时视觉间距不一致             | gap 相等但项的文字行数不同，视觉空白不均匀       | 第一轮 P3/P5/P11 |
| `leading-[2]`/`leading-loose` 行高 2 倍浪费空间            | LLM 使用过大行高，prompt 未限制                  | 第一轮 P5/P12    |
| `mr-[28px]` 图标边距过大                                   | LLM 使用过大边距                                 | 第一轮 P5/P12    |
| ECharts xAxis.data 与 series[].data 长度不匹配             | LLM 配置错误，无校验                             | 第一轮 P12       |
| ECharts SVG 图例在 PPTX 转换后图标和文字不对齐             | 转换器不正确映射 `dominant-baseline="central"`   | 第二轮 P5/P6/P9  |
| `overflow-hidden` 在 main 元素上导致 PPTX 中文本框定位偏移 | 转换器对 overflow 只做检测不真正裁切             | 第一轮 P11       |

---

## 三、代码改动详情

### 提交 1：`cbd69f72` — 主体修复（292+/93-）

#### 3.1 P0：CSS Grid 全面改为 Flexbox

**改动文件**：`ppt_page_gen.py`

**改动内容**：

1. `_HTML_SKELETON`（第 252-270 行）：
   - `grid grid-cols-2 gap-3` → `flex`（去掉 grid）
   - section 从 `h-full min-h-0 overflow-hidden` → `flex-1 min-h-0 min-w-0 pr-[12px]`/`pl-[12px]`（去掉 overflow-hidden，用 padding 替代 gap 做间距）
   - 规则文字更新："禁止使用 `grid grid-cols-*`，html-to-pptx 转换器不支持 CSS Grid"

2. `_PAGE_LAYOUT_TEMPLATES`（第 301-388 行）：
   - data 模板：`grid grid-cols-[3fr_2fr] gap-3` → `flex` + `flex-[3] pr-[12px]` / `flex-[2] pl-[12px]`
   - trend 模板：同上模式
   - comparison 模板：`grid grid-cols-2 grid-rows-3` → `flex flex-col`，间距用 `pr-[6px]`/`pl-[6px]`
   - case 模板：`grid grid-cols-[2fr_3fr]` → `flex` + `flex-[2] pr-[12px]` / `flex-[3] pl-[12px]`
   - technology 模板：`grid grid-cols-3 grid-rows-2` → `flex flex-wrap`，垂直间距用 `pb-[8px]`/`pt-[8px]`

3. `_IMAGE_LAYOUT_TEMPLATES`（第 714-760 行）：
   - 2 张图：`grid grid-cols-2 gap-3` → `flex gap-3` + `flex-1`（注：此处 gap 在修复提交 2 中进一步修正）
   - 3 张图：`grid grid-cols-3` → `flex` + `flex-[2]` / `flex-1 flex-col`
   - 4 张图：`grid grid-cols-2 grid-rows-2` → `flex flex-wrap` + `w-[48%] h-[48%]`

4. `_IMAGE_LAYOUT_TEMPLATE_MANY`：
   - `grid grid-cols-{cols}` → `flex flex-wrap` + `w-[31%]`

#### 3.2 P1：gap 属性限制警告

**改动位置**：`_DESIGN_RULES_DIGEST` 规则 8.2

**改动内容**：

```
"8.2 gap 属性限制（强制）：`gap-*` 类在 PPTX 转换中**完全不生效**，"
"左右分栏时必须在子元素上用 `pl-[Npx]`/`pr-[Npx]` 或 `ml-[Npx]`/`mr-[Npx]` 替代 gap 做间距；"
"例如左右两栏不用 `flex gap-3`，而是左栏加 `pr-[12px]`、右栏加 `pl-[12px]`；"
"在 HTML 预览中 gap 正常，但 PPTX 中间距会完全丢失导致左右栏文本重叠遮挡\n"
```

#### 3.3 P2：统一字号来源

**改动位置**：`_DESIGN_RULES_DIGEST` 规则 3

**改动前**：

```python
"3. 三级字号：页面标题 36-48px / 副标题 24-28px / 正文 16-20px"
"但紧凑卡片内（grid 子项或 flex-col 中 ≥3 个并列卡片）标题 ≤18px、正文 ≤14px"
```

**改动后**：

```python
"3. 字号：严格使用风格规范文件中定义的字号值（如 business-classic.md 定义主标题 37px、正文 19px 等），"
"不自行调整字号范围"
```

#### 3.4 P3：图表防重叠规则通用化

**改动位置**：`_DESIGN_RULES_DIGEST` 新增规则 4.3-4.5

**改动内容**：

- 规则 4.3：所有含图表的页面都必须设 `labelLayout:{moveOverlap:'shiftY'}`，双轴图标签 position 错开
- 规则 4.4：图例项 ≥3 个时设 `legend:{type:'scroll'}` 或 `legend:{orient:'vertical'}`
- 规则 4.5：图表数据系列颜色必须来自风格文件配色表

同时从 `_PAGE_LAYOUT_TEMPLATES["technology"]` 中删除了这些规则（已提升为通用规则）。

#### 3.5 P4：删除 overflow-hidden 矛盾

**改动位置**：`_DESIGN_RULES_DIGEST` 规则 9/10/13/17

**改动前**：

```python
"9. grid 子元素：必须 `h-full min-h-0 overflow-hidden`"
"10. flex-col 子元素：必须 `flex-1 min-h-0 overflow-hidden`"
```

**改动后**：

```python
"9. flex 子元素：必须 `flex-1 min-h-0 min-w-0`（水平）或 `flex-1 min-h-0`（垂直）；禁止使用 `overflow-hidden` 隐藏核心内容"
"10. flex-col 子元素：必须 `flex-1 min-h-0`；禁止使用 `overflow-hidden` 隐藏核心内容"
"17. 禁止在核心内容容器上使用 `overflow-hidden`（仅允许在 `.ppt-slide` 画布边界使用）"
```

#### 3.6 P5：扩充 `_extract_designer_section`

**改动位置**：`_extract_designer_section` 函数（第 30-95 行）

**改动前**：只提取 2 个章节（防溢出硬性约束 + 语义区域划分指南）

**改动后**：提取 7 个章节：

1. 防溢出硬性约束
2. 弹性布局约束（完整）
3. 固定尺寸约束
4. 文本重叠避免
5. 元素遮挡避免
6. 色彩系统
7. 字体系统

#### 3.7 P6：重写约束允许修改布局结构

**改动位置**：`_build_page_prompt` 中的 `rewrite_constraints`

**改动前**：

```python
"- 布局结构（grid/flex-col、子元素数量）如果上次已正确，严禁改动"
```

**改动后**：

```python
"- 如果布局使用了 CSS Grid（`grid grid-cols-*`），必须改为 Flexbox（`flex`）布局，因为 html-to-pptx 转换器不支持 CSS Grid"
"- 如果子元素使用了 `overflow-hidden`，且该元素包含核心内容（标题/正文/图表/数据卡片），必须移除 `overflow-hidden`"
```

#### 3.8 P7：增加程序化密度检查

**改动位置**：新增 3 个检查函数 + 更新 `_post_check_layout_issues` + 更新 `_check_one`

**新增函数**：

1. `_has_grid_layout(html)` — 检测 CSS Grid 使用，正则 `r'\bgrid\s+grid-cols-\S+'`
2. `_has_overflow_hidden_on_content(html)` — 检测核心内容容器上的 overflow-hidden
3. `_check_font_size_consistency(html)` — 检测正文字号（14-24px）是否超过 3 种不同值

**改进函数**：

- `_post_check_data_viz` — 卡片计数从 `html.lower().count("card")` 改为正则匹配 class 属性 `r'class="[^"]*\bcard\b[^"]*"'`
- `_post_check_layout_issues` — 新增检测项
- `_DENSITY_CHECKLIST_DIGEST` — 从 12 项扩展到 15 项

**新增检查项**：

| 检查                       | 正则                              | 失败项             |
| -------------------------- | --------------------------------- | ------------------ |
| leading-[2]/leading-loose  | `r'leading-\[2\]\|leading-loose'` | "行高过大导致空白" |
| justify-between + flex-col | 两个固定顺序正则                  | "间距过大"         |
| mr-[28px]+ 图标边距        | `r'mr-\[(?:[3-9]\d\|2[89])px\]'`  | "图标边距过大"     |

#### 3.9 追加修复：实际产物验证发现的问题

新增规则 19-26，涵盖文本换行、间距控制、ECharts 数据一致性、padding/border 缩放、图表分割线等。

---

### 提交 2：`08bb75d5` — 约束精简与程序化检查修正（49+/51-）

#### 3.10 修复图片模板残留 gap-3

**问题**：提交 1 中页面布局模板已改为 padding 替代 gap，但图片布局模板漏改，仍使用 `flex gap-3`。

**改动内容**：

- `_IMAGE_LAYOUT_TEMPLATES[2]`：`flex gap-3` → `flex` + 包裹 div 加 `pr-[6px]`/`pl-[6px]`
- `_IMAGE_LAYOUT_TEMPLATES[3]`：同上 + 内部垂直间距用 `pb-[4px]`/`pt-[4px]`
- `_IMAGE_LAYOUT_TEMPLATES[4]`：`flex flex-wrap gap-3` → `flex flex-wrap` + `mr-[2%]`/`mb-[2%]`
- `_IMAGE_LAYOUT_TEMPLATE_MANY`：同上模式 + margin 替代 gap

#### 3.11 修复规则与模板的 gap 矛盾

**问题**：规则 8 写 "main 用 `flex gap-3`"，与规则 8.2 "gap 在 PPTX 中不生效" 矛盾。

**改动内容**：

- 规则 8：`main 用 flex gap-3` → `main 用 flex，间距用 pr-[12px]/pl-[12px] 替代 gap`
- Checklist 第 8 项：`flex gap-4` → 移除
- `_REWRITE_ACTIONS["布局错误"]`：`flex gap-3` → `flex + pr-[12px]/pl-[12px]`

#### 3.12 mr-[Npx] 检查限定为图标场景

**问题**：旧正则 `mr-[(?:[3-9]\d|2[89])px]` 匹配所有 ≥28px 的右边距，会误杀普通布局边距（如 `mr-[30px]` 是合理的容器边距）。

**改动前**：

```python
if re.search(r'mr-\[(?:[3-9]\d|2[89])px\]', html):
    failed_items.append("图标边距过大")
```

**改动后**：

```python
# 仅检查 class 含 fa- 的图标元素
for m in re.finditer(r'class="([^"]*\bfa-[^"]*)"', html):
    mr_match = re.search(r'mr-\[(\d+)px\]', m.group(1))
    if mr_match and int(mr_match.group(1)) >= 28:
        failed_items.append("图标边距过大")
        break
```

#### 3.13 justify-between 正则改为顺序无关

**问题**：旧正则只覆盖两种 class 顺序（flex→flex-col→justify-between 和 justify-between→flex→flex-col），`flex justify-between flex-col` 等变体会漏匹配。

**改动前**：

```python
if re.search(r'class="[^"]*flex[^"]*flex-col[^"]*justify-between', html):
    failed_items.append("间距过大")
elif re.search(r'class="[^"]*justify-between[^"]*flex[^"]*flex-col', html):
    failed_items.append("间距过大")
```

**改动后**：

```python
# 使用先行断言确保三个关键词同时出现在同一 class 属性中，不依赖顺序
if re.search(
    r'class="(?=[^"]*\bflex\b)(?=[^"]*\bflex-col\b)(?=[^"]*\bjustify-between\b)[^"]*"',
    html,
):
    failed_items.append("间距过大")
```

#### 3.14 _REWRITE_ACTIONS 修复建议不再一刀切

**问题**："间距过大" 的修复建议 "将 justify-between 改为 justify-start" 会误杀 header/footer 的合法 justify-between 用法。

**改动前**：

```python
"间距过大": "将 justify-between 改为 justify-start，用 mt-[10px] 逐项递增间距",
"图标边距过大": "将 mr-[28px] 或更大的图标边距缩小为 mr-[8px]",
```

**改动后**：

```python
"间距过大": "如果是 flex-col 列表项使用 justify-between 导致间距不均，改为 justify-start + mt-[10px]；header/footer 的 justify-between 可保留",
"图标边距过大": "将图标（fa- 元素）上 mr-[28px] 或更大的边距缩小为 mr-[8px]",
```

#### 3.15 规则 19-26 重组为 23 条

**问题**：规则 19-26 中有多条是对特定 LLM 输出的"打补丁"式约束，过于定制化；且未区分"转换器固有限制"与"LLM 行为纠正"。

**改动内容**：

新增 `### html-to-pptx 转换器限制` 子标题，将转换器能力限制与设计偏好分离。

删除的规则（过于定制化或已由程序化检查覆盖）：

| 原规则                                      | 删除原因                                     |
| ------------------------------------------- | -------------------------------------------- |
| 原 22 justify-between 一刀切禁止            | 过于绝对，程序化检查已覆盖                   |
| 原 22 mr-[28px] 精确值 + "正确写法"代码示例 | 过于定制化，程序化检查已覆盖                 |
| 原 23 ECharts 数据一致性                    | 基本代码正确性，不应在 prompt 层约束         |
| 原 24 容器高度公式                          | LLM 无法在生成时执行此计算，程序化检查已覆盖 |
| 原 25 文本宽度约束（独立条目）              | 合并入规则 21（文本换行）                    |
| 原 26 图例与轴标题防重叠（独立条目）        | 合并入新规则 23（ECharts SVG 图例）          |

保留的规则（转换器固有限制）：

- 19: 图表分割线 dashed
- 20: padding/border 转换缩放
- 21: 文本换行 + 文本宽度约束（合并）
- 22: 行高限制
- 23: ECharts SVG 图例对齐 + 图例防重叠（合并）

---

## 四、25 个问题修复状态

| #    | 问题                    | 根因                                | 修复方式                                             | 状态       |
| ---- | ----------------------- | ----------------------------------- | ---------------------------------------------------- | ---------- |
| 1    | 序号跟文本没有对齐      | CSS 白名单不支持 flex/grid 的 li    | 共性（转换器限制）                                   | 共性未修   |
| 2    | 换行错误                | line-height/break-words 不映射 PPTX | 规则 21 禁止依赖 break-words                         | 部分修复   |
| 3    | 内容溢出                | Grid+overflow-hidden+padding 缩放   | P0(grid→flex)+P4(删overflow)+规则20(padding缩放警告) | **已修复** |
| 4    | 小标题跟正文间距大      | gap 不转换                          | 规则 8.2 强制用 padding 替代 gap                     | **已修复** |
| 5    | 文本被遮挡              | overflow-hidden 裁切+遮挡规则未提取 | P4(删overflow)+P5(扩充提取遮挡规则)                  | **已修复** |
| 6    | 字体偏小导致留白        | 三套字号冲突                        | P2(统一字号来源)+字号一致性检查                      | **已修复** |
| 7    | 黑色遮挡罩遮挡文本      | 遮罩层规则未提取                    | P5(提取遮罩层规则)                                   | **已修复** |
| 8    | 图表元素颜色接近        | 无图表颜色规则                      | 规则 4.5 强制图表配色                                | **已修复** |
| 9    | 不同模块缺少小标题      | 密度检查不程序化                    | P7(字号检查)+层级检查                                | 部分修复   |
| 10   | 文本框大小不一致        | Grid+gap 丢失                       | P0(grid→flex)+P7(字号检查)                           | **已修复** |
| 11   | 左右版式未对齐          | grid-cols-2 被跳过                  | P0(grid→flex)                                        | **已修复** |
| 12   | 图表间距不一致          | gap+图表最小高度不一致              | 规则 8.2+统一图表高度 250px                          | 部分修复   |
| 13   | 图表数据单位重复        | charts.md formatter 不够细          | 共性未修                                             | 共性未修   |
| 14   | 右侧文本格式不一致      | grid-cols-2 右栏不保持              | P0(grid→flex)                                        | **已修复** |
| 15   | 数据来源单独占行配图标  | 规则 6.2+12                         | 规则 6.2 删除"数据来源标注"                          | **已修复** |
| 16   | 排版间距不一致          | gap+padding 缩放+gap 值不统一       | P0+规则 8.2+规则 20                                  | 部分修复   |
| 17   | 标题右侧模块独立        | header flex-shrink-0 分离           | 设计正常（非 bug）                                   | 设计正常   |
| 18   | 图例跟文本没有对齐/重叠 | 防重叠规则只在 technology           | P3(通用化)+规则 4.4                                  | **已修复** |
| 19   | 折线图未连接            | SVG renderer 正则遗漏               | 正则限制+规则 4.1                                    | 部分修复   |
| 20   | 小图标大小不一致        | 字号不统一+无检查                   | P2+P7(字号一致性检查)                                | 部分修复   |
| 21   | 模块配色布局不美观      | 色彩系统未提取                      | P5(提取色彩系统)                                     | **已修复** |
| 22   | 模块/表格边界不清晰     | border 缩放 35%+gap 丢失            | 规则 20(border 缩放警告)                             | 共性未修   |
| 23   | 图表横线实线很突兀      | charts.md 无 dashed                 | 规则 19 建议 dashed                                  | 部分修复   |
| 24   | 图表坐标间距不一致      | Grid+图表容器尺寸错乱               | P0(grid→flex)                                        | **已修复** |
| 25   | 图表数据标签文字重叠    | 防重叠规则只在 technology           | P3(规则 4.3 通用化)                                  | **已修复** |

**统计**：已修复 13 项，部分修复 8 项，共性未修 3 项，设计正常 1 项。

---

## 五、架构层面遗留问题

### 5.1 转换器限制不应由 prompt 承担

**当前状态**：规则 19-23 中包含 padding 缩放系数（0.85）、border 缩放系数（0.65）、break-words 不生效等转换器实现细节。这些规则存在以下问题：

1. **LLM 无法实际执行** — "padding 缩放 0.85，需预留余量" 这种规则，LLM 无法在生成时精确计算补偿值
2. **维护割裂** — 如果 convert.js 修复了 gap 支持，prompt 规则成为过时约束，两边不会同步更新
3. **职责越界** — prompt 应关注设计规范（字号、配色、布局结构），不应关注转换器的 CSS 属性映射细节

**建议的三层分离架构**：

| 层          | 职责                 | 示例                                                   |
| ----------- | -------------------- | ------------------------------------------------------ |
| prompt 规则 | 设计层面的选择       | "用 Flexbox 不用 Grid"、"字号来自风格文件"             |
| 预处理脚本  | 转换器限制的自动补偿 | `gap-3` → 子元素自动加 `pr/pl`、`grid-cols-*` → `flex` |
| convert.js  | HTML→PPTX 转换       | 原生支持或降级处理                                     |

**建议后续行动**：在 skill_turbo 的后处理阶段（类似 `_fix_echarts_svg_renderer`）增加 HTML 预处理步骤，自动做 `gap → padding`、`grid → flex` 的转换，从 prompt 中移除转换器实现细节类规则。

### 5.2 pptx-craft designer/SKILL.md 仍使用 Grid

pptx-craft 的 designer/SKILL.md 仍在示例中大量使用 Grid。skill_turbo 完全禁止 Grid，但 `_extract_designer_section` 会提取 designer/SKILL.md 中的弹性布局约束章节（含 Grid 示例），导致 LLM 同时看到"禁止 Grid"和"Grid 示例"。**建议将 Grid → Flex 修复同步到 pptx-craft designer/SKILL.md**。

---

## 六、与 pptx-craft 对比

| 维度              | skill_turbo（最终版）            | pptx-craft（当前）                 |
| ----------------- | -------------------------------- | ---------------------------------- |
| CSS Grid 使用     | 全部改为 flex，规则 8.1 明确禁止 | designer/SKILL.md 仍有 16 处 grid  |
| overflow-hidden   | 规则禁止，仅保留 .ppt-slide 边界 | .content-safe 仍有 overflow-hidden |
| 图表防重叠规则    | 规则 4.3/4.4 全页面通用          | 完全没有                           |
| 字号来源          | 规则 3 "严格使用风格文件值"      | 默认 32px 兜底                     |
| gap 警告          | 规则 8.2 强制用 padding 替代     | 无任何 gap 警告                    |
| 图表颜色规则      | 规则 4.5 强制配色表              | 无图表颜色规则                     |
| 程序化密度检查    | 6 项程序化检查                   | 无程序化检查                       |
| designer 规范提取 | 7 个章节完整提取                 | 直接读完整 SKILL.md                |
| 文本换行          | 规则 21 禁止依赖 break-words     | 无                                 |
| 行高限制          | 规则 22 禁止 leading-[2]         | 无                                 |
| 程序化检查正则    | 先行断言顺序无关 + 图标场景限定  | 无                                 |
| 规则总数          | 23 条（含"转换器限制"子标题）    | —                                  |

---

## 七、剩余未解决问题

### 7.1 转换器限制（需修改 html-to-pptx 引擎或增加预处理脚本）

| 问题                | 说明                                                 |
| ------------------- | ---------------------------------------------------- |
| gap 不支持          | CSS 白名单无 gap-*，需转换器支持或预处理脚本自动转换 |
| li flex/grid 不支持 | CSS 白名单不支持 flex/grid 布局的 li                 |
| line-height 不映射  | 只影响 detectLineBreaks()，不映射 PPTX lineSpacing   |
| SVG 图例对齐        | dominant-baseline="central" 不正确映射 PPTX valign   |
| border 缩放 35%     | 转换器系数 0.65 导致边框过细                         |
| padding 缩放 15%    | 转换器系数 0.85 导致内容区偏移                       |

### 7.2 LLM 决策问题（需优化 prompt 或增加校验）

| 问题                            | 说明                                                         |
| ------------------------------- | ------------------------------------------------------------ |
| ECharts xAxis/series 长度不匹配 | 已从 prompt 删除该规则（基本正确性不应在 prompt 层约束），无程序化校验 |
| 图表数据单位重复                | charts.md formatter 规则不够细                               |
| 长标题换行位置偏移              | PPTX 文本框定位与 HTML 不同                                  |

---

## 八、修改涉及的代码区域索引

| 代码区域                                 | 行号范围（最终版） | 改动内容                                                 |
| ---------------------------------------- | ------------------ | -------------------------------------------------------- |
| `_extract_designer_section`              | 30-100             | P5：从 2 个章节扩充到 7 个                               |
| `_DESIGN_RULES_DIGEST`                   | 158-247            | P0b/P1/P2/P3/P4 + 规则 19-23（重组后）+ 转换器限制子标题 |
| `_HTML_SKELETON`                         | 250-277            | P0：grid→flex + padding 替代 gap                         |
| `_DENSITY_CHECKLIST_DIGEST`              | 426-446            | P7：12 项→15 项 + 移除 gap-4 引用                        |
| `_GRID_USAGE_RE` 等                      | 570-630            | P7：新增 3 个检查函数                                    |
| `_post_check_data_viz`                   | 643-653            | P7：改进卡片计数                                         |
| `_post_check_layout_issues`              | 656-690            | 修复2：justify-between 先行断言 + mr-[Npx] 图标场景限定  |
| `_REWRITE_ACTIONS`                       | 716-735            | 修复2：布局错误移除 gap-3 + 间距/图标边距建议不再一刀切  |
| `_PAGE_LAYOUT_TEMPLATES`                 | 295-390            | P0：全部 grid→flex + padding                             |
| `_IMAGE_LAYOUT_TEMPLATES`                | 840-882            | 修复1+2：grid→flex + gap-3→padding/margin                |
| `_IMAGE_LAYOUT_TEMPLATE_MANY`            | 885-892            | 修复1+2：grid→flex + gap-3→margin                        |
| `_build_page_prompt` rewrite_constraints | ~950               | P6：允许修改布局结构                                     |
| `_check_one` failed_enum                 | ~1610              | P7：新增失败项                                           |
| `_check_one` post-check 调用             | ~1620              | P7：调用 _post_check_layout_issues                       |

---

## 九、提交历史

| 提交       | 日期             | 说明                                                 | 规模     |
| ---------- | ---------------- | ---------------------------------------------------- | -------- |
| `1cb04c64` | 2026-07-14 10:46 | feat:视觉维度修改（基线）                            | +263/-93 |
| `cbd69f72` | 2026-07-14 10:46 | fix: skill_turbo PPT 视觉效果问题修复                | +292/-93 |
| `08bb75d5` | 2026-07-14 15:27 | fix: skill_turbo PPT prompt 约束精简与程序化检查修正 | +49/-51  |

---

## 十、关键经验

1. **转换器限制应走预处理脚本，不走 prompt** — 把 padding 缩放系数、gap 不支持等转换器实现细节写进 prompt，LLM 无法实际执行，且维护割裂
2. **程序化检查正则要顺序无关** — Tailwind class 顺序是任意的，固定顺序正则会漏匹配
3. **程序化检查要限定场景** — `mr-[28px]` 在普通布局中是合法的，只在图标场景（class 含 `fa-`）才需要检查
4. **prompt 规则与模板必须一致** — 规则说"禁止 gap"，模板就不能用 gap；否则 LLM 收到矛盾指令
5. **不应在 prompt 层约束基本代码正确性** — "xAxis.data 长度必须与 series[].data 一致"是 ECharts 基本正确性，不是视觉设计规范