### PR TITLE
feat(vibeskill): Gateway补充message.send的附件删除接口

### DIFF
--- a/docs/zh/VibeSkillChannel架构与接口.md
+++ b/docs/zh/VibeSkillChannel架构与接口.md
@@ -430,14 +430,47 @@ curl -X POST http://127.0.0.1:19003/api/v1/session \
 
 Standard 模式会额外调用 `ChannelManager.create_agent_session()`，再由 `MessageHandler` 发送 `session.create` 到 AgentServer。
 
-### 5.2 文件接口
+### 5.2 文件与附件接口
 
 | 方法 | 路径 | 状态 | 说明 |
 |------|------|------|------|
 | `GET` | `/api/v1/session/{sessionID}/file` | 已实现 | 调用 `skilldev.file.list`，返回前端 `FileTreeNode[]` |
 | `GET` | `/api/v1/session/{sessionID}/file/content?path={path}` | 已实现 | 调用 `skilldev.file.read`，返回文本内容 |
 | `PUT` | `/api/v1/session/{sessionID}/file/content?path={path}` | 已实现 | 调用 `skilldev.file.write`，覆盖写入文本文件 |
+| `DELETE` | `/api/v1/session/{sessionID}/attachments` | Channel 已实现 | Channel 校验 body 后转发 `skilldev.resource.delete`（按资源身份删除此前 `message.send` 上传的附件）；AgentServer 落盘/解压清理实现待补齐。不改写历史消息 |
 | `GET` | `/api/v1/session/{sessionID}/file/status` | 占位 | 当前返回空数组 |
+
+附件删除请求体示例：
+
+```json
+{
+  "items": [
+    { "type": "file", "filename": "spec.pdf" },
+    { "type": "skill", "filename": "ref.zip" },
+    { "type": "toolDefinition", "pluginId": "bundle.a", "toolName": "do_x" },
+    { "type": "agentDefinition", "agentId": "reviewer" },
+    { "type": "cliDefinition", "name": "my-cli" }
+  ]
+}
+```
+
+附件删除响应示例（HTTP 200，偏成功）：
+
+```json
+{
+  "ok": true,
+  "deleted": [
+    { "type": "file", "filename": "spec.pdf" },
+    { "type": "toolDefinition", "pluginId": "bundle.a", "toolName": "do_x" }
+  ],
+  "notFound": [
+    { "type": "skill", "filename": "ref.zip" }
+  ],
+  "errors": []
+}
+```
+
+语义说明：目标不存在记入 `notFound`，HTTP 仍为 200；非法请求（空 `items`、缺身份字段、未知 type）返回 400，session 不存在返回 404。仅清理 session workspace 内资源与 `resource_state.json`，不删除 OBS 原始上传源，也不擦除 timeline。
 
 文件树转换规则：
 

--- a/jiuwenclaw/channel/vibeskill_channel.py
+++ b/jiuwenclaw/channel/vibeskill_channel.py
@@ -186,9 +186,73 @@ def _http_interface_name(path: str, method: str) -> str:
         return "FileRead"
     if tail == ["file", "content"] and meth_u == "PUT":
         return "FileWrite"
+    if tail == ["attachments"] and meth_u == "DELETE":
+        return "AttachmentDelete"
     if tail == ["export"] and meth_u == "POST":
         return "SkillExport"
     return ""
