### PR TITLE
fix(skill_turbo): P8.1检测ECharts图表容器缺echarts.init初始化，触发重写修复空白

### DIFF
--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py
@@ -616,6 +616,27 @@ def _has_empty_chart_svg(html: str) -> bool:
     return False
 
 
+# --- ECharts 图表容器缺少 echarts.init 初始化检测（P8.1 阶段，P8.2 fix 之前） ---
+# 场景：LLM 生成了 <div id="xxxChart"> + echarts 脚本引用，但遗漏 echarts.init 调用，
+# 导致 P8.2 cli.js fix 将未初始化图表转为空 SVG（页面出现大片空白）。
+# 仅检测"有 ECharts 库但完全没有 echarts.init 调用"——这是最可靠的信号，
+# 不依赖容器 id 命名约定或 init 调用格式，避免误报。
+_ECHARTS_LIB_RE = re.compile(r'<script[^>]*echarts[\w.-]*\.js', re.IGNORECASE)
+_ECHARTS_INIT_RE = re.compile(r'echarts\.init\s*\(', re.IGNORECASE)
+
+
+def _has_chart_without_init(html: str) -> bool:
+    """检测 ECharts 图表容器缺少 echarts.init 初始化脚本。
+
+    在 P8.1 密度检查阶段（P8.2 cli.js fix 之前）运行。
+    检测条件：HTML 引入了 ECharts 库脚本但完全没有 echarts.init 调用。
+    不依赖容器 id 命名或 init 调用格式，避免误报。
+    """
+    if not _ECHARTS_LIB_RE.search(html):
+        return False
+    return not _ECHARTS_INIT_RE.search(html)
+
+
 # 检测 CSS Grid 布局使用（html-to-pptx 不支持 Grid）
 _GRID_USAGE_RE = re.compile(r'\bgrid\s+grid-cols-\S+', re.IGNORECASE)
 
