### PR TITLE
fix(a2ui): 修复安装包缺失 Schema 资源

### DIFF
--- a/scripts/jiuwenswarm.spec
+++ b/scripts/jiuwenswarm.spec
@@ -138,7 +138,11 @@ datas += copy_metadata("fastmcp", recursive=True)
 datas += copy_metadata("mcp", recursive=True)
 datas += copy_metadata("openjiuwen", recursive=True)
 datas += collect_data_files("openjiuwen", include_py_files=False, excludes=OPENJIUWEN_DATA_EXCLUDES)
-datas += collect_data_files("a2ui", include_py_files=False)
+datas += collect_data_files(
+    "a2ui",
+    include_py_files=False,
+    includes=["assets/0.8/*.json"],
+)
 datas += collect_data_files(
     "jiuwenswarm.extensions",
     include_py_files=True,

--- a/scripts/jiuwenswarm.spec
+++ b/scripts/jiuwenswarm.spec
@@ -138,6 +138,7 @@ datas += copy_metadata("fastmcp", recursive=True)
 datas += copy_metadata("mcp", recursive=True)
 datas += copy_metadata("openjiuwen", recursive=True)
 datas += collect_data_files("openjiuwen", include_py_files=False, excludes=OPENJIUWEN_DATA_EXCLUDES)
+datas += collect_data_files("a2ui", include_py_files=False)
 datas += collect_data_files(
     "jiuwenswarm.extensions",
     include_py_files=True,

--- a/tests/unit_tests/a2ui/test_module_boundaries.py
+++ b/tests/unit_tests/a2ui/test_module_boundaries.py
@@ -25,3 +25,9 @@ def test_websocket_hook_keeps_a2ui_feature_outside_generic_transport():
     assert "../features/a2ui/" not in source
     assert "sendA2UIClientEvent" not in source
     assert "sendStructuredChatContent" in source
+
+
+def test_pyinstaller_bundle_includes_a2ui_schema_assets():
+    spec = (ROOT / "scripts/jiuwenswarm.spec").read_text(encoding="utf-8")
+
+    assert 'collect_data_files("a2ui", include_py_files=False)' in spec

--- a/tests/unit_tests/a2ui/test_module_boundaries.py
+++ b/tests/unit_tests/a2ui/test_module_boundaries.py
@@ -1,5 +1,7 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 
+import json
+import tomllib
 from pathlib import Path
 
 
@@ -27,7 +29,32 @@ def test_websocket_hook_keeps_a2ui_feature_outside_generic_transport():
     assert "sendStructuredChatContent" in source
 
 
-def test_pyinstaller_bundle_includes_a2ui_schema_assets():
+def test_a2ui_build_dependencies_and_lockfiles_are_pinned_for_v08():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    uv_lock = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
+    frontend = json.loads(
+        (ROOT / "jiuwenswarm/channels/web/frontend/package.json").read_text(encoding="utf-8")
+    )
+    frontend_lock = json.loads(
+        (ROOT / "jiuwenswarm/channels/web/frontend/package-lock.json").read_text(encoding="utf-8")
+    )
+
+    locked_sdk_version = None
+    for package in uv_lock["package"]:
+        if package.get("name") == "a2ui-agent-sdk":
+            locked_sdk_version = package.get("version")
+            break
+
+    assert "a2ui-agent-sdk==0.2.1" in pyproject["project"]["dependencies"]
+    assert locked_sdk_version == "0.2.1"
+    assert frontend["dependencies"]["@a2ui/react"] == "0.8.0"
+    assert frontend["dependencies"]["@a2ui/web_core"] == "0.8.0"
+    assert frontend_lock["packages"]["node_modules/@a2ui/react"]["version"] == "0.8.0"
+    assert frontend_lock["packages"]["node_modules/@a2ui/web_core"]["version"] == "0.8.0"
+
+
+def test_pyinstaller_bundle_includes_only_a2ui_v08_schema_assets():
     spec = (ROOT / "scripts/jiuwenswarm.spec").read_text(encoding="utf-8")
 
-    assert 'collect_data_files("a2ui", include_py_files=False)' in spec
+    assert 'includes=["assets/0.8/*.json"]' in spec
+    assert 'collect_data_files("a2ui", include_py_files=False)' not in spec


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

### 修复内容
- 修复 Windows 安装包启用 A2UI 后无法生成交互界面的问题。
- 将桌面安装包的 A2UI 依赖和资源严格限定在协议 v0.8，避免误打包 v0.9 Schema。
- 增加依赖版本、锁文件和 PyInstaller 资源范围的回归测试。

### 根因
- `a2ui-agent-sdk==0.2.1` 运行时通过 `importlib.resources` 读取 `a2ui/assets/0.8/server_to_client.json` 等内置 Schema。
- 源码环境可以直接从 `site-packages` 读取这些文件；0.2.2 的 PyInstaller 配置只收集 Python 模块，没有收集 JSON 数据文件，因此安装包报错 `Could not load schema server_to_client.json for version 0.8`。
- SDK 同时附带 0.8 和 0.9 资源，若不限定收集范围，会把当前不支持的 0.9 Schema 一并放入安装包，容易产生错误使用或后续不兼容风险。

### 修复方式
- Python 构建依赖与 `uv.lock` 固定 `a2ui-agent-sdk==0.2.1`。
- Web 端 `package.json` 与 `package-lock.json` 固定 `@a2ui/react`、`@a2ui/web_core` 为 `0.8.0`。
- PyInstaller 仅收集 `assets/0.8/*.json`，不会把 `assets/0.9` 放入安装包。
- 保持运行时支持版本集合仅为 `0.8`，配置 `0.9` 会被拒绝。

### 验证
- A2UI 打包与版本配置定向测试 -> 9 passed
- PyInstaller 资源收集检查 -> 仅包含 `a2ui/assets/0.8/server_to_client.json` 和 `standard_catalog_definition.json`，不包含 0.9
- 依赖清单与锁文件测试 -> Python SDK `0.2.1`，Web A2UI 包 `0.8.0`
- `git diff --check` -> passed