### PR TITLE
fix(vibeskill): 历史 replay 使用局部message上下文 ，不再替换实时实例字段

### DIFF
--- a/jiuwenclaw/channel/vibeskill_channel.py
+++ b/jiuwenclaw/channel/vibeskill_channel.py
@@ -379,6 +379,23 @@ class VibeSkillConfig:
         return http_p == ws_p
 
 
+class _TimelineReplayStore:
+    """No-op persistence boundary for history-only event conversion."""
+
+    async def append_file_ready_obs_url(self, session_id: str, url: str) -> None:
+        return None
+
+    async def set_state(
+        self,
+        session_id: str,
+        state: VibeSkillSessionState,
+    ) -> None:
+        return None
+
+    async def set_exportable(self, session_id: str, exportable: bool) -> None:
+        return None
+
+
 class VibeSkillChannel(BaseChannel):
     """VibeSkill Channel.
 
@@ -3769,12 +3786,14 @@ class VibeSkillChannel(BaseChannel):
         """
         messages: list[dict[str, Any]] = []
         pending_confirms: list[dict[str, Any]] = []
-        replay_ctx_backup = self._message_ctx
-        replay_pending_backup = self._pending_confirms
-        replay_detached_backup = self._detached_tool_parts
-        self._message_ctx = {}
-        self._pending_confirms = {}
-        self._detached_tool_parts = {}
+        # HTTP history replay may overlap a live WebSocket stream. Bind the
+        # existing event handlers to an isolated channel view so replay never
+        # swaps or mutates the live channel's aggregation/persistence state.
+        replay_channel = copy.copy(self)
+        replay_channel._message_ctx = {}
+        replay_channel._pending_confirms = {}
+        replay_channel._detached_tool_parts = {}
+        replay_channel._store = _TimelineReplayStore()
 
         # 需要 replay 的事件类型（使用流式处理器处理）
         replayable_event_keys = (
@@ -3790,7 +3809,7 @@ class VibeSkillChannel(BaseChannel):
             "skilldev.error",
             "skilldev.completed",
         )
-        all_handlers = self._get_skilldev_event_handlers()
+        all_handlers = replay_channel._get_skilldev_event_handlers()
         replayable_handlers = {
             key: handler
             for key, handler in all_handlers.items()
@@ -3815,7 +3834,7 @@ class VibeSkillChannel(BaseChannel):
                 role = "user" if source == "user" else "assistant"
 
                 if event_type in round_boundary_user_events:
-                    self._clear_message_context_for_session(session_id)
+                    replay_channel._clear_message_context_for_session(session_id)
 
                 # skilldev.agent_completed：Agent 单轮结束（Agent 模式专有）。
                 # 仅用于划分回合，不向客户端补发 session.status / 关 WS 等副作用。
@@ -4081,9 +4100,9 @@ class VibeSkillChannel(BaseChannel):
 
             return self._merge_message_update_events(messages)
         finally:
-            self._message_ctx = replay_ctx_backup
-            self._pending_confirms = replay_pending_backup
-            self._detached_tool_parts = replay_detached_backup
+            replay_channel._message_ctx.clear()
+            replay_channel._pending_confirms.clear()
+            replay_channel._detached_tool_parts.clear()
 
     async def http_handler(
         self,


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

**问题**
Skill 生成过程中偶现流式消息被拆分到异常的 messageID：正常 message.part.delta 之间插入新的 message.updated，后续 delta 又恢复使用原 messageID
根因：历史消息 replay 与实时 WebSocket 流并发时，_convert_timeline_to_messages 会临时替换 channel 实例上的 _message_ctx、_pending_confirms 和 _detached_tool_parts。实时 delta 如果在该窗口内到达，会被错误写入 replay 上下文并生成新的 messageID。

**修改内容**
为历史 replay 创建独立的 channel 状态视图。
replay 使用局部的：_message_ctx
_pending_confirms
_detached_tool_parts

不再临时替换或恢复实时 channel 实例字段，保持现有 timeline 事件转换逻辑和返回协议不变。