+
+
+_ATTACHMENT_DELETE_TYPES = frozenset(
+    {"file", "skill", "toolDefinition", "agentDefinition", "cliDefinition"}
+)
+
+
+def validate_attachment_delete_items(
+    items: Any,
+) -> tuple[str | None, list[dict[str, Any]] | None]:
+    """Validate DELETE /attachments request body ``items``.
+
+    Returns ``(None, normalized_items)`` on success, or ``(error, None)`` on failure.
+    """
+    if not isinstance(items, list) or not items:
+        return "items must be a non-empty array", None
+
+    normalized: list[dict[str, Any]] = []
+    for idx, raw in enumerate(items):
+        if not isinstance(raw, dict):
+            return f"items[{idx}] must be an object", None
+        item_type = str(raw.get("type") or "").strip()
+        if item_type not in _ATTACHMENT_DELETE_TYPES:
+            return (
+                f"items[{idx}].type must be one of "
+                f"{', '.join(sorted(_ATTACHMENT_DELETE_TYPES))}",
+                None,
+            )
+        item: dict[str, Any] = {"type": item_type}
+        if item_type in {"file", "skill"}:
+            filename = str(raw.get("filename") or raw.get("name") or "").strip()
+            if not filename:
+                return f"items[{idx}] requires filename", None
+            if (
+                "/" in filename
+                or "\\" in filename
+                or filename in {".", ".."}
+                or ".." in filename
+            ):
+                return f"items[{idx}].filename is illegal", None
+            item["filename"] = filename
+        elif item_type == "toolDefinition":
+            plugin_id = str(
+                raw.get("pluginId") or raw.get("bundleName") or raw.get("plugin_id") or ""
+            ).strip()
+            tool_name = str(raw.get("toolName") or raw.get("name") or "").strip()
+            if not plugin_id or not tool_name:
+                return f"items[{idx}] requires pluginId/bundleName and toolName", None
+            item["pluginId"] = plugin_id
+            item["toolName"] = tool_name
+        elif item_type == "agentDefinition":
+            agent_id = str(raw.get("agentId") or raw.get("agent_id") or "").strip()
+            if not agent_id:
+                return f"items[{idx}] requires agentId", None
+            item["agentId"] = agent_id
+        else:  # cliDefinition
+            name = str(raw.get("name") or "").strip()
+            if not name:
+                return f"items[{idx}] requires name", None
+            item["name"] = name
+        normalized.append(item)
+    return None, normalized
 
 
 def _http_response_log_context(path: str, method: str) -> tuple[str, str]:
@@ -4144,6 +4208,13 @@ class VibeSkillChannel(BaseChannel):
         if request_path.startswith("/api/v1/session/") and request_path.endswith("/summarize") and method == "POST":
             session_id = request_path.replace("/api/v1/session/", "").replace("/summarize", "")
             return await self._handle_http_session_summarize(session_id)
+        if (
+            request_path.startswith("/api/v1/session/")
+            and request_path.endswith("/attachments")
+            and method == "DELETE"
+        ):
+            session_id = request_path.split("/api/v1/session/", 1)[-1].replace("/attachments", "")
+            return await self._handle_http_attachments_delete(session_id, body)
         if request_path.startswith("/api/v1/session/") and method == "DELETE":
             session_id = request_path.split("/api/v1/session/", 1)[-1]
             return await self._handle_http_session_delete(session_id)
@@ -4565,6 +4636,69 @@ class VibeSkillChannel(BaseChannel):
             source="http.session.delete",
         )
         return self._json_response(200, result)
