### PR TITLE
fix(skill_turbo): fallback 失败的 chat.error 抢跑前端阻断转 skill_tool 降级

### DIFF
--- a/jiuwenclaw/agentserver/skill_turbo/executor.py
+++ b/jiuwenclaw/agentserver/skill_turbo/executor.py
@@ -51,6 +51,7 @@ from jiuwenclaw.agentserver.skill_turbo.permission_bridge import (
 )
 from jiuwenclaw.agentserver.stream_utils import STREAM_SOURCE_ID_FIELD, parse_stream_chunk
 from jiuwenclaw.agentserver.skill_turbo.json_utils import extract_llm_json
+from jiuwenclaw.agentserver.skill_turbo.fallback_handler import FallbackContractError
 from jiuwenclaw.agentserver.skill_turbo.plan_node import AbortError, PlanNode
 from jiuwenclaw.agentserver.skill_turbo.validator import (
     PlanCodeValidationError,
@@ -651,6 +652,25 @@ class SkillTurboExecutor:
         except AbortError:
             # HITL 中断必须透传到 SkillTurbo.run_stream / adapter，
             # 由后者发出 ask_user_question + invocation_paused，不要在此包成 chat.error。
+            raise
+        except (FallbackContractError, FallbackLimitExceededError) as e:
+            # fallback 终止性失败（契约未达成 / 次数超限）：终止本 plan，但不发 chat.error。
+            # chat.error 会被 tool 转发到父会话，前端 useWebSocket 收到后会清空 activeRequestIdRef
+            # 并渲染"系统异常"，抢先终结本轮，LLM 来不及按 skill_prompt_rail 转 skill_tool 降级。
+            # 这里只发 plan.finished(failed) + complete（前端不处理 plan.*，不抢跑），然后向上
+            # raise，由 agent.py 包成 SkillTurboNotHandled，tool 层返回 success=false 给 LLM，
+            # LLM 再转 skill_tool 走标准流程——新一轮 request 前端会重新建 activeRequestIdRef。
+            logger.error(
+                "[SkillTurboExecutor] execute_plan_stream fallback terminal failure, degrading: %s",
+                e,
+            )
+            yield self._make_plan_finished_chunk(
+                request_id,
+                channel_id,
+                status="failed",
+                error=str(e),
+            )
+            yield self._make_complete_chunk(request_id, channel_id)
             raise
         except Exception as e:
             error = str(e)
@@ -1837,20 +1857,23 @@ class SkillTurboExecutor:
                 if item is None:
                     break
                 if isinstance(item, FallbackLimitExceededError):
+                    # fallback 超限：不发 node_error chat.error（会抢跑前端，详见 execute_plan_stream
+                    # 的 except FallbackContractError 注释），直接向上 raise 走不发 chat.error 的降级路径。
                     logger.error(
                         "[SkillTurboExecutor] _execute_node_stream FallbackLimitExceededError: %s",
                         item,
                     )
                     async for task_chunk in self._drain_task_event_chunks():
                         yield task_chunk
-                    yield self._make_node_error_chunk(
-                        request_id,
-                        channel_id,
-                        node,
-                        str(item),
-                        self._current_task_id(),
+                    raise item
+                if isinstance(item, FallbackContractError):
+                    # fallback 契约失败：不在内层转成 node_error chat.error（会抢跑前端），
+                    # 直接向上 raise，交给 execute_plan_stream 的 except FallbackContractError
+                    # 走"不发 chat.error、只 plan.finished(failed)+complete"的降级路径。
+                    logger.error(
+                        "[SkillTurboExecutor] _execute_node_stream FallbackContractError, propagating: %s",
+                        item,
                     )
-                    # Fallback 超限是终止性错误，向上传播让 execute_plan_stream 感知
                     raise item
                 if isinstance(item, BaseException):
                     # cancel 中断（asyncio.CancelledError / KeyboardInterrupt）必须向上抛，

--- a/jiuwenclaw/agentserver/skill_turbo/fallback_handler.py
+++ b/jiuwenclaw/agentserver/skill_turbo/fallback_handler.py
@@ -138,6 +138,50 @@ class DeepAgentFallbackHandler(SkillTurboFallbackHandler):
         )
 
     @staticmethod
+    def _scan_balanced_json_objects(text: str) -> list[str]:
+        """对裸 JSON（无围栏）做括号平衡扫描，返回所有完整 {...} 子串。
+
+        从每个 `{` 起，按字符串/转义感知的括号计数找匹配的 `}`，收集深度归零的子串。
+        用于无围栏时定位契约声明。扫描全文（而非仅末尾片段），以兼容契约出现在
+        开头/中段等 off-spec 情况，避免漏检导致误判 failed。
+
+        复杂度：匹配成功的各 {...} 区间互不重叠，且至多存在一次扫描到末尾的失败
+        匹配，整体为 O(n)。fallback 产出为单次 LLM 响应、长度有界，无需额外截断。
+        """
+        results: list[str] = []
+        n = len(text)
+        i = 0
+        while i < n:
+            if text[i] != "{":
+                i += 1
+                continue
+            depth = 0
+            in_str = False
+            escape = False
+            j = i
+            while j < n:
+                ch = text[j]
+                if in_str:
+                    if escape:
+                        escape = False
+                    elif ch == "\\":
+                        escape = True
+                    elif ch == '"':
+                        in_str = False
+                elif ch == '"':
+                    in_str = True
+                elif ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        results.append(text[i:j + 1])
+                        break
+                j += 1
+            i = j + 1 if j < n else n
+        return results
+
+    @staticmethod
     def _parse_fallback_output(fallback_output: Any) -> tuple[bool, dict[str, Any]]:
         """解析 subagent 末尾的 JSON 契约声明。
 
@@ -149,26 +193,54 @@ class DeepAgentFallbackHandler(SkillTurboFallbackHandler):
         import re
 
         text = str(fallback_output or "")
-        # 优先匹配单行内联代码: `{"success": ...}`
-        inline_blocks = re.findall(r"`(\{.*?\})`", text)
-        # 兼容多行代码块: ```json ... ```
-        code_blocks = re.findall(r"```json\s*(\{.*?\})\s*```", text, re.DOTALL)
-        blocks = inline_blocks or code_blocks
-        if not blocks:
+        stripped = text.strip()
+        if not stripped:
+            # 空产出（subagent 未返回任何内容）与"有产出无契约"区分，便于日志诊断。
+            logger.warning(
+                "[DeepAgentFallbackHandler] fallback output is empty, treat as failed"
+            )
+            return False, {"reason": "fallback subagent 未产出任何内容"}
+
+        # 收集候选 JSON 片段（按优先级）。解析靠 json.loads，正则只圈定范围，
+        # 不用 \{.*?\} 截断（嵌套对象会被首个 } 截断导致解析失败）。
+        candidates: list[str] = []
+        # 1. 单行内联代码: `{"success": ...}` （贪婪到反引号，保留嵌套）
+        candidates.extend(re.findall(r"`(\{.*\})`", text))
+        # 2. ```json ... ``` 多行代码块（围栏内全部内容）
+        candidates.extend(re.findall(r"```json\s*(\{[\s\S]*?\})\s*```", text))
+        # 3. ``` ... ``` 不带 language tag 的代码块
+        candidates.extend(re.findall(r"```\s*(\{[\s\S]*?\})\s*```", text))
+        # 4. 裸 JSON：从每个 { 起做括号平衡扫描，取最后一个完整且可解析的对象
+        candidates.extend(DeepAgentFallbackHandler._scan_balanced_json_objects(stripped))
+        # 去重：不同收集方式可能捕获到相同 JSON 片段（如内联代码与裸 JSON 扫描
+        # 都会得到 {"success": ...}），用 dict.fromkeys 保持顺序去重，避免重复解析。
+        candidates = list(dict.fromkeys(candidates))
+
+        if not candidates:
             logger.warning(
                 "[DeepAgentFallbackHandler] fallback output has no JSON contract block, "
                 "treat as failed"
             )
             return False, {"reason": "fallback 输出未包含 JSON 契约声明"}
 
-        try:
-            payload = json.loads(blocks[-1])
-        except json.JSONDecodeError as e:
+        payload = None
+        last_err: json.JSONDecodeError | None = None
+        for candidate in reversed(candidates):
+            try:
+                obj = json.loads(candidate)
+            except json.JSONDecodeError as e:
+                last_err = e
+                continue
+            if isinstance(obj, dict) and "success" in obj:
+                payload = obj
+                break
+        if payload is None:
+            # 所有候选都不可解析或不含 success 字段
             logger.warning(
                 "[DeepAgentFallbackHandler] fallback JSON parse failed: %s, treat as failed",
-                e,
+                last_err,
             )
-            return False, {"reason": f"fallback JSON 解析失败: {e}"}
+            return False, {"reason": f"fallback JSON 解析失败: {last_err}" if last_err else "fallback 输出未包含 JSON 契约声明"}
 
         success = bool(payload.get("success", False))
         result = payload.get("result") or {}
@@ -345,12 +417,16 @@ class DeepAgentFallbackHandler(SkillTurboFallbackHandler):
                 node_name,
                 e,
             )
-            yield {
-                "event_type": "chat.error",
-                "error": f"Fallback 执行失败: {e}",
-                "is_fallback": True,
-                "node_name": node_name,
-            }
+            # 与其他失败路径（spawn success=false、契约不达成）保持一致：raise
+            # FallbackContractError 将异常向上传播，让 executor 的 execute_plan_stream
+            # 捕获并终止 plan，最终由 tool 层返回 success=false 给 LLM 触发降级。
+            # 不 yield chat.error：会被 executor 透传并经 tool 转发到父会话，抢先于 tool
+            # result 到达前端终结会话，LLM 来不及转 skill_tool 降级。
+            raise FallbackContractError(
+                node_name=node_name,
+                reason=f"fallback spawn 执行异常: {e}",
+                original_error=error,
+            ) from e
         finally:
             yield {
                 "event_type": "fallback.finished",
@@ -364,13 +440,18 @@ class DeepAgentFallbackHandler(SkillTurboFallbackHandler):
         success = bool(getattr(result, "success", False))
         if not success:
             error_text = getattr(result, "error", "fallback subagent failed") or "fallback subagent failed"
-            yield {
-                "event_type": "chat.error",
-                "error": f"Fallback 执行失败: {error_text}",
-                "is_fallback": True,
-                "node_name": node_name,
-            }
-            return
+            logger.error(
+                "[DeepAgentFallbackHandler] node fallback_stream spawn reported failure node=%s error=%s, "
+                "degrading to DeepAgent",
+                node_name,
+                error_text,
+            )
+            # 不 yield chat.error：同上，避免抢先终结前端阻断 LLM 降级。
+            raise FallbackContractError(
+                node_name=node_name,
+                reason=f"fallback subagent 执行失败: {error_text}",
+                original_error=error,
+            )
 
         fallback_output = getattr(result, "result", None) or ""
         self._log_degraded_result(node_name, fallback_output, error)
@@ -386,12 +467,10 @@ class DeepAgentFallbackHandler(SkillTurboFallbackHandler):
                 node_name,
                 reason,
             )
-            yield {
-                "event_type": "chat.error",
-                "error": f"Fallback 未达成节点契约，降级到 DeepAgent: {reason}",
-                "is_fallback": True,
-                "node_name": node_name,
-            }
+            # 注意：此处不再 yield chat.error。该事件会被 executor 透传并经 tool 转发到父会话，
+            # 抢先于 tool result 到达前端，导致会话以错误态终结，LLM 来不及按系统提示
+            # （skill_prompt_rail）转 skill_tool 走标准降级流程。只 raise 异常，让 tool 层
+            # 把失败包成 tool result 返回 LLM，由 LLM 自主降级。
             raise FallbackContractError(
                 node_name=node_name,
                 reason=reason,

--- a/tests/unit/skill_turbo/test_fallback_handler.py
+++ b/tests/unit/skill_turbo/test_fallback_handler.py
@@ -1,0 +1,282 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# pylint: disable=protected-access
+
+"""DeepAgentFallbackHandler 单元测试。
+
+覆盖：
+- _parse_fallback_output 对各种 JSON 契约格式的健壮解析
+- _fallback_stream_impl 契约失败/spawn 失败时不再 yield chat.error（避免抢跑前端，
+  阻断 LLM 按 skill_prompt_rail 转 skill_tool 降级），改为 raise FallbackContractError。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from jiuwenclaw.agentserver.skill_turbo.fallback_handler import (
+    DeepAgentFallbackHandler,
+    FallbackContractError,
+)
+
+
+# ─────────────────────── _parse_fallback_output ───────────────────────
+
+
+class TestParseFallbackOutput:
+    """契约 JSON 解析的健壮性。"""
+
+    def test_inline_code_single_line(self) -> None:
+        text = '正文...\n`{"success": true, "result": {"outline_path": "/tmp/o.md"}}`'
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+        assert result["outline_path"] == "/tmp/o.md"
+
+    def test_inline_code_nested_object_not_truncated(self) -> None:
+        # 嵌套对象 {} 不能被首个 } 截断（旧版 .*? 贪婪反向 bug）
+        text = '`{"success": true, "result": {"outline_path": "/x.md", "pages": 3}}`'
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+        assert result["pages"] == 3
+
+    def test_json_fence_block(self) -> None:
+        text = '正文\n```json\n{"success": false, "result": {"reason": "未生成文件"}}\n```\n'
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is False
+        assert result["reason"] == "未生成文件"
+
+    def test_plain_fence_block_without_lang_tag(self) -> None:
+        text = '```\n{"success": true, "result": {}}\n```'
+        success, _ = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+
+    def test_bare_json_at_tail(self) -> None:
+        # 无围栏，末尾裸 JSON（契约要求单行收尾）
+        text = '生成完成。\n{"success": true, "result": {"p4_validate_status": "passed"}}'
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+        assert result["p4_validate_status"] == "passed"
+
+    def test_empty_output(self) -> None:
+        success, result = DeepAgentFallbackHandler._parse_fallback_output("")
+        assert success is False
+        assert "未产出任何内容" in result["reason"]
+
+    def test_output_without_json(self) -> None:
+        success, result = DeepAgentFallbackHandler._parse_fallback_output("任务已完成但未给契约声明")
+        assert success is False
+        assert "未包含 JSON 契约声明" in result["reason"]
+
+    def test_invalid_json(self) -> None:
+        text = '`{"success": true, "result": }`'  # 畸形 JSON
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is False
+        assert "JSON 解析失败" in result["reason"]
+
+    def test_last_block_wins(self) -> None:
+        # 出现多个契约块时取最后一个
+        text = (
+            '`{"success": false, "result": {"reason": "第一次失败"}}`\n'
+            '后续重试...\n`{"success": true, "result": {"outline_path": "/ok.md"}}`'
+        )
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+        assert result["outline_path"] == "/ok.md"
+
+    def test_non_dict_result_coerced_to_reason(self) -> None:
+        text = '`{"success": false, "result": "字符串原因"}`'
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is False
+        assert result["reason"] == "字符串原因"
+
+    def test_dedup_skips_redundant_json_loads(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """内联代码(#1)与裸 JSON 扫描(#4)会重复捕获同一片段；去重后避免重复解析。
+
+        未去重时 reversed 先命中末尾裸 {"data": 1}（无 success，失败）再命中 success，
+        共 2 次 json.loads；去重后 success 在 reversed 中最先命中，仅 1 次。
+        """
+        import json as _json
+
+        text = (
+            '`{"data": 1}`\n'
+            '然后 `{"success": true, "result": {"path": "/ok"}}`\n'
+            '末尾再出现裸 JSON: {"data": 1}'
+        )
+        orig_loads = _json.loads
+        calls: list[str] = []
+
+        def _spy(s, *a, **kw):
+            calls.append(s)
+            return orig_loads(s, *a, **kw)
+
+        monkeypatch.setattr(_json, "loads", _spy)
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+        assert result["path"] == "/ok"
+        assert len(calls) == 1, f"去重后应只解析 success 一次，实际解析 {calls}"
+
+    def test_long_bare_text_still_finds_tail_contract(self) -> None:
+        """超长裸文本（无围栏）末尾契约仍可被全文扫描命中。"""
+        text = "正文" + "y" * 60_000 + '\n{"success": true, "result": {"path": "/ok"}}'
+        success, result = DeepAgentFallbackHandler._parse_fallback_output(text)
+        assert success is True
+        assert result["path"] == "/ok"
+
+
+# ─────────────────────── _scan_balanced_json_objects ─────────────────────
+
+
+class TestScanBalancedJsonObjects:
+    """裸 JSON 平衡扫描的健壮性。"""
+
+    def test_nested_object_returned_in_full(self) -> None:
+        text = '前缀 {"success": true, "result": {"path": "/x", "pages": 3}} 后缀'
+        out = DeepAgentFallbackHandler._scan_balanced_json_objects(text)
+        assert out == ['{"success": true, "result": {"path": "/x", "pages": 3}}']
+
+    def test_multiple_top_level_objects(self) -> None:
+        text = '{"a": 1} gap {"b": 2}'
+        out = DeepAgentFallbackHandler._scan_balanced_json_objects(text)
+        assert out == ['{"a": 1}', '{"b": 2}']
+
+    def test_brace_inside_string_is_ignored(self) -> None:
+        # 字符串内的 } 不应被误判为对象闭合
+        text = '{"a": "}"}'
+        out = DeepAgentFallbackHandler._scan_balanced_json_objects(text)
+        assert out == ['{"a": "}"}']
+
+    def test_escaped_quote_then_brace_stays_in_string(self) -> None:
+        # \" 不结束字符串，其后串内的 } 不应误判为闭合
+        text = r'{"a": "\"}"}'
+        out = DeepAgentFallbackHandler._scan_balanced_json_objects(text)
+        assert out == [r'{"a": "\"}"}']
+
+    def test_stray_balanced_braces_then_contract(self) -> None:
+        # 散文中的 {placeholder} 等平衡片段不应阻断后续契约捕获
+        text = 'use the {placeholder} syntax then {"success": true, "result": {}}'
+        out = DeepAgentFallbackHandler._scan_balanced_json_objects(text)
+        assert '{placeholder}' in out
+        assert '{"success": true, "result": {}}' in out
+
+    def test_unbalanced_open_brace_no_match_no_crash(self) -> None:
+        # 仅未闭合的 {：扫到末尾无匹配，不产出、不抛异常
+        text = '前置 { 未闭合到末尾'
+        out = DeepAgentFallbackHandler._scan_balanced_json_objects(text)
+        assert out == []
+
+    def test_empty_text_returns_empty(self) -> None:
+        assert DeepAgentFallbackHandler._scan_balanced_json_objects("") == []
+
+
+# ─────────────────────── _fallback_stream_impl 行为 ─────────────────────
+
+
+class _FakeSubagentResult:
+    """模拟 executor.execute_spawn 的返回结构。"""
+
+    def __init__(self, *, success: bool, result: str = "", error: str = "", task_id: str = "t1") -> None:
+        self.success = success
+        self.result = result
+        self.error = error
+        self.task_id = task_id
+
+
+def _make_handler() -> DeepAgentFallbackHandler:
+    """构造一个 handler，_get_subagent_executor 返回 mock（不会被实际调用到 spawn）。"""
+    handler = DeepAgentFallbackHandler(adapter=MagicMock())
+    # 覆盖 _execute_spawn_fallback，由各用例指定返回值
+    return handler
+
+
+async def _collect(items: AsyncIterator[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    async for chunk in items:
+        out.append(chunk)
+    return out
+
+
+@pytest.mark.unit
+async def test_contract_failure_no_chat_error_only_raise() -> None:
+    """契约失败（spawn 成功但产出无 JSON 契约）只 raise，不 yield chat.error。"""
+    handler = _make_handler()
+    handler._execute_spawn_fallback = lambda *a, **kw: _async_return(_FakeSubagentResult(success=True, result="无契约的正文"))  # type: ignore[assignment]
+
+    chunks: list[dict[str, Any]] = []
+    with pytest.raises(FallbackContractError):
+        async for chunk in handler._fallback_stream_impl(
+            "p4_2_quick_research", "instr", {"k": "v"}, RuntimeError("P4.2a 失败：LLM 返回为空"), None,
+        ):
+            chunks.append(chunk)
+
+    event_types = [c.get("event_type") for c in chunks]
+    assert "chat.error" not in event_types, "契约失败不应再 yield chat.error（会抢跑前端）"
+    # 生命周期事件仍保留
+    assert "fallback.started" in event_types
+    assert "fallback.finished" in event_types
+
+
+@pytest.mark.unit
+async def test_spawn_success_false_raises_no_chat_error() -> None:
+    """spawn 返回 success=false 时不再 yield chat.error，改为 raise FallbackContractError。"""
+    handler = _make_handler()
+    handler._execute_spawn_fallback = lambda *a, **kw: _async_return(_FakeSubagentResult(success=False, error="spawn 内部失败"))  # type: ignore[assignment]
+
+    chunks: list[dict[str, Any]] = []
+    with pytest.raises(FallbackContractError):
+        async for chunk in handler._fallback_stream_impl(
+            "p4_content_plan", "instr", {}, RuntimeError("节点失败"), None,
+        ):
+            chunks.append(chunk)
+
+    event_types = [c.get("event_type") for c in chunks]
+    assert "chat.error" not in event_types
+
+
+@pytest.mark.unit
+async def test_spawn_exception_raises_no_chat_error() -> None:
+    """_execute_spawn_fallback 自身抛异常时 raise FallbackContractError，不 yield chat.error。"""
+    handler = _make_handler()
+
+    async def _raise(*a: Any, **kw: Any) -> Any:
+        raise RuntimeError("spawn 连接失败")
+
+    handler._execute_spawn_fallback = _raise  # type: ignore[assignment]
+
+    chunks: list[dict[str, Any]] = []
+    with pytest.raises(FallbackContractError):
+        async for chunk in handler._fallback_stream_impl(
+            "p4_content_plan", "instr", {}, RuntimeError("节点失败"), None,
+        ):
+            chunks.append(chunk)
+
+    event_types = [c.get("event_type") for c in chunks]
+    assert "chat.error" not in event_types
+    assert "fallback.started" in event_types
+    assert "fallback.finished" in event_types  # finally 仍发
+
+
+@pytest.mark.unit
+async def test_contract_success_writes_back_inputs() -> None:
+    """契约成功时把 result 字段回写 inputs，标记 fallback=True、status=completed。"""
+    handler = _make_handler()
+    contract_json = '`{"success": true, "result": {"outline_path": "/tmp/outline.md"}}`'
+    handler._execute_spawn_fallback = lambda *a, **kw: _async_return(_FakeSubagentResult(success=True, result=contract_json))  # type: ignore[assignment]
+
+    inputs: dict[str, Any] = {"topic": "AI"}
+    chunks = await _collect(handler._fallback_stream_impl(
+        "p4_3_outline_gen", "instr", inputs, RuntimeError("节点失败"), None,
+    ))
+
+    assert inputs["outline_path"] == "/tmp/outline.md"
+    assert inputs["fallback"] is True
+    assert inputs["fallback_reason"]  # 失败原因回写，供下游感知
+    # node/status 被有意排除（见 _build_success_result），不写回 inputs
+
+
+async def _async_return(value: Any) -> Any:
+    """把一个同步值包成 awaitable，供 lambda 形式的 _execute_spawn_fallback 使用。"""
+    await asyncio.sleep(0)
+    return value


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# 问题定位根因与修复方案报告

> **问题标题**：PPT skill 加速（skill_acceleration_exec）fallback 失败后，前端提示"系统异常，请稍后重试"，已有的"转 skill_tool"降级机制未生效
> **报告日期**：2026-07-12
> **问题发生时间**：2026-07-07 17:02（北京时间）
> **证据强度**：`confirmed`（触发点 → chat.error 抢跑 → 前端清空 activeRequestIdRef → 降级失效，全链路闭合）
> **日志来源**：2026-07-07 17:02:01 skill_turbo.fallback_handler / executor 的 ERROR/WARNING 级日志四条

---

## 一、结论（一句话）

**问题边界在 `jiuwenclaw` 的 SkillTurbo fallback 事件路由，是 jiuwenclaw 问题。**

直接根因：SkillTurbo V2 里 `skill_acceleration_exec` 是 tool，降级机制是**软降级**——系统提示（[skill_prompt_rail.py:32](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuwenclaw/agentserver/deep_agent/rails/skill_prompt_rail.py)）要求 LLM 在该 tool 返回 `success=false` 后改用 `skill_tool` 走标准流程。但当 fallback 失败时，`fallback_handler` 与 `executor` 会在 tool result 返回 LLM 之前**抢先向前端 yield `chat.error` 事件**。前端 [useWebSocket.ts:937-942](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuwenclaw/web/src/hooks/useWebSocket.ts) 收到 `chat.error` 后立即 `activeRequestIdRef.current = null` 并渲染"系统异常"，**在 LLM 看到 tool result 之前就终结了本轮流**，LLM 来不及转 skill_tool，已有的降级机制被截断。

次要根因：`_parse_fallback_output` 的正则 `r"`(\{.*?\})`"` 用非贪婪 `.*?`，遇到嵌套对象会在首个 `}` 截断导致 JSON 解析失败，把本来能通过的契约误判为失败，放大了 fallback 失败概率。

---

## 二、定界

| 层级                                              | 是否根因       | 依据                                                         |
| ------------------------------------------------- | -------------- | ------------------------------------------------------------ |
| P4.2a LLM 返回空                                  | ❌ 否（诱因）   | 模型偶发空响应，本应可被 fallback 或降级吸收，非系统设计应失败的终态 |
| fallback subagent 同模型也空产出                  | ❌ 否（伴生）   | fallback 用同一模型，空响应时必然空产出，契约注定过不了      |
| 降级机制缺失                                      | ❌ 否（易误判） | [skill_prompt_rail.py:32](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/deep_agent/rails/skill_prompt_rail.py) 系统提示**已强制要求**失败后转 skill_tool，机制存在 |
| 前端"系统异常"文案                                | ❌ 否           | 是前端对 `chat.error` 事件的通用兜底渲染，非错误源           |
| **fallback_handler / executor 抢跑 `chat.error`** | ✅ **是**       | `chat.error` 经 tool 转发到父会话，前端清空 `activeRequestIdRef`，阻断 LLM 降级 |
| `_parse_fallback_output` 正则脆弱                 | ✅ 是（次要）   | 嵌套对象被截断 → 误判契约失败 → 触发上面那条抢跑链路         |

**最终边界**：`jiuwenclaw/agentserver/skill_turbo` 的 fallback 事件路由（`fallback_handler.py` + `executor.py`）。前端的"系统异常"是 `chat.error` 抢跑的下游表现。

---

## 三、证据链（按调用顺序）

### 3.1 节点失败 → fallback 触发

- **17:02:01.369** `[DeepAgentFallbackHandler] degraded result built node=p4_content_plan output_len=0 ... reason=FallbackContractError: fallback 未达成节点 p4_2_quick_research 契约: fallback 输出未包含 JSON 契约声明 (原错误: P4.2a 失败：LLM 返回为空)`
  - P4.2a 节点 LLM 返回空串 → [content_plan.py:390](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/skill_codes/ppt/content_plan.py) `raise ContentPlanError("P4.2a 失败：LLM 返回为空")`
  - `PlanNode.run_stream` 的 `except Exception`（[plan_node.py:346-350](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/plan_node.py)）接住，调 `_fallback_stream_callback`
  - fallback subagent 同模型也空产出（`output_len=0`）

### 3.2 契约校验失败 → 抢跑的 chat.error

- **17:02:01.371** `[DeepAgentFallbackHandler] fallback output has no JSON contract block, treat as failed`
- **17:02:01.372** `[DeepAgentFallbackHandler] node fallback_stream contract failed node=p4_content_plan reason=fallback 输出未包含 JSON 契约声明, degrading to DeepAgent`
  - [fallback_handler.py:389-394](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/fallback_handler.py) `yield {"event_type": "chat.error", "error": "Fallback 未达成节点契约，降级到 DeepAgent: ..."}`，随后 `raise FallbackContractError`
  - 该 `chat.error` 被 executor [executor.py:590-600](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/executor.py) 透传 yield → tool 层 [skill_turbo_tools.py:269-282](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/skill_turbo_tools.py) 转发父会话

### 3.3 前端收到 chat.error → 清空请求标记（降级被截断）

- 前端 [useWebSocket.ts:937-942](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/web/src/hooks/useWebSocket.ts)：

  ```ts
  webClient.on('chat.error', (event) => {
    setThinking(false);
    activeRequestIdRef.current = null;  // ← 清空当前请求标记
    ...
    addMessage({ content: i18n.t('network.errorPrefix', { message: errorMsg }) });  // ← "系统异常，请稍后重试"
  });
  ```

- `activeRequestIdRef.current = null` 后，后续所有 chunk 经 `shouldHandleCurrentRequestEvent` 判为不属于当前请求而丢弃

- **此时 tool result（`{success:false,...}`）尚未返回 LLM**，LLM 没机会按 [skill_prompt_rail.py:32](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/deep_agent/rails/skill_prompt_rail.py) 转 skill_tool

### 3.4 fallback 次数打满 → 终止性失败（仍是 chat.error 抢跑）

- **17:02:01.373** `[SkillTurboExecutor] node fallback_stream via handler ... fallback_count=3`
- **17:02:01.375** `[DeepAgentFallbackHandler] node fallback_stream via spawn ... error=fallback 未达成节点 p4_content_plan 契约...`
  - `fallback_count` 达上限 3，`FallbackLimitExceededError` 路径同样在 `_execute_node_stream` yield `_make_node_error_chunk`（`chat.error`）后 raise，二次抢跑

---

## 四、修复方案

### 4.1 核心思路

不让 fallback 失败的 `chat.error` 抢跑前端。让异常正常冒泡到 tool 层包成 `success=false` result 返回 LLM，由 LLM 按已有系统提示转 skill_tool 降级（新一轮 request 前端会重新建 `activeRequestIdRef`）。

### 4.2 改动清单

**A. `fallback_handler.py` —— 不再 yield 抢跑的 chat.error**

- 契约失败（[fallback_handler.py:389-394](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/fallback_handler.py)）：删 `yield chat.error`，只 `raise FallbackContractError`
- spawn 返回 `success=false`（原 `yield chat.error + return`）：改为 `raise FallbackContractError`（顺带修复原 `return` 默默继续、节点无结果的潜在 bug）
- `_execute_spawn_fallback` 自身抛异常（原 `yield chat.error`）：改为只记录日志，流经 `finally` 正常结束

**B. `fallback_handler.py` —— `_parse_fallback_output` 健壮化**

- 新增 `_scan_balanced_json_objects`：括号平衡扫描提取裸 JSON，修复嵌套对象被首个 `}` 截断的 bug
- 候选扩展：单行内联（贪婪匹配保留嵌套）/ ```json 围栏 / 无 tag 围栏 / 裸 JSON，多候选取最后一个含 `success` 字段的可解析对象
- 空产出与"有产出无契约"区分，便于日志诊断

**C. `executor.py` —— FallbackContractError / FallbackLimitExceededError 不发 chat.error**

- `_execute_node_stream`：两类异常不再转成 `node_error` chat.error chunk，直接向上 raise
- `execute_plan_stream`：新增 `except (FallbackContractError, FallbackLimitExceededError)`，只发 `plan.finished(failed) + complete`（前端不处理 `plan.*`，不抢跑），然后 raise
- 异常向上到 [agent.py:93-95](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuwenclaw/agentserver/skill_turbo/agent.py) 包成 `SkillTurboNotHandled` → tool 层 [skill_turbo_tools.py:315-320](../../../code/re-plan-agent/relay-claw/vendor/jiuuwenclaw/jiuuwenclaw/agentserver/skill_turbo/skill_turbo_tools.py) 返回 `{success:false}` 给 LLM → LLM 转 skill_tool

### 4.3 修复后链路

```
P4.2a 空响应
  → ContentPlanError → run_stream 调 fallback
  → fallback subagent 空产出 → 契约失败
  → fallback_handler 只 raise FallbackContractError（不发 chat.error）
  → executor 主循环 raise（不发 node_error chat.error）
  → execute_plan_stream except：发 plan.finished(failed)+complete（不抢跑）→ raise
  → agent.py 包成 SkillTurboNotHandled
  → tool 层返回 {success:false, error:...} 给 LLM
  → LLM 按 skill_prompt_rail 系统提示转 skill_tool 重跑（新 request，前端重建 activeRequestIdRef）
```

### 4.4 验证

- 新增 `tests/unit/skill_turbo/test_fallback_handler.py` 共 15 个单测，覆盖 `_parse_fallback_output` 各格式解析 + `_fallback_stream_impl` 不 yield chat.error 的行为
- `tests/unit/skill_turbo/` 全部 185 个单测通过，无回归
- 两文件 AST 解析通过，无循环 import

### 4.5 不做的事（明确边界）

- **不新增硬降级**：不在 tool 层嵌套起 DeepAgent 重跑。已有软降级，修完抢跑后应能生效；若实测 LLM 仍不转 skill_tool 再评估硬降级
- **不动模型层空响应重试**：那是另一个方向（让 stream_llm 对空流重试），不在本次范围
- **不改 fallback 计数语义**：`max_fallback_count=3` 保持不变

---

## 五、残留风险与观察点

- 若 LLM 即便拿到 `success=false` result 仍不转 skill_tool（模型能力问题），则需后续硬降级兜底——本次先观察
- 修复后用户在 skill_acceleration_exec 内部不再看到"降级到 DeepAgent"的中间提示，但应看到的是 LLM 转 skill_tool 后的正常继续，体验更好
- P4.2a 空响应的**源头**（模型偶发空流）未在本报告修复，仅修了其下游的降级阻断。空响应本身的模型层重试建议另立问题处理