### PR TITLE
fix:补充jiuwenswarm进程退出日志

### DIFF
--- a/jiuwenclaw/agentserver/agent_ws_server.py
+++ b/jiuwenclaw/agentserver/agent_ws_server.py
@@ -355,8 +355,23 @@ class AgentWebSocketServer:
                 task = asyncio.create_task(self._handle_message(ws, raw, send_lock))
                 tasks.add(task)
                 task.add_done_callback(tasks.discard)
-        except websockets.exceptions.ConnectionClosed:
-            logger.info("[AgentWebSocketServer] 连接关闭: %s", remote, extra={'user_visible': 'critical'})
+        except websockets.exceptions.ConnectionClosed as e:
+            # websockets>=12: 正式字段为 rcvd/sent；勿用已 deprecate 的 e.code/e.reason
+            rcvd = getattr(e, "rcvd", None)
+            sent = getattr(e, "sent", None)
+            logger.warning(
+                "[AgentWebSocketServer] 连接关闭 remote=%s "
+                "rcvd_code=%s rcvd_reason=%r sent_code=%s sent_reason=%r "
+                "rcvd_then_sent=%s detail=%s",
+                remote,
+                getattr(rcvd, "code", None),
+                getattr(rcvd, "reason", None) or "",
+                getattr(sent, "code", None),
+                getattr(sent, "reason", None) or "",
+                getattr(e, "rcvd_then_sent", None),
+                e,
+                extra={"user_visible": "critical"},
+            )
         except Exception as e:
             logger.exception("[AgentWebSocketServer] 连接处理异常 (%s): %s", remote, e, 
                              extra={'user_visible': 'critical'})

--- a/jiuwenclaw/app_agentserver.py
+++ b/jiuwenclaw/app_agentserver.py
@@ -12,6 +12,7 @@ Both processes share the same user workspace directory (~/.jiuwenclaw).
 from __future__ import annotations
 
 import argparse
+import atexit
 import asyncio
 import logging
 import os
@@ -57,6 +58,22 @@ for _lg in LogManager.get_all_loggers().values():
 
 # Load env from user workspace config/.env
 load_dotenv(dotenv_path=get_env_file())
+
+# 进程退出诊断：仅记录原因，不改变退出码/清理顺序。默认为 unknown，
+# 若 atexit 仍为 unknown 且看不到 stopping…，多半是强杀/原生崩/os._exit。
+_EXIT_REASON = "unknown"
+
+
+def _set_exit_reason(reason: str) -> None:
+    global _EXIT_REASON
+    _EXIT_REASON = reason
+
+
+def _atexit_log_exit_reason() -> None:
+    logger.critical("[AgentServer] atexit reason=%s", _EXIT_REASON)
+
+
+atexit.register(_atexit_log_exit_reason)
 
 
 class _NopCronScheduler:
@@ -179,6 +196,7 @@ async def _run(host: str, port: int) -> None:
         except Exception as exc:  # noqa: BLE001
             logger.warning("[AgentServer] history flush failed: %s", exc)
         logger.info("[AgentServer] stopped")
+        _set_exit_reason("clean_shutdown")
 
 
 def main() -> None:
@@ -207,7 +225,17 @@ def main() -> None:
         else:
             port = 18092
 
-    asyncio.run(_run(host=host, port=port))
+    try:
+        asyncio.run(_run(host=host, port=port))
+        # 若 finally 已标 clean_shutdown，保留之；否则记录“正常返回但未走完收尾”
+        if _EXIT_REASON == "unknown":
+            _set_exit_reason("asyncio_run_returned")
+    except SystemExit as exc:
+        _set_exit_reason(f"SystemExit({exc.code})")
+        raise
+    except BaseException as exc:
+        _set_exit_reason(f"{type(exc).__name__}: {exc}")
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

## Summary

定位「jiuwen WebSocket connection closed unexpectedly / Sidecar exit code=0」时，AgentServer 侧缺少两类关键信息：
1. 进程以何种路径退出（正常收尾 / SystemExit / 未捕获异常 / 无遗言）
2. WebSocket 关闭时的 close frame（对端/本端 code、reason）

本次仅增加**只读诊断日志**，不改变退出码、信号处理器、cleanup 顺序或业务行为。

## Changes

### 1. `jiuwenclaw/app_agentserver.py`
- 注册 `atexit` 回调，退出时打 `[AgentServer] atexit reason=...`
- `_run` 正常收尾后标记 `clean_shutdown`
- `main()` 外层捕获 `SystemExit` / `BaseException`，记录 reason 后**原样 re-raise**
- **不改** Windows `add_signal_handler` 失败后的 `pass` 逻辑（避免信号回调里碰 asyncio 的风险）

| atexit reason | 含义 |
|---|---|
| `clean_shutdown` | 走完 `_run` finally（stopping → stopped） |
| `asyncio_run_returned` | `asyncio.run` 返回但未看到 clean_shutdown |
| `SystemExit(code)` | 显式 `sys.exit` |
| `<ExceptionType>: ...` | 未捕获异常导致退出 |
| `unknown` 且无 stopping 日志 | 强杀 / 原生崩 / `os._exit` 等未走 Python 正常收尾 |

### 2. `jiuwenclaw/agentserver/agent_ws_server.py`
- `ConnectionClosed` 日志升级为 warning，输出 `rcvd_code` / `rcvd_reason` / `sent_code` / `sent_reason` / `rcvd_then_sent` / `detail`
- 兼容 `websockets>=12`：使用 `rcvd`/`sent` 正式字段 + `getattr` 防护
- **不访问**已在 13.1+ deprecate 的 `e.code` / `e.reason`

## Non-goals
- 不改 Gateway / relay-claw 侧日志
- 不加 event-loop lag 心跳、faulthandler、Windows 自定义 signal handler
- 不改连接关闭后的 `cancel_all_inflight_work` 行为

## Test plan
- [ ] 正常启动 AgentServer，Ctrl+C / 协作停止后，日志出现 `atexit reason=clean_shutdown`，且仍有 `stopping…` / `stopped`
- [ ] Gateway 主动断开 WS 后，出现带 `rcvd_code`/`sent_code` 的「连接关闭」warning，业务清理仍执行
- [ ] 确认进程退出码与改前一致（本改动不主动改 exit code）
- [ ] 回归：正常 chat 流式收发不受影响

## Risk
低。仅为日志与退出原因标记；`atexit` 回调包在 try/except 内，shutdown 路径不会因打日志失败而二次异常；异常路径均 `raise`，不吞异常。