### PR TITLE
fix:修复权限 resume 后 QA freeze 未落盘导致下一轮 orphan salvage / system-only LLM

### DIFF
--- a/jiuwenclaw/agentserver/deep_agent/rails/qa_block_freeze_rail.py
+++ b/jiuwenclaw/agentserver/deep_agent/rails/qa_block_freeze_rail.py
@@ -15,10 +15,12 @@ from openjiuwen.core.context_engine.qa_block.registry import load_registry
 from openjiuwen.core.context_engine.qa_block.selector import resolve_summarizer_model
 from openjiuwen.core.context_engine.qa_block.store import QABlockStore
 from openjiuwen.core.session.interaction.interactive_input import InteractiveInput
+from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, InvokeInputs
 from openjiuwen.harness.rails.base import DeepAgentRail
 
 from jiuwenclaw.agentserver.deep_agent.plan_pause_helpers import (
+    post_agent_execute_for_session,
     resolve_actual_session,
     resolve_context_engine,
 )
@@ -130,6 +132,17 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
             native_messages=native_messages,
         )
 
+    async def _persist_freeze_checkpoint(self, session: Any, *, session_id: str) -> None:
+        """Flush registry after freeze; inner ReAct post_run may have checkpointed early."""
+        try:
+            await post_agent_execute_for_session(session)
+        except Exception as exc:
+            logger.warning(
+                "[QABlockFreezeRail] freeze checkpoint flush failed session_id=%s: %s",
+                session_id,
+                exc,
+            )
+
     def _on_freeze_commit(self, session: Any, context: Any, commit: FreezeCommitResult) -> None:
         try:
             loop = asyncio.get_running_loop()
@@ -204,6 +217,7 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
         if entry is not None:
             clear_assembly_committed_qa_id(actual_session)
             await context_engine.save_contexts(actual_session)
