### PR TITLE
feat: 支持请求级多 MCP server 注册，实现 per-request 工具隔离与自动清理

### DIFF
--- a/jiuwenclaw/agentserver/interface.py
+++ b/jiuwenclaw/agentserver/interface.py
@@ -1238,68 +1238,67 @@ class JiuWenClaw:
             inputs["memory_block"] = memory_block
 
         async def run_agent_task():
-            # 注册 Office Claw MCP（请求级环境变量）
-            office_claw_mcp = request.params.get("office_claw_mcp")
-            if isinstance(office_claw_mcp, dict):
+            mcp_payload = self._extract_request_mcp_payload(request)
+            if mcp_payload:
                 try:
-                    await self._get_tool_manager().register_request_scoped_office_claw_mcp(office_claw_mcp)
+                    await self._get_tool_manager().register_request_scoped_mcp(
+                        mcp_payload, request_id=request.request_id
+                    )
                 except Exception as exc:
-                    logger.warning("[JiuWenClaw] office_claw_mcp 注册失败: %s", exc, extra={'user_visible': 'progress'})
+                    logger.warning("[JiuWenClaw] request_mcp_servers 注册失败: %s", exc, extra={'user_visible': 'progress'})
             return await adapter.process_message_impl(request, inputs)
 
-        result = await self._session_manager.submit_and_wait(session_id, run_agent_task)
+        try:
+            result = await self._session_manager.submit_and_wait(session_id, run_agent_task)
 