@@ -722,7 +743,10 @@ _REWRITE_ACTIONS = {
     "缺数据可视化": (
         "在页面底部（footer 之前）插入一个 ECharts 图表，按以下规则选择图表类型："
         "时间序列数据用折线图，占比/构成数据用饼图，对比/排名数据用柱状图。"
-        "直接使用页面中已有的数字作为数据点，不要修改现有卡片和布局结构"
+        "直接使用页面中已有的数字作为数据点，不要修改现有卡片和布局结构。"
+        "如果页面已存在图表容器（如 <div id=\"xxxChart\">）但缺少初始化脚本，"
+        "必须在该容器之后紧邻 </body> 补充完整的"
+        " echarts.init(document.getElementById('xxx'), null, {renderer:'svg'}).setOption({...}) 初始化代码"
     ),
     "核心要点不足": "将段落拆分为 6-10 个列表项或卡片，每条 1-2 行加图标",
     "缺装饰图标": "为每个核心要点/卡片添加相关 FontAwesome 图标（class 含 fa-）",
@@ -1691,6 +1715,10 @@ class PageWorkerNode(PlanNode):
                 if _has_empty_chart_svg(html) and "缺数据可视化" not in failed_items:
                     failed_items.append("缺数据可视化")
                     logger.info("[P8.1] 页面 %d 检测到空SVG图表，标记缺数据可视化", page_num)
+                # 主动检测图表容器缺初始化：有 echarts.min.js + 空 div 容器但无 echarts.init 调用
+                if _has_chart_without_init(html) and "缺数据可视化" not in failed_items:
+                    failed_items.append("缺数据可视化")
+                    logger.info("[P8.1] 页面 %d 检测到图表容器缺少echarts.init初始化，标记缺数据可视化", page_num)
                 # 程序化布局检查：Grid 使用、overflow-hidden 裁切、字号不一致、溢出风险（leading-loose）
                 before_count = len(failed_items)
                 failed_items = _post_check_layout_issues(html, failed_items)


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# P5 页面图表空白问题定位与修复总结

> **问题模块**: `jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py`
> **session_id**: `officeclaw_bdd863f2461408f3027f37bc`
> **产物路径**: `.../output/20260715_000741_000/pages/page-5.pptx.html`
> **日志路径**: `officeace-logs_15turbo0715(1)/jiuwenclaw-service-logs/agent_server.log`
> **证据强度**: confirmed

---

## 一、问题现象

P5 页面"海上与陆上丝绸之路发展对比"模块出现大片空白。最终 PPTX 中该区域为空白矩形，无图表内容。

---

## 二、根因分析

### 2.1 直接原因

LLM 在 P8.1 页面生成阶段，生成了 ECharts 图表容器 `<div id="silkRoadChart" class="w-full h-full"></div>` 和 `<script src="...echarts.min.js">` 库引用，但**遗漏了 `echarts.init(document.getElementById('silkRoadChart'), null, {renderer:'svg'}).setOption({...})` 初始化脚本**。

P8.2 cli.js fix 阶段执行 ECharts → 静态 SVG 转换时，因图表从未被初始化（无 `echarts.init` 调用），Playwright 渲染出空 SVG（仅有 viewBox，无 path/text 等图形元素），替换到 HTML 中形成空白。

### 2.2 为什么 P8.1 密度检查没有拦截

P8.1 密度检查已触发重写，但**触发原因是"字号不一致"而非图表缺失初始化**，完整链路：

```
P5 生成 HTML（有 <div id="silkRoadChart"> 但无 echarts.init）
  ↓
密度检查
  ├── LLM 判定 → failed_items = ["字号不一致"]   ← LLM 只看到字号问题
  ├── _has_empty_chart_svg(html) → False         ← 检查 echarts-static-svg 容器，但 P8.1 阶段还没有这个容器
  └── _post_check_layout_issues → 追加 "字号不一致"
  ↓
failed_items = ["字号不一致"]
pass = False → 触发重写（重写确实触发了）
  ↓
重写提示词 = "统一同级别卡片/模块的字号..."   ← 只提到字号，没提到图表 init
  ↓
LLM 重写 → 修了字号，但图表 init 仍然缺失（提示词没提）
  ↓
再次密度检查 → 仍然只检出"字号不一致"
  ↓
重试耗尽 → 进 low_density → P8.2 fix → 空 SVG → 空白
```

### 2.3 检测缺口

| 检测函数                          | 检测目标                                        | 在 P8.1 阶段能否触发 | 原因                                                         |
| --------------------------------- | ----------------------------------------------- | -------------------- | ------------------------------------------------------------ |
| `_has_empty_chart_svg`            | `echarts-static-svg` 容器内空 SVG               | **不能**             | `echarts-static-svg` 容器是 P8.2 cli.js fix 才创建的，P8.1 阶段图表还是 `<div id="xxxChart"></div>` 空容器 |
| `_has_chart_without_init`（新增） | 有 ECharts 库脚本但完全没有 `echarts.init` 调用 | **能**               | 直接在 P8.1 阶段检测 HTML 源码中的脚本缺失                   |

### 2.4 定界

**是 jiuwenclaw/skill_turbo 问题。** 边界在 P8.1 密度检查的检测缺口：已有 `_has_empty_chart_svg` 只能检测 P8.2 fix 之后的空 SVG，无法检测 P8.1 阶段"图表容器缺初始化"的问题。不是 CDN 加载问题（CDN URL 正确），不是 P8.2 fix 脚本 bug（fix 的行为是设计预期，问题是它不校验转换结果）。

---

## 三、修复方案

### 3.1 思路

参考 pptx-craft skill 的模式：**在编排层（P8.1）检测并触发重写，fix 层（P8.2）只做纯转换。** 最小改动——仅加固 P8.1 的检测环节，让重写因为正确的原因触发，并给出正确的修复指引。

### 3.2 修复后的链路

```
P5 生成 HTML（有 <div id="silkRoadChart"> 但无 echarts.init）
  ↓
密度检查
  ├── LLM 判定 → ["字号不一致"]
  ├── _has_empty_chart_svg → False
  ├── 【新增】_has_chart_without_init → True ✓（检测到 echarts 库但无 echarts.init 调用）
  └── failed_items = ["字号不一致", "缺数据可视化"]
  ↓
重写提示词 = "统一字号..." + "如果已存在图表容器但缺初始化，必须补充 echarts.init + setOption"
  ↓
LLM 重写 → 修字号 + 补 echarts.init + setOption ✓
  ↓
再次密度检查 → _has_chart_without_init → False ✓ → 通过
```

---

## 四、代码改动

**文件**: `jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/ppt_page_gen.py`
**改动数**: 3 处，全部在 P8.1 范围内

### 改动 1：新增 `_has_chart_without_init` 检测函数（行 619-635）

在 `_has_empty_chart_svg` 之后新增函数和正则，检测 P8.1 阶段（P8.2 fix 之前）的图表容器缺初始化问题：

```python
_ECHARTS_LIB_RE = re.compile(r'<script[^>]*echarts[\w.-]*\.js', re.IGNORECASE)
_ECHARTS_INIT_RE = re.compile(r'echarts\.init\s*\(', re.IGNORECASE)

def _has_chart_without_init(html: str) -> bool:
    """检测 ECharts 图表容器缺少 echarts.init 初始化脚本。

    在 P8.1 密度检查阶段（P8.2 cli.js fix 之前）运行。
    检测条件：HTML 引入了 ECharts 库脚本但完全没有 echarts.init 调用。
    不依赖容器 id 命名或 init 调用格式，避免误报。
    """
    if not _ECHARTS_LIB_RE.search(html):
        return False
    return not _ECHARTS_INIT_RE.search(html)
```

**设计考量**：

- `_ECHARTS_LIB_RE` 匹配 `echarts.min.js`、`echarts.js`、`echarts.common.js` 等多种脚本名（`echarts[\w.-]*\.js`）
- 仅检测"有 ECharts 库但完全没有 `echarts.init` 调用"——这是最可靠的信号
- **不**依赖容器 id 命名约定（如 id 含 "chart"）或 init 调用格式（如 `document.getElementById`），避免因 LLM 未严格遵循格式约定而产生的误报
- "部分图表有 init、部分没有"的场景极少见（LLM 要么全忘了要么全写了），不为此引入脆弱的容器级匹配

### 改动 2：P8.1 密度检查中调用（行 1731-1734）

在现有 `_has_empty_chart_svg` 检测之后，增加 `_has_chart_without_init` 检测：

```python
# 主动检测图表容器缺初始化：有 echarts.min.js + 空 div 容器但无 echarts.init 调用
if _has_chart_without_init(html) and "缺数据可视化" not in failed_items:
    failed_items.append("缺数据可视化")
    logger.info("[P8.1] 页面 %d 检测到图表容器缺少echarts.init初始化，标记缺数据可视化", page_num)
```

### 改动 3：更新重写提示词（行 722-729）

`_REWRITE_ACTIONS["缺数据可视化"]` 中追加图表初始化指引：

```python
"缺数据可视化": (
    "在页面底部（footer 之前）插入一个 ECharts 图表，..."
    "直接使用页面中已有的数字作为数据点，不要修改现有卡片和布局结构。"
    "如果页面已存在图表容器（如 <div id=\"xxxChart\">）但缺少初始化脚本，"
    "必须在该容器之后紧邻 </body> 补充完整的"
    " echarts.init(document.getElementById('xxx'), null, {renderer:'svg'}).setOption({...}) 初始化代码"
),
```

---

## 五、验证结果

使用真实 P5 HTML 文件验证检测函数：

| 测试样本                                     | `_has_chart_without_init` | `_has_empty_chart_svg` | 预期                |
| -------------------------------------------- | ------------------------- | ---------------------- | ------------------- |
| P5 备份（修复前：有 echarts.min.js 无 init） | **True**                  | False                  | P8.1 阶段能检测到 ✓ |
| P5 最终（修复后：空 SVG）                    | False                     | **True**               | P8.2 阶段能检测到 ✓ |
| P4 正常页面（有库 + 有 init）                | False                     | False                  | 无误报 ✓            |
| P8 正常页面（有库 + 有 init）                | False                     | False                  | 无误报 ✓            |

- 语法检查：通过
- 改动范围：仅 P8.1，不碰 P8.2，不改架构

---

## 六、补充说明

### 6.1 影响范围

17 页中 10 页有 ECharts 图表，仅 P5 一页受影响（LLM 偶发遗漏 init）。其余 9 页均正常生成了 `echarts.init` 调用。问题是概率性的 LLM 行为，非系统性缺陷。

### 6.2 重写能否修复

能。重写时 LLM 拿到完整上下文：

1. 原始 HTML 全文（能看到 `<div id="silkRoadChart">` 空容器）
2. 更新后的重写提示词（明确指出"如果已有图表容器缺初始化，必须补 echarts.init"）
3. 重写约束（"必须基于上次产物做针对性修改"）

重写后再次密度检查会验证 `_has_chart_without_init` 是否通过。

### 6.3 重写仍失败的兜底

如果 LLM 重写后仍未补 init（概率性行为），重试耗尽后进入 `low_density`，P8.2 fix 仍会产出空 SVG。此情况保持现有逻辑不变（标记 partial），不再额外处理。

### 6.4 检测策略选择

采用"有 ECharts 库但完全没有 `echarts.init` 调用"作为唯一检测条件，而非容器级精确匹配。理由：

| 方案                    | 优点                             | 缺点                                                         | 采用   |
| ----------------------- | -------------------------------- | ------------------------------------------------------------ | ------ |
| **仅检查"有库无 init"** | 简单可靠，不依赖格式约定，无误报 | 不覆盖"部分图表有 init 部分没有"的极少见场景                 | **是** |
| 容器级精确匹配          | 能检测部分缺 init                | 依赖容器 id 含 "chart" + init 用 `getElementById` 格式，LLM 不遵循约定时误报 | 否     |

P5 实际场景就是"完全没有 init"（LLM 要么全忘了要么全写了），简单方案覆盖核心场景且无副作用。