### PR TITLE
fix(installer): launch app through explorer after setup

### DIFF
--- a/scripts/installer.iss
+++ b/scripts/installer.iss
@@ -44,6 +44,6 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Run]
-; shellexec 让程序通过 ShellExecute 启动，正确处理 UAC 权限请求
+; 通过 Explorer 代启动程序，使安装完成后的启动上下文更接近桌面快捷方式启动
 ; postinstall 在安装向导最后一页显示"运行 JiuwenSwarm"复选框，由用户决定是否启动
-Filename: "{app}\{#MyAppExeName}"; Flags: nowait postinstall shellexec
+Filename: "{win}\explorer.exe"; Parameters: """{app}\{#MyAppExeName}"""; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [x] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [x] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [x] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

修改思路：

安装完成页勾选“启动 JiuwenSwarm”时，原来由 Inno Setup 直接启动 `{app}\jiuwenswarm.exe`。在管理员安装场景下，该启动链路可能继承安装器/UAC 上下文，与用户从桌面快捷方式启动的 Explorer shell 上下文不一致，进而影响 Windows 下 symlink/junction 的创建与访问行为。

本次调整不改变安装路径、权限模型和主程序 manifest，只调整安装完成后的启动方式：通过系统 Explorer 代为启动 JiuwenSwarm，使 postinstall 启动路径更接近用户双击快捷方式启动。

修改方案：

- 将 `[Run]` 中的启动目标从应用 exe 改为 `{win}\explorer.exe`。
- 通过 `Parameters` 传入实际应用路径：`"{app}\{#MyAppExeName}"`。
- 增加 `Description`，确保安装完成页仍显示“启动 JiuwenSwarm”，而不是显示“启动 explorer”。
- 保留 `nowait postinstall` flags。