### PR TITLE
fix(web): Model validation falsely fails for local Ollama models

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -2124,8 +2124,16 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
         # tokens into reasoning_content while leaving content empty.  Treat a
         # non-empty reasoning_content as a valid response as well.
         reasoning_content = getattr(resp, "reasoning_content", None) if hasattr(resp, "reasoning_content") else None
-        has_valid_response = (isinstance(content, str) and content) or (
-                isinstance(reasoning_content, str) and reasoning_content
+        # Some backends report thinking in a field the client does not map at
+        # all (e.g. Ollama's "reasoning"), leaving both content and
+        # reasoning_content empty.  Generated-token usage still proves the
+        # endpoint, credentials, and model name are all valid.
+        usage = getattr(resp, "usage_metadata", None)
+        output_tokens = usage.get("output_tokens") if isinstance(usage, dict) else getattr(usage, "output_tokens", None)
+        has_valid_response = (
+            (isinstance(content, str) and content)
+            or (isinstance(reasoning_content, str) and reasoning_content)
+            or (isinstance(output_tokens, (int, float)) and output_tokens > 0)
         )
         if not has_valid_response:
             await channel.send_response(


### PR DESCRIPTION
Paired: [GitHub #373](https://github.com/openJiuwen-ai/jiuwenswarm/pull/373) ↔ [GitCode !3800](https://gitcode.com/openJiuwen/jiuwenswarm/pull/3800)

# fix(web): Model validation falsely fails for local Ollama models

## Problem

The **Test** button in the config page (`config.validate_model`) reported **"configuration not working"** for thinking models served by local Ollama (e.g. `qwen3.6:27b` at `http://localhost:11434/v1`), even though the configuration was valid and the model worked fine in normal chat.

Root cause: the probe sends a "Hi" message and accepts the response only if it contains visible `content` or `reasoning_content`. Ollama reports thinking output in a **`reasoning`** field that the openjiuwen OpenAI client does not map, so both `content` and `reasoning_content` come back empty and the probe wrongly concludes the model is broken. No token budget could fix this — the data is dropped at the client layer before the handler sees it.

## Changes

Backend (`app_web_handlers.py`):

- Accept `usage_metadata.output_tokens > 0` as a valid probe result. If the model provably generated tokens, the endpoint, credentials, and model name are all valid — regardless of which field the backend used for the output. This is robust to field naming and fixes Ollama on the first probe.

Deliberately minimal: the probe timeout, retry logic, and request budget are unchanged. (An earlier revision also normalized provider casing and surfaced the backend error in the frontend toast; the casing fix has since landed on `develop` independently, and the toast change was dropped to keep user-facing error messages clean.)

## Testing

- `pytest tests/unit_tests/gateway/`: 350 passed (3 failures are pre-existing local-environment issues unrelated to this change — an openjiuwen version skew and `git init.defaultBranch`-dependent tests — reproduced identically on the unmodified tree).
- End-to-end against real Ollama (`qwen3.6:27b`): valid config → passes in ~5s (previously always failed); wrong model name → fails immediately.

## Root cause (fixed upstream)

The underlying reason `content`/`reasoning_content` come back empty is that the openjiuwen OpenAI client only maps DeepSeek-style `reasoning_content` and drops Ollama's `reasoning` field — which also hides thinking output in normal chat. That root cause is fixed separately in **openJiuwen-ai/agent-core#74**.

This PR is still worth landing on its own: the `output_tokens > 0` criterion validates connectivity by generated-token usage rather than by a specific response field, so it stays correct regardless of field naming and independent of the upstream fix.