+
+    async def _handle_http_attachments_delete(
+        self, session_id: str, body: bytes
+    ) -> tuple[int, dict, bytes]:
+        """DELETE /api/v1/session/{id}/attachments — skilldev.resource.delete."""
+        sid = str(session_id or "").strip().strip("/")
+        if not sid:
+            return self._json_response(400, {"error": "sessionID cannot be empty"})
+        session_obj = await self._store.resolve_session(sid)
+        if session_obj is None:
+            return self._json_response(404, {"error": "session_not_found"})
+
+        try:
+            payload = json.loads(body.decode("utf-8") or "{}")
+        except Exception:
+            return self._json_response(400, {"error": "invalid JSON body"})
+        if not isinstance(payload, dict):
+            return self._json_response(400, {"error": "body must be a JSON object"})
+
+        err, items = validate_attachment_delete_items(payload.get("items"))
+        if err or items is None:
+            return self._json_response(400, {"error": err or "invalid items"})
+
+        request_id = f"vibeskill-att-del-{int(time.time() * 1000):x}-{secrets.token_hex(3)}"
+        delete_params: dict[str, Any] = {
+            "task_id": session_obj.session_id,
+            "session_id": session_obj.session_id,
+            "items": items,
+        }
+        self._apply_tenant_service_id(delete_params, session_obj.session_id)
+        env = e2a_from_agent_fields(
+            request_id=request_id,
+            channel_id=VIBESKILL_CHANNEL_ID,
+            session_id=session_obj.session_id,
+            req_method=ReqMethod.SKILLDEV_RESOURCE_DELETE,
+            params=delete_params,
+            is_stream=False,
+            timestamp=time.time(),
+            user_id=self._session_user_id(session_obj.session_id),
+        )
+        logger.info(
+            "[VibeSkillChannel] skilldev.resource.delete sent, session_id=%s items=%d",
+            session_obj.session_id,
+            len(items),
+        )
+        resp = await self._send_agent_request(env)
+        if not resp.ok:
+            pl = dict(resp.payload) if isinstance(resp.payload, dict) else {}
+            return self._json_response(502, {"error": str(pl.get("error") or "request failed")})
+        result = dict(resp.payload) if isinstance(resp.payload, dict) else {}
+        if result.get("event_type") == "skilldev.error":
+            return self._json_response(400, {"error": str(result.get("error") or "skilldev.error")})
+        return self._json_response(
+            200,
+            {
+                "ok": bool(result.get("ok", True)),
+                "deleted": result.get("deleted") if isinstance(result.get("deleted"), list) else [],
+                "notFound": (
+                    result.get("notFound") if isinstance(result.get("notFound"), list) else []
+                ),
+                "errors": result.get("errors") if isinstance(result.get("errors"), list) else [],
+            },
+        )
 
     async def _handle_http_file_list(self, session_id: str, headers: dict) -> tuple[int, dict, bytes]:
         """GET /api/v1/.../file — 列目录（skilldev.file.list → FileTreeNode[] 嵌套树）。"""

--- a/jiuwenclaw/schema/message.py
+++ b/jiuwenclaw/schema/message.py
@@ -134,6 +134,7 @@ class ReqMethod(Enum):
     SKILLDEV_FILE_LIST = "skilldev.file.list"  # 获取工作区文件树（产物弹窗浏览）
     SKILLDEV_FILE_READ = "skilldev.file.read"  # 读取工作区文件内容
     SKILLDEV_FILE_WRITE = "skilldev.file.write"  # 覆盖写入工作区文本文件
+    SKILLDEV_RESOURCE_DELETE = "skilldev.resource.delete"  # 按身份删除 message.send 上传的资源
     SKILLDEV_BATCH_UPLOAD = "skilldev.batch_upload"  # 批量打包上传 workspace 到 OBS
     SKILLDEV_BATCH_DOWNLOAD = "skilldev.batch_download"  # 批量下载解压 workspace
     SKILLDEV_ANSWER = "skilldev.user_answer"


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

- vibeskill channel 新增 REST DELETE /api/v1/session/{sessionID}/attachments，按资源身份批量删除此前 message.send 落入 workspace 的附件（file / skill / toolDefinition / agentDefinition / cliDefinition）。
- vibeskill channel 校验 body 后转发 unary RPC skilldev.resource.delete 到 AgentServer

Channel → AgentServer（unary E2A / skilldev.resource.delete）请求示例：
```
{
  "request_id": "vibeskill-att-del-19a3c2f1-a1b2c3",
  "channel_id": "vibeskill",
  "session_id": "vibeskill_abc123def456",
  "user_id": "user-001",
  "service_id": "vibeskill_abc123def456",
  "method": "skilldev.resource.delete",
  "is_stream": false,
  "params": {
    "task_id": "vibeskill_abc123def456",
    "items": [
      { "type": "file", "filename": "spec.pdf" },
      { "type": "skill", "filename": "ref.zip" },
      { "type": "toolDefinition", "pluginId": "bundle.a", "toolName": "do_x" },
      { "type": "agentDefinition", "agentId": "reviewer" },
      { "type": "cliDefinition", "name": "my-cli" }
    ]
  }
}
```

AgentServer → Channel 成功响应 payload（Channel 原样映射为 HTTP 200 body）：
```
{
  "ok": true,
  "deleted": [
    { "type": "file", "filename": "spec.pdf" },
    { "type": "toolDefinition", "pluginId": "bundle.a", "toolName": "do_x" }
  ],
  "notFound": [
    { "type": "skill", "filename": "ref.zip" }
  ],
  "errors": []
}
```