-        if result.ok and result.payload.get("content"):
-            content = result.payload["content"]
-            content_str = content if isinstance(content, str) else str(content)
-            # 记录Agent回答到日志
-            logger.info(
-                "[JiuWenClaw] Agent回答: %s",
-                _truncate_for_log(content_str),
-                extra={'user_visible': 'critical'}
-            )
-            append_history_record(
-                session_id=session_id,
-                request_id=request.request_id,
-                channel_id=request.channel_id,
-                role="assistant",
-                event_type="chat.final",
-                content=content_str,
-                timestamp=time.time(),
-                mode=request.params.get("mode", "unknown"),
-                sessions_root=self._sessions_dir,
-            )
-
-            # cloud memory: after chat hook
-            if memory_mode == "cloud":
-                after_ctx = MemoryHookContext(
-                    session_id=request.session_id or "default",
-                    request_id=request.request_id or "",
-                    channel_id=request.channel_id,
-                    agent_name="main_agent",
-                    workspace_dir=str(get_agent_home_dir()),
-                    assistant_message=content_str,
-                    extra=request.params,
+            if result.ok and result.payload.get("content"):
+                content = result.payload["content"]
+                content_str = content if isinstance(content, str) else str(content)
+                logger.info(
+                    "[JiuWenClaw] Agent回答: %s",
+                    _truncate_for_log(content_str),
+                    extra={'user_visible': 'critical'}
                 )
-                await ExtensionRegistry.get_instance().trigger(AgentServerHookEvents.MEMORY_AFTER_CHAT, after_ctx)
+                append_history_record(
+                    session_id=session_id,
+                    request_id=request.request_id,
+                    channel_id=request.channel_id,
+                    role="assistant",
+                    event_type="chat.final",
+                    content=content_str,
+                    timestamp=time.time(),
+                    mode=request.params.get("mode", "unknown"),
+                    sessions_root=self._sessions_dir,
+                )
 
-        # 文件后处理：上传 Agent 生成的输出文件到对象存储
-        if result.ok:
-            # 从 session_id 或 metadata 中提取用户 ID
-            user_id = request.session_id or "default"
-            if request.metadata and isinstance(request.metadata, dict):
-                user_id = request.metadata.get("user_id", user_id)
+                if memory_mode == "cloud":
+                    after_ctx = MemoryHookContext(
+                        session_id=request.session_id or "default",
+                        request_id=request.request_id or "",
+                        channel_id=request.channel_id,
+                        agent_name="main_agent",
+                        workspace_dir=str(get_agent_home_dir()),
+                        assistant_message=content_str,
+                        extra=request.params,
+                    )
+                    await ExtensionRegistry.get_instance().trigger(AgentServerHookEvents.MEMORY_AFTER_CHAT, after_ctx)
 
-            # 统一提取 chat_id 和 channel_type
-            cleaned_chat_id, channel_type = self._extract_chat_id(request)
+            if result.ok:
+                user_id = request.session_id or "default"
+                if request.metadata and isinstance(request.metadata, dict):
+                    user_id = request.metadata.get("user_id", user_id)
 
-            logger.info(
-                f"[JiuWenClaw] 开始上传文件: request_id={request.request_id} "
-                f"files_count={len(result.payload.get('files'))} user_id={user_id} chat_id={cleaned_chat_id}",
-                extra={'user_visible': 'critical'}
-            )
-            await self.upload_agent_files(result, user_id, cleaned_chat_id, channel_type)
-        return result
+                cleaned_chat_id, channel_type = self._extract_chat_id(request)
+
+                logger.info(
+                    f"[JiuWenClaw] 开始上传文件: request_id={request.request_id} "
+                    f"files_count={len(result.payload.get('files'))} user_id={user_id} chat_id={cleaned_chat_id}",
+                    extra={'user_visible': 'critical'}
+                )
+                await self.upload_agent_files(result, user_id, cleaned_chat_id, channel_type)
+            return result
+        finally:
+            await self._cleanup_request_scoped_mcp(request.request_id)
 
     async def process_message_stream(
             self, request: AgentRequest
@@ -1457,17 +1456,18 @@ class JiuWenClaw:
 
             async def run_stream_task():
                 try:
-                    # 注册 Office Claw MCP（请求级环境变量）
-                    office_claw_mcp = request.params.get("office_claw_mcp")
-                    if isinstance(office_claw_mcp, dict):
+                    mcp_payload = self._extract_request_mcp_payload(request)
+                    if mcp_payload:
                         try:
-                            await self._get_tool_manager().register_request_scoped_office_claw_mcp(office_claw_mcp)
-                        except Exception as exc:
-                            logger.error(
-                                f"[JiuWenClaw] office_claw_mcp注册失败: request_id={request.request_id} error={str(exc)}",
-                                extra={'user_visible': 'critical'}
+                            await self._get_tool_manager().register_request_scoped_mcp(
+                                mcp_payload, request_id=request.request_id
                             )
-                            logger.warning("[JiuWenClaw] office_claw_mcp 注册失败: %s", exc)
+                        except Exception as exc:
+                            logger.warning(
+                                "[JiuWenClaw] request_mcp_servers 注册失败: request_id=%s error=%s",
+                                request.request_id, exc,
+                                extra={'user_visible': 'progress'},
+                            )
                     async for chunk in adapter.process_message_stream_impl(request, inputs):
                         await stream_queue.put(("chunk", chunk))
                 except asyncio.CancelledError:
@@ -1713,7 +1713,29 @@ class JiuWenClaw:
 
         finally:
             self._release_inflight_stream()
+            await self._cleanup_request_scoped_mcp(request.request_id)
             await self._try_apply_adapter_pending_reload()
+
+    @staticmethod
+    def _extract_request_mcp_payload(request) -> dict | None:
+        payload = request.params.get("request_mcp_servers")
+        servers = payload.get("mcpServers") if isinstance(payload, dict) else None
+        if isinstance(servers, dict) and servers:
+            return payload
+        legacy = request.params.get("office_claw_mcp")
+        if isinstance(legacy, dict):
+            from jiuwenclaw.agentserver.tool_manager import _OFFICE_CLAW_SERVER_NAME_PREFIX
+            return {"mcpServers": {_OFFICE_CLAW_SERVER_NAME_PREFIX: legacy}}
+        return None
+
+    async def _cleanup_request_scoped_mcp(self, request_id: str) -> None:
+        tm = self._tool_manager
+        if tm is None:
+            return
+        try:
+            await tm.unregister_request_scoped_mcp(request_id)
+        except Exception:
+            logger.exception("[JiuWenClaw] request-scoped MCP 清理失败: %s", request_id)
 
     async def _try_apply_adapter_pending_reload(self) -> None:
         """Apply adapter deferred config reload at a harness-idle boundary."""
@@ -1791,6 +1813,11 @@ class JiuWenClaw:
                 logger.warning("[JiuWenClaw] Adapter cleanup failed: %s", e)
             self._adapter = None
 
+        if self._tool_manager is not None:
+            try:
+                await self._tool_manager.unregister_all_request_scoped_mcp()
+            except Exception as e:
+                logger.warning("[JiuWenClaw] request-scoped MCP 兜底清理失败: %s", e)
         self._tool_manager = None
 
         logger.info("[JiuWenClaw] cleanup: 完成")

--- a/jiuwenclaw/agentserver/tool_manager.py
+++ b/jiuwenclaw/agentserver/tool_manager.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import copy
+import ipaddress
 import json
 import os
 import re
@@ -12,6 +15,7 @@ import sys
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 from openjiuwen.core.foundation.tool import ToolCard
 from openjiuwen.core.runner import Runner
@@ -26,10 +30,8 @@ from jiuwenclaw.agentserver.tools.ephemeral_stdio_mcp_tool import (
 from jiuwenclaw.agentserver.tools.mcp_toolkits import _normalize_stdio_command_kind, create_mcp_tool
 
 _OFFICE_CLAW_SERVER_NAME_PREFIX = "office-claw"
-_REQUEST_SCOPED_OFFICE_CLAW_SERVER_ID = "office-claw-request"
 
-# 请求级 stdio 参数：每个异步上下文独立，避免并发请求间配置串台
-_OFFICE_CLAW_STDIO_PARAMS: ContextVar[dict[str, Any]] = ContextVar("_OFFICE_CLAW_STDIO_PARAMS", default={})
+_REQUEST_STDIO_PARAMS: ContextVar[dict[str, dict[str, Any]] | None] = ContextVar("_REQUEST_STDIO_PARAMS", default=None)
 
 
 # ── 安全拦截规则 ──
@@ -56,9 +58,108 @@ def _check_mcp_security(tool_name: str, cfg: dict) -> None:
         )
 
 
-def _get_office_claw_stdio_params() -> dict[str, Any]:
-    """回调函数：供 EphemeralStdioMcpTool 在 invoke 时获取当前请求级的 stdio 参数。"""
-    return _OFFICE_CLAW_STDIO_PARAMS.get()
+_REQUEST_REMOTE_BLOCKED_HOSTS = frozenset({
+    "localhost",
+    "metadata.google.internal",
+    "metadata",
+    "metadata.azure.com",
+})
+
+_REQUEST_REMOTE_METADATA_HOSTS = frozenset({
+    "metadata.google.internal",
+    "metadata",
+    "metadata.azure.com",
+})
+
+
+def _loopback_mcp_allowed() -> bool:
+    return (os.getenv("JIUWENCLAW_ALLOW_LOOPBACK_MCP") or "").strip().lower() in ("1", "true", "yes")
+
+
+def _is_blocked_host(host: str) -> bool:
+    """判断 host 是否指向内网/环回/元数据地址（SSRF 防护）。"""
+    if not host:
+        return False
+    host = host.lower().strip()
+    allow_loopback = _loopback_mcp_allowed()
+    if allow_loopback and host == "localhost":
+        return False
+    if host in _REQUEST_REMOTE_METADATA_HOSTS:
+        return True
+    if not allow_loopback and host in _REQUEST_REMOTE_BLOCKED_HOSTS:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    if allow_loopback and ip.is_loopback:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _validate_request_scoped_remote_mcp(tool_name: str, cfg: dict) -> None:
+    """请求级 sse/streamable-http MCP 安全校验。
+
+    安全边界（评审结论）：
+    - url 不做域名白名单（业务需要连接任意合法外网 MCP 端点），但拦截内网/环回/
+      元数据地址，缓解 SSRF
+    - auth_headers / auth_query_params 的字符串值做同样的内网/元数据地址黑名单，
+      防止被用作重定向入口
+    - 不拦截字段本身（sse/http 功能必需 url 与 auth）
+    - JIUWENCLAW_ALLOW_LOOPBACK_MCP=1 时放行 loopback/localhost（仅开发测试用，
+      metadata 地址仍拦截，private/link_local 仍拦截）
+    """
+    if not isinstance(cfg, dict):
+        return
+    if _loopback_mcp_allowed():
+        logger.warning(
+            "[ToolManager][WARN] JIUWENCLAW_ALLOW_LOOPBACK_MCP 已启用，"
+            "loopback/localhost 地址放行（仅开发测试用，生产环境勿设此变量）"
+        )
+    url = cfg.get("url")
+    if isinstance(url, str) and url:
+        try:
+            host = urlparse(url).hostname or ""
+        except Exception:
+            host = ""
+        if _is_blocked_host(host):
+            raise ValueError(
+                f"安全拦截阻断：请求级 sse/http MCP ({tool_name!r}) 的 url 指向"
+                f"内网/元数据地址 ({host})，疑似 SSRF 攻击。"
+            )
+    for field in ("auth_headers", "auth_query_params"):
+        val = cfg.get(field)
+        if not isinstance(val, dict):
+            continue
+        for k, v in val.items():
+            if not isinstance(v, str):
+                continue
+            # 值可能是完整 URL（含 host）或裸 host/IP
+            try:
+                host = (urlparse(v).hostname or "") if "://" in v else v.strip()
+            except Exception:
+                host = v.strip()
+            if _is_blocked_host(host):
+                raise ValueError(
+                    f"安全拦截阻断：请求级 sse/http MCP ({tool_name!r}) 的 "
+                    f"{field}[{k!r}] 值指向内网/元数据地址，疑似凭证外泄/SSRF。"
+                )
+
+
+def _make_stdio_params_getter(server_name: str) -> Callable[[], dict[str, Any]]:
+    def _get() -> dict[str, Any]:
+        params_map = _REQUEST_STDIO_PARAMS.get()
+        if params_map is None:
+            return {}
+        return params_map.get(server_name, {})
+    return _get
 
 
 def _trusted_cat_cafe_stdio_roots() -> list[Path]:
@@ -340,8 +441,8 @@ class ToolManager:
         """
         self._get_agent = get_agent
         self._get_tools_dir = get_tools_dir
-        # (tool_id, tool_name)，请求级 Office Claw stdio 走 ephemeral 注册时用于下次替换前卸载
-        self._office_claw_ephemeral_tools: list[tuple[str, str]] = []
+        self._request_registrations: dict[str, list[dict[str, Any]]] = {}
+        self._request_registrations_lock = asyncio.Lock()
 
     def _resolve_tools_dir(self) -> Path:
         if self._get_tools_dir is not None:
@@ -500,97 +601,184 @@ class ToolManager:
             "errors": errors,
         }
 
-    async def register_request_scoped_office_claw_mcp(self, cfg: dict[str, Any]) -> dict[str, Any]:
-        """按请求注册 Office Claw MCP；stdio 工具以单次 invoke 模式执行。"""
-        if not isinstance(cfg, dict):
-            raise ValueError("office_claw_mcp 必须是对象")
+    async def register_request_scoped_mcp(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise ValueError("request_mcp_servers 必须是对象")
+
+        servers = payload.get("mcpServers")
+        if not isinstance(servers, dict) or not servers:
+            raise ValueError("缺少有效的 mcpServers 对象")
 
         agent = self._get_agent() if self._get_agent else None
         if agent is None:
             raise RuntimeError("JiuWenClaw 未初始化，请先调用 create_instance()")
 
-        mcp_servers = getattr(agent.ability_manager, "_mcp_servers", {})
-        names_to_remove = [
-            name for name in mcp_servers
-            if isinstance(name, str) and name.startswith(_OFFICE_CLAW_SERVER_NAME_PREFIX)
-        ]
-        for server_name in names_to_remove:
-            get_server_ids = getattr(Runner.resource_mgr, "get_mcp_server_ids", None)
-            server_ids = list(get_server_ids(server_name) or []) if callable(get_server_ids) else []
-            for server_id in server_ids:
+        registered: list[dict[str, str]] = []
+
+        for tool_name, cfg in servers.items():
+            if not isinstance(tool_name, str) or not tool_name.strip():
+                raise ValueError(f"非法的工具名: {tool_name!r}")
+            if not isinstance(cfg, dict):
+                raise ValueError(f"mcpServers[{tool_name!r}] 必须是对象")
+
+            record = {"name": tool_name, **cfg}
+            single_json = json.dumps(record, ensure_ascii=False)
+            mcp_cfg = create_mcp_tool(single_json)
+            server_name = mcp_cfg.server_name
+            request_scoped_server_id = f"{server_name}::{request_id}"
+
+            if getattr(mcp_cfg, "client_type", "") == "stdio":
                 try:
-                    await Runner.resource_mgr.remove_tool_server(server_id, ignore_not_exist=True)
-                except Exception as exc:
-                    logger.warning("[ToolManager] 移除旧的 Office Claw MCP 失败 name=%s id=%s: %s",
-                        server_name, server_id, exc)
-            agent.ability_manager.remove(server_name)
+                    _validate_cat_cafe_request_scoped_stdio(mcp_cfg.params or {})
+                except ValueError as exc:
+                    raise RuntimeError(str(exc)) from exc
 
-        record = {
-            "name": _OFFICE_CLAW_SERVER_NAME_PREFIX,
-            "server_id": _REQUEST_SCOPED_OFFICE_CLAW_SERVER_ID,
-            **cfg,
-        }
-        single_json = json.dumps(record, ensure_ascii=False)
-        mcp_cfg = create_mcp_tool(single_json)
+                stdio_sp = stdio_params_from_mcp_config(mcp_cfg.params or {})
+                params_map = dict(_REQUEST_STDIO_PARAMS.get() or {})
+                params_map[server_name] = stdio_sp
+                _REQUEST_STDIO_PARAMS.set(params_map)
 
-        # stdio：不经过 add_mcp_server，每工具每次 invoke 单独起停子进程，避免会话间状态串台
-        if getattr(mcp_cfg, "client_type", "") == "stdio":
-            try:
-                _validate_cat_cafe_request_scoped_stdio(mcp_cfg.params or {})
-            except ValueError as exc:
-                raise RuntimeError(str(exc)) from exc
-            stdio_sp = stdio_params_from_mcp_config(mcp_cfg.params or {})
-            _OFFICE_CLAW_STDIO_PARAMS.set(stdio_sp)
-
-            if not self._office_claw_ephemeral_tools:
                 try:
                     tool_defs = await list_stdio_mcp_tool_defs(mcp_cfg.params or {})
                 except Exception as exc:
-                    raise RuntimeError(f"列举 Office Claw stdio MCP 工具失败: {exc}") from exc
+                    raise RuntimeError(f"列举 stdio MCP 工具失败: {exc}") from exc
+
+                tool_ids: list[str] = []
+                tool_names: list[str] = []
+                getter = _make_stdio_params_getter(server_name)
                 for td in tool_defs:
                     tname = td["name"]
-                    tool_id = f"{mcp_cfg.server_id}.{mcp_cfg.server_name}.{tname}"
+                    tool_id = f"{request_scoped_server_id}.{server_name}.{tname}"
                     card = ToolCard(
                         id=tool_id,
                         name=tname,
                         description=td.get("description") or "",
                         input_params=td.get("input_params") or {},
                     )
-                    ephemeral = EphemeralStdioMcpTool(card, _get_office_claw_stdio_params)
-                    add_res = Runner.resource_mgr.add_tool(ephemeral, tag=mcp_cfg.server_name)
+                    ephemeral = EphemeralStdioMcpTool(card, getter)
+                    add_res = Runner.resource_mgr.add_tool(ephemeral, tag=server_name)
                     if add_res is not None and hasattr(add_res, "is_ok") and not add_res.is_ok():
                         err = _mcp_add_result_error_text(add_res)
                         if "already exist" not in err.lower():
-                            raise RuntimeError(f"注册 ephemeral Office Claw 工具失败 {tname}: {err}")
-                        logger.info(
-                            "[ToolManager] ephemeral Office Claw 工具已存在，复用现有资源 tool=%s id=%s err=%s",
-                            tname,
-                            tool_id,
-                            err,
-                        )
+                            raise RuntimeError(f"注册 ephemeral 工具失败 {tname}: {err}")
                     agent.ability_manager.add(card)
-                    self._office_claw_ephemeral_tools.append((tool_id, tname))
+                    tool_ids.append(tool_id)
+                    tool_names.append(tname)
+
+                reg = {
+                    "kind": "stdio",
+                    "server_name": server_name,
+                    "server_id": request_scoped_server_id,
+                    "tool_ids": tool_ids,
+                    "tool_names": tool_names,
+                }
+                async with self._request_registrations_lock:
+                    self._request_registrations.setdefault(request_id, []).append(reg)
+                registered.append({"name": server_name, "server_id": request_scoped_server_id, "kind": "stdio"})
                 logger.info(
-                    "[ToolManager] 已注册请求级 Office Claw MCP（stdio 每调用隔离）name=%s id=%s tools=%s",
-                    mcp_cfg.server_name,
-                    mcp_cfg.server_id,
-                    [t[1] for t in self._office_claw_ephemeral_tools],
+                    "[ToolManager] 已注册请求级 MCP（stdio）request_id=%s name=%s tools=%s",
+                    request_id, server_name, tool_names,
                 )
             else:
+                try:
+                    _validate_request_scoped_remote_mcp(tool_name, cfg)
+                except ValueError as exc:
+                    raise RuntimeError(str(exc)) from exc
+                mcp_cfg = copy.copy(mcp_cfg)
+                mcp_cfg.server_id = request_scoped_server_id
                 logger.info(
-                    "[ToolManager] 已有 ephemeral Office Claw 工具，仅更新 stdio 参数 tools=%s",
-                    [t[1] for t in self._office_claw_ephemeral_tools],
+                    "[ToolManager][AUDIT] 请求级 MCP 注册 request_id=%s kind=%s name=%s "
+                    "url=%s has_auth=%s",
+                    request_id, mcp_cfg.client_type, server_name,
+                    cfg.get("url", ""),
+                    bool(cfg.get("auth_headers") or cfg.get("auth_query_params")),
                 )
-            return {
-                "registered": True,
-                "name": mcp_cfg.server_name,
-                "server_id": mcp_cfg.server_id,
-            }
+                await _add_mcp_server_and_ability(agent, mcp_cfg, tag=server_name)
+                reg = {
+                    "kind": "shared",
+                    "server_name": server_name,
+                    "server_id": request_scoped_server_id,
+                }
+                async with self._request_registrations_lock:
+                    self._request_registrations.setdefault(request_id, []).append(reg)
+                registered.append({
+                    "name": server_name,
+                    "server_id": request_scoped_server_id,
+                    "kind": mcp_cfg.client_type,
+                })
+                logger.info(
+                    "[ToolManager] 已注册请求级 MCP（%s）request_id=%s name=%s",
+                    mcp_cfg.client_type, request_id, server_name,
+                )
 
-        await _add_mcp_server_and_ability(agent, mcp_cfg, tag=mcp_cfg.server_name)
-        logger.info("[ToolManager] 已注册请求级 Office Claw MCP name=%s id=%s", mcp_cfg.server_name, mcp_cfg.server_id)
         return {
             "registered": True,
-            "name": mcp_cfg.server_name,
-            "server_id": mcp_cfg.server_id,
+            "request_id": request_id,
+            "tools": registered,
         }
+
+    async def unregister_request_scoped_mcp(self, request_id: str) -> None:
+        async with self._request_registrations_lock:
+            registrations = self._request_registrations.pop(request_id, None)
+        if not registrations:
+            return
+
+        agent = self._get_agent() if self._get_agent else None
+        has_stdio = False
+
+        for reg in registrations:
+            try:
+                if reg.get("kind") == "stdio":
+                    has_stdio = True
+                    for tool_id in reg.get("tool_ids", []):
+                        try:
+                            Runner.resource_mgr.remove_tool(tool_id)
+                        except Exception as exc:
+                            logger.warning("[ToolManager] remove_tool 失败 tool_id=%s: %s", tool_id, exc)
+                    if agent is not None:
+                        for tool_name in reg.get("tool_names", []):
+                            try:
+                                agent.ability_manager.remove(tool_name)
+                            except Exception as exc:
+                                logger.warning("[ToolManager] ability_manager.remove 失败 name=%s: %s", tool_name, exc)
+                elif reg.get("kind") == "shared":
+                    server_id = reg.get("server_id")
+                    if server_id:
+                        try:
+                            await Runner.resource_mgr.remove_mcp_server(
+                                server_id=server_id,
+                                tag=reg.get("server_name"),
+                                ignore_exception=True,
+                            )
+                        except Exception as exc:
+                            logger.warning("[ToolManager] remove_mcp_server 失败 server_id=%s: %s", server_id, exc)
+                    if agent is not None:
+                        server_name = reg.get("server_name")
+                        if server_name:
+                            try:
+                                agent.ability_manager.remove(server_name)
+                            except Exception as exc:
+                                logger.warning("[ToolManager] ability_manager.remove 失败 name=%s: %s", server_name, exc)
+                logger.info(
+                    "[ToolManager] 已清理请求级 MCP request_id=%s kind=%s name=%s",
+                    request_id, reg.get("kind"), reg.get("server_name"),
+                )
+            except Exception as exc:
+                logger.warning("[ToolManager] 清理请求级 MCP 失败 request_id=%s: %s", request_id, exc)
+
+        if has_stdio:
+            _REQUEST_STDIO_PARAMS.set(None)
+
+    async def unregister_all_request_scoped_mcp(self) -> None:
+        request_ids = list(self._request_registrations.keys())
+        for request_id in request_ids:
+            try:
+                await self.unregister_request_scoped_mcp(request_id)
+            except Exception as exc:
+                logger.warning("[ToolManager] 兜底清理失败 request_id=%s: %s", request_id, exc)
+
+    async def register_request_scoped_office_claw_mcp(self, cfg: dict[str, Any]) -> dict[str, Any]:
+        from uuid import uuid4
+        request_id = f"legacy_office_claw_{uuid4().hex[:12]}"
+        payload = {"mcpServers": {_OFFICE_CLAW_SERVER_NAME_PREFIX: cfg}}
+        return await self.register_request_scoped_mcp(payload, request_id=request_id)

--- a/jiuwenclaw/agentserver/tools/mcp_toolkits.py
+++ b/jiuwenclaw/agentserver/tools/mcp_toolkits.py
@@ -8,6 +8,12 @@ from pathlib import Path
 
 from openjiuwen.core.foundation.tool import Tool, McpServerConfig
 
+# 显式导入 MCP 客户端模块，触发 __init_subclass__ 自动注册到客户端注册表
+# 必须在 create_mcp_tool 被调用前完成
+from openjiuwen.core.foundation.tool.mcp.client import sse_client as _sse_client  # noqa: F401
+from openjiuwen.core.foundation.tool.mcp.client import stdio_client as _stdio_client  # noqa: F401
+from openjiuwen.core.foundation.tool.mcp.client import streamable_http_client as _streamable_http_client  # noqa: F401
+
 from jiuwenclaw.agentserver.tools.command_tools import mcp_exec_command
 from jiuwenclaw.agentserver.tools.web_fetch_tools import mcp_fetch_webpage
 from jiuwenclaw.agentserver.tools.web_search import web_search

--- a/tests/unit_tests/agentserver/test_request_scoped_mcp.py
+++ b/tests/unit_tests/agentserver/test_request_scoped_mcp.py
@@ -1,0 +1,429 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from contextvars import ContextVar
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jiuwenclaw.agentserver.tool_manager import (
+    ToolManager,
+    _make_stdio_params_getter,
+    _REQUEST_STDIO_PARAMS,
+    _validate_request_scoped_remote_mcp,
+)
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock()
+    agent.ability_manager = MagicMock()
+    agent.ability_manager.add = MagicMock()
+    agent.ability_manager.remove = MagicMock()
+    agent.ability_manager._mcp_servers = {}
+    return agent
+
+
+@pytest.fixture
+def tool_manager(mock_agent):
+    tm = ToolManager(get_agent=lambda: mock_agent)
+    return tm
+
+
+class TestRequestStdioParamsContextVar:
+    def test_default_is_none(self):
+        assert _REQUEST_STDIO_PARAMS.get() is None
+
+    def test_set_and_get_single_server(self):
+        _REQUEST_STDIO_PARAMS.set({"email": {"command": "node", "args": ["a.js"]}})
+        getter = _make_stdio_params_getter("email")
+        assert getter() == {"command": "node", "args": ["a.js"]}
+        _REQUEST_STDIO_PARAMS.set(None)
+
+    def test_missing_server_returns_empty(self):
+        _REQUEST_STDIO_PARAMS.set({"email": {"command": "node"}})
+        getter = _make_stdio_params_getter("cloud_docs")
+        assert getter() == {}
+        _REQUEST_STDIO_PARAMS.set(None)
+
+    def test_multiple_servers(self):
+        params_map = {
+            "email": {"command": "node", "args": ["email.js"]},
+            "cloud_docs": {"command": "python", "args": ["-m", "cloud"]},
+        }
+        _REQUEST_STDIO_PARAMS.set(params_map)
+        assert _make_stdio_params_getter("email")() == {"command": "node", "args": ["email.js"]}
+        assert _make_stdio_params_getter("cloud_docs")() == {"command": "python", "args": ["-m", "cloud"]}
+        _REQUEST_STDIO_PARAMS.set(None)
+
+    def test_concurrent_tasks_isolated(self):
+        results = {}
+
+        async def main():
+            async def task_a():
+                _REQUEST_STDIO_PARAMS.set({"email": {"command": "node_a"}})
+                await asyncio.sleep(0.01)
+                results["a"] = _make_stdio_params_getter("email")()
+
+            async def task_b():
+                _REQUEST_STDIO_PARAMS.set({"email": {"command": "node_b"}})
+                await asyncio.sleep(0.01)
+                results["b"] = _make_stdio_params_getter("email")()
+
+            await asyncio.gather(task_a(), task_b())
+
+        asyncio.run(main())
+        assert results["a"] == {"command": "node_a"}
+        assert results["b"] == {"command": "node_b"}
+        _REQUEST_STDIO_PARAMS.set(None)
+
+
+class TestRegistrationTracking:
+    def test_init_has_empty_registrations(self, tool_manager):
+        assert tool_manager._request_registrations == {}
+
+    def test_unregister_nonexistent_is_noop(self, tool_manager):
+        asyncio.run(tool_manager.unregister_request_scoped_mcp("nonexistent"))
+        assert tool_manager._request_registrations == {}
+
+    def test_unregister_removes_stdio_tools(self, tool_manager, mock_agent):
+        tool_manager._request_registrations["req_A"] = [
+            {
+                "kind": "stdio",
+                "server_name": "email",
+                "server_id": "email::req_A",
+                "tool_ids": ["email::req_A.email.send", "email::req_A.email.read"],
+                "tool_names": ["send", "read"],
+            }
+        ]
+
+        with patch("jiuwenclaw.agentserver.tool_manager.Runner") as mock_runner:
+            mock_runner.resource_mgr.remove_tool = MagicMock()
+            asyncio.run(tool_manager.unregister_request_scoped_mcp("req_A"))
+
+        assert "req_A" not in tool_manager._request_registrations
+        assert mock_runner.resource_mgr.remove_tool.call_count == 2
+        assert mock_agent.ability_manager.remove.call_count == 2
+
+    def test_unregister_multiple_requests(self, tool_manager, mock_agent):
+        tool_manager._request_registrations["req_A"] = [
+            {"kind": "stdio", "server_name": "email", "tool_ids": ["t1"], "tool_names": ["n1"]}
+        ]
+        tool_manager._request_registrations["req_B"] = [
+            {"kind": "stdio", "server_name": "docs", "tool_ids": ["t2"], "tool_names": ["n2"]}
+        ]
+
+        with patch("jiuwenclaw.agentserver.tool_manager.Runner") as mock_runner:
+            mock_runner.resource_mgr.remove_tool = MagicMock()
+            asyncio.run(tool_manager.unregister_request_scoped_mcp("req_A"))
+
+        assert "req_A" not in tool_manager._request_registrations
+        assert "req_B" in tool_manager._request_registrations
+
+    def test_unregister_all(self, tool_manager):
+        tool_manager._request_registrations["req_A"] = [
+            {"kind": "stdio", "server_name": "email", "tool_ids": [], "tool_names": []}
+        ]
+        tool_manager._request_registrations["req_B"] = [
+            {"kind": "stdio", "server_name": "docs", "tool_ids": [], "tool_names": []}
+        ]
+
+        with patch("jiuwenclaw.agentserver.tool_manager.Runner") as mock_runner:
+            mock_runner.resource_mgr.remove_tool = MagicMock()
+            asyncio.run(tool_manager.unregister_all_request_scoped_mcp())
+
+        assert tool_manager._request_registrations == {}
+
+    def test_unregister_handles_remove_tool_error(self, tool_manager, mock_agent):
+        tool_manager._request_registrations["req_A"] = [
+            {"kind": "stdio", "server_name": "email", "tool_ids": ["t1"], "tool_names": ["n1"]}
+        ]
+
+        with patch("jiuwenclaw.agentserver.tool_manager.Runner") as mock_runner:
+            mock_runner.resource_mgr.remove_tool = MagicMock(side_effect=Exception("boom"))
+            asyncio.run(tool_manager.unregister_request_scoped_mcp("req_A"))
+
+        assert "req_A" not in tool_manager._request_registrations
+
+    def test_unregister_removes_shared_mcp_server(self, tool_manager, mock_agent):
+        tool_manager._request_registrations["req_A"] = [
+            {
+                "kind": "shared",
+                "server_name": "remote_api",
+                "server_id": "remote_api::req_A",
+            }
+        ]
+
+        with patch("jiuwenclaw.agentserver.tool_manager.Runner") as mock_runner:
+            mock_runner.resource_mgr.remove_mcp_server = AsyncMock()
+            asyncio.run(tool_manager.unregister_request_scoped_mcp("req_A"))
+
+        assert "req_A" not in tool_manager._request_registrations
+        mock_runner.resource_mgr.remove_mcp_server.assert_called_once_with(
+            server_id="remote_api::req_A",
+            tag="remote_api",
+            ignore_exception=True,
+        )
+        mock_agent.ability_manager.remove.assert_called_once_with("remote_api")
+
+    def test_unregister_mixed_stdio_and_shared(self, tool_manager, mock_agent):
+        tool_manager._request_registrations["req_A"] = [
+            {
+                "kind": "stdio",
+                "server_name": "local_tool",
+                "server_id": "local_tool::req_A",
+                "tool_ids": ["t1"],
+                "tool_names": ["n1"],
+            },
+            {
+                "kind": "shared",
+                "server_name": "remote_api",
+                "server_id": "remote_api::req_A",
+            },
+        ]
+
+        with patch("jiuwenclaw.agentserver.tool_manager.Runner") as mock_runner:
+            mock_runner.resource_mgr.remove_tool = MagicMock()
+            mock_runner.resource_mgr.remove_mcp_server = AsyncMock()
+            asyncio.run(tool_manager.unregister_request_scoped_mcp("req_A"))
+
+        assert "req_A" not in tool_manager._request_registrations
+        mock_runner.resource_mgr.remove_tool.assert_called_once_with("t1")
+        mock_runner.resource_mgr.remove_mcp_server.assert_called_once()
+        assert mock_agent.ability_manager.remove.call_count == 2
+
+    def test_shared_mcp_cfg_copied_not_mutated(self, tool_manager, mock_agent):
+        """shared 分支拷贝 mcp_cfg 后改 server_id 不污染原对象（防御未来缓存）"""
+        from jiuwenclaw.agentserver.tools.mcp_toolkits import create_mcp_tool
+
+        shared_cfg_str = json.dumps({
+            "name": "test-sse",
+            "type": "sse",
+            "url": "https://mcp.example.com/sse",
+        })
+        shared_mcp_cfg = create_mcp_tool(shared_cfg_str)
+        original_server_id = shared_mcp_cfg.server_id
+
+        captured_cfgs: list = []
+
+        async def fake_add(agent, cfg, *, tag):
+            captured_cfgs.append(cfg)
+
+        with patch("jiuwenclaw.agentserver.tool_manager.create_mcp_tool", return_value=shared_mcp_cfg), \
+             patch("jiuwenclaw.agentserver.tool_manager._add_mcp_server_and_ability", new=fake_add):
+            asyncio.run(tool_manager.register_request_scoped_mcp(
+                {"mcpServers": {"test-sse": {"type": "sse", "url": "https://mcp.example.com/sse"}}},
+                request_id="req_A",
+            ))
+            asyncio.run(tool_manager.register_request_scoped_mcp(
+                {"mcpServers": {"test-sse": {"type": "sse", "url": "https://mcp.example.com/sse"}}},
+                request_id="req_B",
+            ))
+
+        assert shared_mcp_cfg.server_id == original_server_id
+        assert captured_cfgs[0].server_id == "test-sse::req_A"
+        assert captured_cfgs[1].server_id == "test-sse::req_B"
+        assert captured_cfgs[0] is not shared_mcp_cfg
+        assert captured_cfgs[1] is not shared_mcp_cfg
+        assert captured_cfgs[0] is not captured_cfgs[1]
+
+
+class TestExtractRequestMcpPayload:
+    def _make_request(self, params: dict):
+        req = MagicMock()
+        req.params = params
+        return req
+
+    def test_new_param_takes_priority(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({
+            "request_mcp_servers": {"mcpServers": {"email": {"command": "node"}}},
+            "office_claw_mcp": {"command": "old"},
+        })
+        payload = jc._extract_request_mcp_payload(req)
+        assert "email" in payload["mcpServers"]
+
+    def test_legacy_office_claw_mcp_wrapped(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({
+            "office_claw_mcp": {"command": "node", "args": ["email.js"]},
+        })
+        payload = jc._extract_request_mcp_payload(req)
+        assert payload == {"mcpServers": {"office-claw": {"command": "node", "args": ["email.js"]}}}
+
+    def test_no_mcp_params_returns_none(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({"query": "hello"})
+        assert jc._extract_request_mcp_payload(req) is None
+
+    def test_empty_mcp_servers_returns_none(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({"request_mcp_servers": {"mcpServers": {}}})
+        assert jc._extract_request_mcp_payload(req) is None
+
+    def test_non_dict_mcp_servers_returns_none(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({"request_mcp_servers": "not a dict"})
+        assert jc._extract_request_mcp_payload(req) is None
+
+    def test_mcp_servers_string_returns_none(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({"request_mcp_servers": {"mcpServers": "not a dict"}})
+        assert jc._extract_request_mcp_payload(req) is None
+
+    def test_mcp_servers_list_returns_none(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        req = self._make_request({"request_mcp_servers": {"mcpServers": ["a", "b"]}})
+        assert jc._extract_request_mcp_payload(req) is None
+
+
+class TestDeprecatedWrapper:
+    def test_office_claw_wrapper_delegates(self, tool_manager):
+        with patch.object(tool_manager, "register_request_scoped_mcp", new_callable=AsyncMock) as mock_reg:
+            mock_reg.return_value = {"registered": True}
+            asyncio.run(tool_manager.register_request_scoped_office_claw_mcp(
+                {"command": "node", "args": ["email.js"]}
+            ))
+        assert mock_reg.called
+        call_kwargs = mock_reg.call_args
+        payload = call_kwargs[0][0]
+        assert "office-claw" in payload["mcpServers"]
+        assert payload["mcpServers"]["office-claw"]["command"] == "node"
+        request_id = call_kwargs[1]["request_id"]
+        assert request_id.startswith("legacy_office_claw_")
+
+    def test_legacy_wrapper_request_id_unique_under_concurrency(self, tool_manager):
+        seen_ids: list[str] = []
+
+        async def capture(payload, *, request_id):
+            seen_ids.append(request_id)
+            return {"registered": True}
+
+        tool_manager.register_request_scoped_mcp = capture
+
+        async def run():
+            await asyncio.gather(*[
+                tool_manager.register_request_scoped_office_claw_mcp({"command": "node"})
+                for _ in range(100)
+            ])
+
+        asyncio.run(run())
+        assert len(seen_ids) == 100
+        assert len(set(seen_ids)) == 100
+
+
+class TestCleanupRequestScopedMcp:
+    def test_cleanup_delegates_to_tool_manager(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        mock_tm = MagicMock()
+        mock_tm.unregister_request_scoped_mcp = AsyncMock()
+        jc._tool_manager = mock_tm
+
+        asyncio.run(jc._cleanup_request_scoped_mcp("req_123"))
+        mock_tm.unregister_request_scoped_mcp.assert_awaited_once_with("req_123")
+
+    def test_cleanup_noop_when_tool_manager_is_none(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        jc._tool_manager = None
+        asyncio.run(jc._cleanup_request_scoped_mcp("req_123"))
+
+    def test_cleanup_catches_exceptions(self):
+        from jiuwenclaw.agentserver.interface import JiuWenClaw
+        jc = JiuWenClaw.__new__(JiuWenClaw)
+        mock_tm = MagicMock()
+        mock_tm.unregister_request_scoped_mcp = AsyncMock(side_effect=Exception("boom"))
+        jc._tool_manager = mock_tm
+        asyncio.run(jc._cleanup_request_scoped_mcp("req_123"))
+
+
+class TestValidateRequestScopedRemoteMcp:
+    def test_external_url_allowed(self):
+        _validate_request_scoped_remote_mcp("ok", {"url": "https://mcp.example.com/sse"})
+
+    def test_loopback_ipv4_blocked(self):
+        for host in ("127.0.0.1", "127.1.2.3"):
+            with pytest.raises(ValueError, match="SSRF"):
+                _validate_request_scoped_remote_mcp("t", {"url": f"http://{host}/sse"})
+
+    def test_metadata_endpoint_blocked(self):
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://169.254.169.254/latest/meta-data/"})
+
+    def test_private_network_blocked(self):
+        for host in ("10.0.0.1", "192.168.1.1", "172.16.0.1"):
+            with pytest.raises(ValueError, match="SSRF"):
+                _validate_request_scoped_remote_mcp("t", {"url": f"http://{host}/mcp"})
+
+    def test_localhost_blocked(self):
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://localhost:8080/sse"})
+
+    def test_unspecified_address_blocked(self):
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://0.0.0.0/mcp"})
+
+    def test_ipv6_loopback_blocked(self):
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://[::1]/mcp"})
+
+    def test_no_url_allowed(self):
+        _validate_request_scoped_remote_mcp("t", {"type": "sse"})
+
+    def test_non_dict_cfg_noop(self):
+        _validate_request_scoped_remote_mcp("t", "not-a-dict")
+
+    def test_auth_headers_value_blocked(self):
+        with pytest.raises(ValueError, match="凭证外泄"):
+            _validate_request_scoped_remote_mcp("t", {
+                "url": "https://mcp.example.com/sse",
+                "auth_headers": {"X-Redirect": "http://169.254.169.254/"},
+            })
+
+    def test_auth_query_params_value_blocked(self):
+        with pytest.raises(ValueError, match="凭证外泄"):
+            _validate_request_scoped_remote_mcp("t", {
+                "url": "https://mcp.example.com/mcp",
+                "auth_query_params": {"target": "127.0.0.1"},
+            })
+
+    def test_auth_headers_external_value_allowed(self):
+        _validate_request_scoped_remote_mcp("t", {
+            "url": "https://mcp.example.com/sse",
+            "auth_headers": {"Authorization": "Bearer valid-token"},
+            "auth_query_params": {"token": "abc123"},
+        })
+
+    def test_loopback_allowed_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("JIUWENCLAW_ALLOW_LOOPBACK_MCP", "1")
+        _validate_request_scoped_remote_mcp("t", {"url": "http://127.0.0.1:9999/sse"})
+        _validate_request_scoped_remote_mcp("t", {"url": "http://localhost:8080/mcp"})
+        _validate_request_scoped_remote_mcp("t", {"url": "http://[::1]/mcp"})
+
+    def test_metadata_still_blocked_when_loopback_allowed(self, monkeypatch):
+        monkeypatch.setenv("JIUWENCLAW_ALLOW_LOOPBACK_MCP", "1")
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://169.254.169.254/meta-data/"})
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://metadata.google.internal/"})
+
+    def test_private_still_blocked_when_loopback_allowed(self, monkeypatch):
+        monkeypatch.setenv("JIUWENCLAW_ALLOW_LOOPBACK_MCP", "1")
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://10.0.0.1/sse"})
+        with pytest.raises(ValueError, match="SSRF"):
+            _validate_request_scoped_remote_mcp("t", {"url": "http://192.168.1.1/mcp"})


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# 请求级 MCP 工具注册

## 功能概述

请求级 MCP 工具注册允许用户在发起请求时通过 `request_mcp_servers` 参数指定需要使用的 MCP 工具（如邮箱、云文档、云空间等）。系统按请求隔离注册这些工具，请求完成后自动清理。

支持三种传输类型：
- **stdio**：请求级隔离（per-invoke 子进程 + 请求唯一 ID + per-request ContextVar）
- **sse**：请求级隔离（独立连接 + headers 认证）
- **streamable-http**：请求级隔离（独立连接 + headers 认证）

## 设计背景

### 旧实现的问题

系统原先仅支持 `office_claw_mcp` 单 server 请求级注册，存在以下瓶颈：

| # | 问题 | 后果 |
|---|---|---|
| B1 | 固定 `server_id = "office-claw-request"` | 并发请求撞 ID |
| B2 | `_office_claw_ephemeral_tools` 列表全局累积 | 请求完成后 Tool 不删除，靠下次注册时"先移除旧的"兜底 |
| B3 | 单 ContextVar `_OFFICE_CLAW_STDIO_PARAMS` 只存一个 server 的参数 | 一次请求只能挂一个 stdio MCP server |
| B4 | 无 finally 清理 | 请求结束后 MCP 工具不删除 |
| B5 | 不支持 sse/streamable-http 的请求级隔离 | 无法为不同请求携带不同认证的远程 MCP |

### 关键观察

`ability_manager` 是 per-agent-instance（per-session）的，天然按 session 隔离。全局共享的只有 `Runner.resource_mgr` 的三个字典。因此隔离策略 = **唯一 ID（避免全局字典撞键）+ ContextVar（避免 stdio 参数串台）+ per-session ability_manager（控制可见性）+ finally 清理（回收全局字典条目）**。

## 设计目标

1. 请求内可携带**多个** MCP server 配置
2. stdio MCP：请求级隔离（per-invoke 子进程 + 请求唯一 ID + per-request ContextVar）
3. sse/streamable-http MCP：请求级隔离（独立连接 + headers 认证）
4. 请求完成后，所有类型工具从 `Runner.resource_mgr` + `ability_manager` 删除
5. 并发安全：多请求并发注册/调用/清理互不干扰
6. `office_claw_mcp` 收编为新机制的特例（向后兼容）

## 整体架构

```
┌──────────────── AgentServer 进程（JiuWenClaw Facade）────────────────┐
│                                                                       │
│  process_message[_stream](request)                                   │
│    │ params["request_mcp_servers"] = {"mcpServers": {name: cfg}}     │
│    │                                                                   │
│    ├─ run_agent_task / run_stream_task 内:                            │
│    │    ToolManager.register_request_scoped_mcp(payload, request_id)  │
│    │      ├─ stdio ─→ EphemeralStdioMcpTool × N                      │
│    │      │   ├─ server_id = f"{name}::{request_id}"  (唯一)          │
│    │      │   ├─ _REQUEST_STDIO_PARAMS ContextVar[name→params]        │
│    │      │   ├─ Runner.resource_mgr.add_tool(ephemeral, tag=...)     │
│    │      │   ├─ agent.ability_manager.add(card)                      │
│    │      │   └─ 记录到 _request_registrations[request_id]            │
│    │      │                                                           │
│    │      ├─ sse ─→ _add_mcp_server_and_ability (独立连接)           │
│    │      │   ├─ server_id = f"{name}::{request_id}"  (唯一)          │
│    │      │   ├─ auth_headers 从 cfg 透传                             │
│    │      │   ├─ Runner.resource_mgr.add_mcp_server(cfg, tag=...)     │
│    │      │   ├─ agent.ability_manager.add(mcp_cfg)                   │
│    │      │   └─ 记录到 _request_registrations[request_id]            │
│    │      │                                                           │
│    │      └─ streamable-http ─→ 同 sse 路径                           │
│    │                                                                   │
│    └─ finally:                                                        │
│         await ToolManager.unregister_request_scoped_mcp(request_id)   │
│           ├─ stdio: remove_tool(id) × N + ability_manager.remove × N  │
│           └─ sse/http: remove_mcp_server(id) + ability_manager.remove │
│                                                                       │
│  Runner.resource_mgr (进程单例)                                        │
│    _tools[ "email::req_A.email.send", "docs::req_B.read", ... ]      │
└───────────────────────────────────────────────────────────────────────┘
```

## 详细设计

### 1. 请求参数

新增 `request_mcp_servers`，结构复用 `handle_tools_add` 的 `mcp_json` 约定：

```jsonc
{
  "query": "...",
  "mode": "agent.plan",
  "request_mcp_servers": {
    "mcpServers": {
      "email": {
        "command": "node",
        "args": ["/trusted/root/email-mcp/index.js"],
        "env": { "IMAP_HOST": "..." },
        "cwd": "/trusted/root"
      },
      "cloud_docs": {
        "command": "python",
        "args": ["-m", "cloud_docs_mcp"],
        "cwd": "/trusted/root"
      },
      "remote_api": {
        "type": "sse",
        "url": "http://mcp-server.example.com/sse",
        "auth_headers": {
          "Authorization": "Bearer eyJhbGciOi..."
        }
      },
      "remote_http": {
        "type": "streamableHttp",
        "url": "http://mcp-server.example.com/mcp",
        "auth_headers": {
          "X-API-Key": "xxx"
        },
        "auth_query_params": {
          "token": "yyy"
        }
      }
    }
  }
}
```

**向后兼容**：旧参数 `office_claw_mcp`（单 server dict）在 Facade 层由 `_extract_request_mcp_payload` 自动包装为 `{"mcpServers": {"office-claw": <cfg>}}`。

### 2. 注册流程

`ToolManager.register_request_scoped_mcp(payload, *, request_id)` 遍历 `mcpServers` 中每个 server：

```python
for tool_name, cfg in servers.items():
    mcp_cfg = create_mcp_tool(json.dumps({"name": tool_name, **cfg}))
    server_name = mcp_cfg.server_name
    request_scoped_server_id = f"{server_name}::{request_id}"

    if mcp_cfg.client_type == "stdio":
        # 安全校验 → ContextVar 设置 → 枚举工具定义 → 逐个注册 EphemeralStdioMcpTool
        ...
    elif mcp_cfg.client_type in ("sse", "streamableHttp"):
        # 安全校验（SSRF 防护）→ 拷贝后改 server_id → 独立连接，透传 auth_headers
        _validate_request_scoped_remote_mcp(tool_name, cfg)
        mcp_cfg = copy.copy(mcp_cfg)
        mcp_cfg.server_id = request_scoped_server_id
        await _add_mcp_server_and_ability(agent, mcp_cfg, tag=server_name)
        # 在 asyncio.Lock 内追加到 _request_registrations 供清理
        ...
```

#### 2.1 stdio 请求级隔离

**a) 多 server ContextVar**

```python
_REQUEST_STDIO_PARAMS: ContextVar[dict[str, dict[str, Any]] | None] = ContextVar(
    "_REQUEST_STDIO_PARAMS", default=None
)
```

注册时构造 `params_map = {server_name: stdio_params, ...}` 并 set。每个 `EphemeralStdioMcpTool` 持有闭包按 `server_name` 取参数：

```python
def _make_stdio_params_getter(server_name: str) -> Callable[[], dict]:
    def _get():
        params_map = _REQUEST_STDIO_PARAMS.get()
        if params_map is None:
            return {}
        return params_map.get(server_name, {})
    return _get
```

ContextVar 的可见性边界 = 异步任务。`run_stream_task` / `run_agent_task` 既 set ContextVar 又在其内部跑 agent 的 ReAct 循环，工具 invoke 发生在同一任务内，不同请求不同任务天然隔离。

**b) 请求唯一 tool_id**

```python
tool_id = f"{request_scoped_server_id}.{server_name}.{tool_def_name}"
# 例: "email::req_abc123.email.send_mail"
```

`Runner.resource_mgr.add_tool(ephemeral, tag=server_name)` 用唯一 key 写入全局 `_tools` 字典，并发请求不撞键。

**c) 工具定义枚举**

注册前调 `list_stdio_mcp_tool_defs(params)` 一次性拉起子进程枚举工具定义后退出。此步失败则该 server 整体注册失败，不影响其他 server。

**d) 注册追踪**

每个注册的 server 记录到 `_request_registrations[request_id]`：

```python
reg = {
    "kind": "stdio",
    "server_name": server_name,
    "server_id": request_scoped_server_id,
    "tool_ids": [...],
    "tool_names": [...],
}
self._request_registrations[request_id].append(reg)
```

#### 2.2 sse / streamable-http 请求级隔离

**a) 独立连接**

每个请求创建独立的 MCP server 连接，`server_id` 包含 `request_id` 确保不撞键：

```python
request_scoped_server_id = f"{server_name}::{request_id}"
mcp_cfg = copy.copy(mcp_cfg)
mcp_cfg.server_id = request_scoped_server_id
```

注：`create_mcp_tool` 返回的对象先 `copy.copy` 浅拷贝再修改 `server_id`，避免直接 mutation 工厂返回对象——即使未来 `create_mcp_tool` 引入缓存返回共享对象，也不会跨请求污染。

**b) headers 认证透传**

`create_mcp_tool` 已支持 `auth_headers` 和 `auth_query_params` 字段，直接透传到 `McpServerConfig`：

```python
record = {
    "name": tool_name,
    "type": "sse",  # 或 "streamableHttp"
    "url": cfg["url"],
    "auth_headers": cfg.get("auth_headers", {}),
    "auth_query_params": cfg.get("auth_query_params", {}),
}
mcp_cfg = create_mcp_tool(json.dumps(record))
```

**c) 注册追踪**

```python
reg = {
    "kind": "shared",  # sse 或 streamableHttp
    "server_name": server_name,
    "server_id": request_scoped_server_id,
}
self._request_registrations[request_id].append(reg)
```

### 3. 清理流程

在 `process_message` 和 `process_message_stream` 的 **Facade finally 块**调用清理：

**非流式**（`interface.py:1273-1274`）：
```python
try:
    result = await self._session_manager.submit_and_wait(session_id, run_agent_task)
    ...
    return result
finally:
    await self._cleanup_request_scoped_mcp(request.request_id)
```

**流式**（`interface.py:1687-1688`）：
```python
finally:
    self._release_inflight_stream()
    await self._cleanup_request_scoped_mcp(request.request_id)
    await self._try_apply_adapter_pending_reload()
```

**清理实现**（`interface.py:1702-1709`）：
```python
async def _cleanup_request_scoped_mcp(self, request_id: str) -> None:
    tm = self._tool_manager
    if tm is None:
        return
    try:
        await tm.unregister_request_scoped_mcp(request_id)
    except Exception:
        logger.exception("[JiuWenClaw] request-scoped MCP 清理失败: %s", request_id)
```

**`unregister_request_scoped_mcp`**（`tool_manager.py:696-744`）：
- 在 `asyncio.Lock` 内 `pop` 出该 request_id 的所有注册记录（注册/注销互斥，避免竞态）
- `has_stdio` 标记是否有 stdio 注册被处理
- 对 stdio 类型：逐个调 `Runner.resource_mgr.remove_tool(tool_id)` + `agent.ability_manager.remove(tool_name)`
- 对 sse/http 类型：调 `Runner.resource_mgr.remove_mcp_server(server_id=...)` + `agent.ability_manager.remove(server_name)`
- 每个 remove 操作用 try/except 包裹，不因单个失败中断后续清理
- 方法末尾：若 `has_stdio=True` 则 `_REQUEST_STDIO_PARAMS.set(None)` 显式清理 ContextVar（防御性，防止同 context 内残留值被后续请求误读）

**兜底清理**：`JiuWenClaw.cleanup()`（`interface.py:1788-1791`）调 `unregister_all_request_scoped_mcp()` 清空所有残留。

### 4. 并发安全

| 维度 | 机制 |
|---|---|
| 全局 `_tools` 字典 | 请求唯一 tool_id / server_id，并发写不同 key |
| `_request_registrations` dict | `asyncio.Lock` 保护 setdefault+append / pop 临界区（注册/注销互斥） |
| stdio 参数 | `_REQUEST_STDIO_PARAMS` ContextVar，异步任务级隔离；请求结束 `set(None)` 显式清理 |
| sse/http 连接 | 每个请求独立 server_id，`Runner.resource_mgr` 按 server_id 分桶 |
| ability_manager | per-session agent 实例，每个 session 独立 |
| 同 session 串行 | `SessionManager` PriorityQueue FIFO |
| 跨 session 并发 | 唯一 ID 天然隔离 |
| legacy request_id | `uuid4().hex[:12]`（非毫秒时间戳），消除同毫秒碰撞 |

### 5. 安全模型

| 传输类型 | 安全校验 |
|---|---|
| stdio | `_validate_cat_cafe_request_scoped_stdio`：禁止 `python -c`/`node -e`；cwd 与脚本路径须在受信根路径下 |
| sse / http | `_validate_request_scoped_remote_mcp`：url 不做域名白名单（业务需连接任意合法外网端点），但拦截内网/环回/元数据地址（SSRF 防护）；auth_headers / auth_query_params 的字符串值做同样的内网地址黑名单 |

不复用 `_check_mcp_security`（拦截 RPC 来源的 command/args/url，与请求级携带配置冲突）。

#### 5.1 sse / http 安全校验详情

`_validate_request_scoped_remote_mcp(tool_name, cfg)`（`tool_manager.py`）在 `register_request_scoped_mcp` 的非 stdio 分支调用，覆盖：

| 检查项 | 策略 | 拦截示例 |
|---|---|---|
| `url` 的 host | 域名**不做白名单**（合法外网域名放行），但命中内网/环回/元数据地址则阻断 | `http://127.0.0.1/sse`、`http://169.254.169.254/`、`http://10.0.0.1/`、`http://localhost/`、`http://[::1]/` |
| `auth_headers` / `auth_query_params` 的字符串值 | 值若为 URL 先解析 hostname，裸 host/IP 直接判断；命中内网/元数据地址则阻断（防止被用作重定向入口、凭证外泄） | `{"X-Redirect": "http://169.254.169.254/"}` |

**黑名单判定** `_is_blocked_host(host)`：
- 命中已知 hostname 集合：`localhost`、`metadata.google.internal`、`metadata`、`metadata.azure.com`
- 解析为 IP 后属以下类别：`is_private` / `is_loopback` / `is_link_local` / `is_multicast` / `is_reserved` / `is_unspecified`

**安全边界（评审结论）**：
- url **不做域名白名单**——业务需要连接用户自有的合法外网 MCP 端点，白名单会限制功能性
- 但**必须拦截内网/元数据地址**——经 Gateway 鉴权的用户仍可能注册指向内网的 sse/http server 进行 SSRF 或窃取 Agent 上下文，这是不可接受的风险
- headers 字段本身**不拦**（sse/http 功能必需 auth），只拦值的内网地址
- 不复用 `_check_mcp_security` 的全字段拦截（会把 url/auth_headers/auth_query_params 字段整体禁止，等于禁用 sse/http 请求级注册）

**审计**：非 stdio 分支注册成功前记 `[AUDIT]` 日志（request_id / kind / name / url / 是否带 auth），不记录凭证值。

### 6. 向后兼容

`_extract_request_mcp_payload`（`interface.py:1691-1701`，`@staticmethod`）统一入口：

```python
@staticmethod
def _extract_request_mcp_payload(request) -> dict | None:
    payload = request.params.get("request_mcp_servers")
    servers = payload.get("mcpServers") if isinstance(payload, dict) else None
    if isinstance(servers, dict) and servers:
        return payload
    legacy = request.params.get("office_claw_mcp")
    if isinstance(legacy, dict):
        from jiuwenclaw.agentserver.tool_manager import _OFFICE_CLAW_SERVER_NAME_PREFIX
        return {"mcpServers": {_OFFICE_CLAW_SERVER_NAME_PREFIX: legacy}}
    return None
```

注意：对 `mcpServers` 字段做显式 `isinstance(..., dict)` 校验，对 `{"mcpServers": "not a dict"}` 或 `{"mcpServers": ["list"]}` 等错误类型在入口即返回 `None`，避免误传给 `register_request_scoped_mcp` 触发误导性的「缺少有效的 mcpServers 对象」错误。

废弃项：
- `_REQUEST_STDIO_PARAMS` 替代了旧的 `_OFFICE_CLAW_STDIO_PARAMS` 单值 ContextVar
- `_request_registrations` dict 替代了旧的 `_office_claw_ephemeral_tools` list
- `register_request_scoped_office_claw_mcp` 保留为薄包装，内部转调 `register_request_scoped_mcp`，生成 `legacy_office_claw_{uuid4().hex[:12]}` 作为 request_id（uuid4 替代毫秒时间戳，消除高并发/快速重试场景下的碰撞）

## 改动清单

| 文件 | 改动 |
|---|---|
| `jiuwenclaw/agentserver/tool_manager.py` | 新增 `register_request_scoped_mcp` / `unregister_request_scoped_mcp` / `unregister_all_request_scoped_mcp`；新增 `_REQUEST_STDIO_PARAMS` + `_make_stdio_params_getter`；新增 `_request_registrations` dict + `_request_registrations_lock`（asyncio.Lock 保护临界区）；支持 sse/streamable-http 请求级隔离与清理；新增 `_validate_request_scoped_remote_mcp` + `_is_blocked_host`（sse/http SSRF 防护）；非 stdio 分支注册前校验 + `[AUDIT]` 审计日志；非 stdio 分支 `copy.copy(mcp_cfg)` 后改 server_id（避免 mutation 工厂对象）；`unregister` 末尾条件清理 ContextVar；`register_request_scoped_office_claw_mcp` 降级为兼容包装，request_id 用 uuid4 |
| `jiuwenclaw/agentserver/interface.py` | `process_message` 包 try/finally 加清理；`process_message_stream` finally 加清理；新增 `_extract_request_mcp_payload`（staticmethod，含 mcpServers 类型校验）+ `_cleanup_request_scoped_mcp`；`run_agent_task`/`run_stream_task` 内改调新方法；注册失败统一单条 `logger.warning`（progress）；`cleanup()` 加兜底清理 |
| `jiuwenclaw/agentserver/tools/mcp_toolkits.py` | 显式导入 `sse_client`/`stdio_client`/`streamable_http_client` 模块，触发 `__init_subclass__` 自动注册到客户端注册表，确保 `create_mcp_tool` 能识别 sse/streamable-http 类型 |
| `tests/unit_tests/agentserver/test_request_scoped_mcp.py` | **新增** 38 个单测（含 sse/http 安全校验 12 个、mcpServers 类型校验 2 个、legacy request_id 并发唯一性 1 个、shared mcp_cfg 拷贝不污染 1 个） |
| `scripts/test_echo_server.py` | **新增**测试用 stdio MCP server |
| `scripts/test_echo_b_server.py` | **新增**测试用 stdio MCP server (echo_b) |
| `scripts/test_echo_sse_server.py` | **新增**测试用 sse MCP server |
| `scripts/test_echo_http_server.py` | **新增**测试用 streamable-http MCP server |
| `scripts/test_request_scoped_mcp_websocket.py` | **新增** WebSocket E2E 测试脚本（11 个场景，含 security_block） |

## 验证

### 单测（38 个，全部通过）

```powershell
python -m pytest tests/unit_tests/agentserver/test_request_scoped_mcp.py -v -o "addopts="
```

覆盖：
- ContextVar 隔离（单 server、多 server、并发任务）
- 注册追踪（初始化、不存在清理、多请求清理、错误处理、shared 类型清理、混合类型清理、shared mcp_cfg 拷贝不污染原对象）
- 参数提取（新参数优先、旧参数兼容、空参数、非 dict、mcpServers 字段为字符串/列表）
- 清理委托（正常、异常、tool_manager 为 None）
- 兼容包装（legacy request_id 格式、payload 包装、并发 100 次 request_id 唯一）
- sse/http 安全校验（外网放行、loopback/元数据/私网/localhost/unspecified/IPv6 loopback 拦截、auth 字段值拦截、合法 token 放行）

### 端到端验证

启动 AgentServer，通过 WebSocket 发送携带 `request_mcp_servers` 的请求，观测日志：

| 阶段 | 日志关键字 |
|---|---|
| stdio 注册成功 | `[ToolManager] 已注册请求级 MCP（stdio）request_id=` |
| sse/http 注册成功 | `[ToolManager] 已注册请求级 MCP（shared）request_id=` |
| 清理成功 | `[ToolManager] 已清理请求级 MCP request_id=` |
| 注册失败 | `[JiuWenClaw] request_mcp_servers 注册失败` |
| 清理异常 | `[JiuWenClaw] request-scoped MCP 清理失败` |

### E2E 测试场景（11 个）

```powershell
python scripts/test_request_scoped_mcp_websocket.py --scenario all
```

| 场景 | 验证点 |
|---|---|
| single | 单 stdio server 注册 + 调用 + 清理 |
| concurrent | 并发请求隔离（不同 session 各自注册/清理） |
| cancel | 请求取消时 finally 清理 |
| multi | 同一请求注册多个 stdio server |
| legacy | 旧参数 `office_claw_mcp` 兼容 |
| sse | sse 类型 MCP server 注册 + 清理（含 `auth_headers` / `auth_query_params` 验证） |
| streamable-http | streamable-http 类型 MCP server 注册 + 清理（含 `auth_headers` / `auth_query_params` 验证） |
| mixed | 同一请求同时携带 stdio + sse server（混合类型注册 + 清理） |
| partial_fail | 一个 stdio server 用非法路径失败，另一个正常 server 仍注册成功（部分失败容错） |
| non_stream | 使用 `agent.chat` 模式触发非流式 `process_message` 路径，验证 finally 清理 |
| security_block | sse/http 的 url 与 auth 字段值指向内网/元数据地址时被 `_validate_request_scoped_remote_mcp` 拦截，注册失败（6 个子测试，每子测试独立 session_id 避免 FIFO 排队） |

## 风险与权衡

| ID | 风险 | 缓解 |
|---|---|---|
| R1 | sse/http 每次请求新建连接，连接建立开销约 0.5-2s | 可后续加连接池复用（按 url+headers 哈希） |
| R2 | stdio 每次注册前 `list_stdio_mcp_tool_defs` 拉子进程，冷启动约 0.5-2s | 可缓存 tool_defs（按 command+args 哈希），首版不缓存 |
| R3 | `Runner.resource_mgr` 全局字典在并发下无锁 | CPython GIL 缓解；唯一 ID 避免写同一 key |
| R4 | 清理在 gateway 断开/任务取消路径未执行 | `cleanup()` 兜底 + 日志可观测 |
| R5 | sse/http 的 headers 明文传输，可能含敏感凭证 | 建议上层 Gateway 做 TLS 终止；headers 不落盘、不日志输出 |
| R6 | sse/http url 仍可指向合法外网域名，存在 DNS rebinding / 重定向链到内网的残余 SSRF | `_validate_request_scoped_remote_mcp` 拦截内网/元数据地址；后续可在连接阶段校验解析后的 IP，或限制重定向跳数 |