+            await self._persist_freeze_checkpoint(actual_session, session_id=session_id)
             logger.info(
                 "[QABlockFreezeRail] cancel sync freeze done session_id=%s qa_id=%s status=%s",
                 session_id,
@@ -242,12 +256,20 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
             logger.info("[QABlockFreezeRail] skip freeze for ask_user_question interrupt session_id=%s", session_id)
             return
 
-        # 弹窗确认恢复请求，未产生最终结果前不卸载QA
-        # 避免恢复失败时把第一请求保留的上下文也冻掉
+        # 弹窗确认恢复：仅当仍处于中断时跳过 freeze。
+        # stream 外层 result 常为 None，不能再据此 skip，否则成功收尾会留下孤儿 QA。
+        # invoke 看 result_type=interrupt；stream 以 session INTERRUPTION_KEY 为准。
         if isinstance(ctx.inputs, InvokeInputs) and isinstance(ctx.inputs.query, InteractiveInput):
             result = getattr(ctx.inputs, "result", None)
-            if result is None or (isinstance(result, dict) and result.get("result_type") == "interrupt"):
-                logger.info("[QABlockFreezeRail] skip freeze for popup confirmation resume session_id=%s", session_id)
+            still_interrupted = (
+                (isinstance(result, dict) and result.get("result_type") == "interrupt")
+                or bool(session.get_state(INTERRUPTION_KEY))
+            )
+            if still_interrupted:
+                logger.info(
+                    "[QABlockFreezeRail] skip freeze for popup confirmation resume session_id=%s",
+                    session_id,
+                )
                 return
 
         workspace_root = ""
@@ -280,6 +302,7 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
         clear_assembly_committed_qa_id(session)
         ctx.extra[_FREEZE_DONE_KEY] = entry.qa_id
         await context_engine.save_contexts(session)
+        await self._persist_freeze_checkpoint(session, session_id=session_id)
         logger.info(
             "[QABlockFreezeRail] freeze committed session_id=%s qa_id=%s status=%s persist=%s",
             session_id,

--- a/tests/unit_tests/agentserver/test_qa_block_freeze_rail.py
+++ b/tests/unit_tests/agentserver/test_qa_block_freeze_rail.py
@@ -9,10 +9,13 @@ import pathlib
 import unittest
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from openjiuwen.core.context_engine.qa_block.freezer import FreezeCommitResult
 from openjiuwen.core.context_engine.qa_block.schema import QABlockEntry
+from openjiuwen.core.session.interaction.interactive_input import InteractiveInput
+from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
+from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, InvokeInputs
 
 _MODULE_PATH = (
     pathlib.Path(__file__).resolve().parents[3]
@@ -41,6 +44,33 @@ async def _schedule_freeze_artifact_produce_async(rail: Any, **kwargs: Any) -> N
 
 def _on_freeze_commit(rail: Any, session: Any, context: Any, commit: FreezeCommitResult) -> None:
     getattr(rail, "_on_freeze_commit")(session, context, commit)
+
+
+def _make_interactive_freeze_ctx(
+    *, interruption: Any = None
+) -> tuple[AgentCallbackContext, Any, Any]:
+    state = {INTERRUPTION_KEY: interruption} if interruption is not None else {}
+
+    def get_state(key: str, default: Any = None) -> Any:
+        return state.get(key, default)
+
+    session = SimpleNamespace(
+        get_session_id=lambda: "session-1",
+        get_state=get_state,
+    )
+    context = MagicMock()
+    context.context_id.return_value = "ctx-1"
+    context_engine = MagicMock()
+    context_engine.get_context.return_value = context
+    context_engine.get_history_qa_buffer.return_value = []
+    context_engine.save_contexts = AsyncMock()
+    agent = SimpleNamespace()
+    ctx = AgentCallbackContext(
+        agent=agent,
+        inputs=InvokeInputs(query=InteractiveInput()),
+        session=session,
+    )
+    return ctx, context_engine, session
 
 
 class TestQABlockFreezeRailProduceSchedule(unittest.IsolatedAsyncioTestCase):
@@ -120,6 +150,49 @@ class TestQABlockFreezeRailProduceSchedule(unittest.IsolatedAsyncioTestCase):
         with patch.object(asyncio, "get_running_loop", side_effect=RuntimeError):
             _on_freeze_commit(self.rail, object(), MagicMock(), commit)
         self.mgr.schedule_freeze_artifact_produce.assert_not_called()
+
+
+class TestQABlockFreezeRailInteractiveResume(unittest.IsolatedAsyncioTestCase):
+    """InteractiveInput resume: freeze only when interruption is settled."""
+
+    def setUp(self) -> None:
+        self.rail = JiuClawQABlockFreezeRail()
+        self.rail.workspace = SimpleNamespace(root_path="/tmp/ws")
+        self.freeze_mock = AsyncMock(return_value=_make_commit().entry)
+        self.rail._freezer = SimpleNamespace(freeze=self.freeze_mock)
+        self.rail._maybe_await_overview_before_freeze = AsyncMock()
+
+    async def test_interactive_resume_with_none_result_freezes_when_no_interrupt(self) -> None:
+        ctx, context_engine, _session = _make_interactive_freeze_ctx()
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "clear_assembly_committed_qa_id"), patch.object(
+            _module, "QABlockStore", return_value=MagicMock()
+        ), patch.object(_module, "post_agent_execute_for_session", new_callable=AsyncMock):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_awaited_once()
+
+    async def test_interactive_resume_skips_when_session_still_interrupted(self) -> None:
+        ctx, context_engine, _session = _make_interactive_freeze_ctx(
+            interruption=SimpleNamespace(original_query="paused"),
+        )
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "QABlockStore", return_value=MagicMock()):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_not_awaited()
+
+    async def test_interactive_resume_skips_when_result_type_interrupt(self) -> None:
+        ctx, context_engine, _session = _make_interactive_freeze_ctx()
+        ctx.inputs.result = {"result_type": "interrupt", "interrupt_ids": ["id-1"]}
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "QABlockStore", return_value=MagicMock()):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_not_awaited()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

fix: 修复权限 resume 后 QA freeze 未落盘导致下一轮 orphan salvage / system-only LLM

权限弹窗 resume 走 single-round stream 时，ReAct 会先 post_run 落盘
（仍带 current_qa_id），外层 freeze 只更新内存；Runner 二次 post_run
因 _post_run_done 被跳过，checkpoint 残留脏指针。下一轮普通消息误触发
orphan salvage，strip 掉新用户消息后出现 roles={'system'} / 81001。

变更：
1. InteractiveInput resume 仅在仍有中断时 skip freeze（成功收尾必须冻）
2. freeze 成功后 post_agent_execute，把 current_qa_id=None 刷进 checkpoint

验证结果：包含权限审批的长任务后再次请求不会出现报错
![image.png](https://raw.gitcode.com/user-images/assets/9297832/6201d8ee-3576-41d8-b3f6-b936eaa099fd/image.png 'image.png')
![image.png](https://raw.gitcode.com/user-images/assets/9297832/32de1fa4-9e27-4081-97d9-c5b415bd7ed4/image.png 'image.png')