### PR TITLE
fix(qa-block): 修复权限续跑/脏指针导致的 system-only LLM 失败

### DIFF
--- a/jiuwenclaw/agentserver/deep_agent/rails/qa_block_assembly_rail.py
+++ b/jiuwenclaw/agentserver/deep_agent/rails/qa_block_assembly_rail.py
@@ -12,8 +12,11 @@ from openjiuwen.core.context_engine.qa_artifact.store import QAArtifactStore
 from openjiuwen.core.context_engine.qa_artifact.assembly_state import clear_assembly_qa_artifact_state
 from openjiuwen.core.context_engine.qa_artifact.window import make_processor_ctx
 from openjiuwen.core.context_engine.qa_block.messages import (
+    extract_qa_native_messages,
     is_other_qa_message,
+    message_qa_id,
 )
+from openjiuwen.core.foundation.llm import UserMessage
 from openjiuwen.core.context_engine.qa_block.catalog import (
     build_catalog_section,
     build_catalog_text,
@@ -38,6 +41,7 @@ from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, InvokeI
 from openjiuwen.harness.rails.base import DeepAgentRail
 
 from jiuwenclaw.agentserver.deep_agent.plan_pause_helpers import (
+    post_agent_execute_for_session,
     resolve_actual_session,
     resolve_context_engine,
     session_id_from_session,
@@ -99,8 +103,15 @@ def _should_keep_current_qa_on_interrupt_resume(
     """Permission/HITL resume 后继续沿用未冻结的进行中 QA，避免错误新开轮次。
 
     ``before_model_call`` 看不到 InteractiveInput，因此用 before_invoke 写入的
-    session 标记识别 resume 轮。空上下文 + 无 assembly commit 的 stale 指针
-    仍放行给后续清理/组装逻辑。
+    session 标记识别 resume 轮。
+
+    Keep 条件（满足其一即可）：
+    1. 本轮已 assembly commit 到该 QA；
+    2. context 上已有该 QA 的 native 工作内容；
+    3. 下一轮 user query 为空（权限/HITL resume 的预期形态）——避免误 allocate 空 QA。
+
+    若 resume 轮却带着非空 query、且无 commit/无 native work，视为 stale 指针，
+    放行给后续清理/组装逻辑。
     """
     if not _is_interrupt_resume_turn(session):
         return False
@@ -113,6 +124,15 @@ def _should_keep_current_qa_on_interrupt_resume(
     if _get_assembly_committed_qa_id(session) == active_qa_id:
         return True
     if _context_has_active_qa_work(ctx, active_qa_id):
+        return True
+    messages: list = []
+    context = ctx.context
+    if context is not None:
+        getter = getattr(context, "get_messages", None)
+        if callable(getter):
+            messages = getter() or []
+    # Empty query is expected on permission/HITL resume; keep unfrozen QA.
+    if not extract_next_user_query(messages).strip():
         return True
     return False
 
@@ -213,11 +233,67 @@ def _pop_pending_orphan_salvage(session: Any) -> str | None:
     return str(qa_id)
 
 
-def _is_task_continuation(ctx: AgentCallbackContext, next_query: str) -> bool:
+def _tail_unassigned_user_messages(messages: list) -> list:
+    """Trailing UserMessage copies without qa_id/source_qa_id (current-round input)."""
+    preserved: list = []
+    for message in reversed(messages):
+        if not isinstance(message, UserMessage):
+            break
+        if message_qa_id(message):
+            break
+        copy = message.model_copy(deep=True) if hasattr(message, "model_copy") else message
+        preserved.insert(0, copy)
+    return preserved
+
+
+def _strip_tail_unassigned_user_messages(messages: list) -> list:
+    preserved = _tail_unassigned_user_messages(messages)
+    if not preserved:
+        return list(messages)
+    return list(messages[: len(messages) - len(preserved)])
+
+
+def _orphan_needs_no_salvage(
+    ctx: AgentCallbackContext,
+    qa_id: str,
+    entry: QABlockEntry | None,
+    registry: QABlockRegistry,
+) -> bool:
+    """True when stale orphan pointer has nothing worth freezing (repair-only clear).
+
+    ``before_invoke`` often runs before ``ctx.context`` is ready. When the buffer
+    cannot be inspected, keep deferred salvage (do not clear blindly).
+    """
+    if _is_resume_invoke(ctx):
+        return False
+
+    context = ctx.context
+    if context is None:
+        return False
+    getter = getattr(context, "get_messages", None)
+    if not callable(getter):
+        return False
+
+    messages = getter() or []
+    if not messages:
+        return True
+    preserved_count = len(_tail_unassigned_user_messages(messages))
+    candidate = messages[: len(messages) - preserved_count] if preserved_count else messages
+    orphan_native = extract_qa_native_messages(candidate, registry)
+    return not orphan_native
+
+
+def _is_task_continuation(
+    ctx: AgentCallbackContext,
+    next_query: str,
+    session: Any | None = None,
+) -> bool:
     resume_input = ctx.extra.get(RESUME_USER_INPUT_KEY)
     if isinstance(resume_input, InteractiveInput):
         return True
     if not next_query.strip() and _is_resume_invoke(ctx):
+        return True
+    if session is not None and _is_interrupt_resume_turn(session) and not next_query.strip():
         return True
     return False
 
@@ -297,6 +373,25 @@ class JiuClawQABlockAssemblyRail(DeepAgentRail):
             return
 
         if entry is None or not entry.freeze_committed_at:
+            if _orphan_needs_no_salvage(ctx, qa_id, entry, registry):
+                _clear_current_qa_pointer(session, registry, qa_id)
+                try:
+                    await post_agent_execute_for_session(session)
+                except Exception as exc:
+                    logger.warning(
+                        "[QABlockAssemblyRail] orphan pointer checkpoint flush failed "
+                        "session_id=%s qa_id=%s: %s",
+                        session_id,
+                        qa_id,
+                        exc,
+                    )
+                logger.info(
+                    "[QABlockAssemblyRail] repaired empty/stale orphan pointer without salvage "
+                    "session_id=%s qa_id=%s",
+                    session_id,
+                    qa_id,
+                )
+                return
             _set_pending_orphan_salvage(session, qa_id)
             logger.info(
                 "[QABlockAssemblyRail] deferred orphan salvage session_id=%s qa_id=%s",
@@ -314,12 +409,31 @@ class JiuClawQABlockAssemblyRail(DeepAgentRail):
         freeze_rail = self._freeze_rail
         if freeze_rail is None:
             return False
+
+        context = ctx.context
+        original_messages: list | None = None
+        preserved_users: list = []
+        if context is not None:
+            getter = getattr(context, "get_messages", None)
+            if callable(getter):
+                messages = list(getter() or [])
+                original_messages = messages
+                preserved_users = _tail_unassigned_user_messages(messages)
+                if preserved_users:
+                    context.set_messages(
+                        _strip_tail_unassigned_user_messages(messages),
+                        with_history=True,
+                    )
+
         try:
+            # persist_context=False: avoid checkpointing the stripped buffer before
+            # current-round user messages are restored (crash-window / Problem A).
             await freeze_rail.freeze_current_qa_sync(
                 session_id,
                 agent=ctx.agent,
                 session=session,
                 status="interrupted",
+                persist_context=False,
             )
         except Exception as exc:
             logger.warning(
@@ -329,11 +443,46 @@ class JiuClawQABlockAssemblyRail(DeepAgentRail):
                 exc,
                 exc_info=True,
             )
+            if context is not None and original_messages is not None:
+                context.set_messages(original_messages, with_history=True)
             return False
 
         registry = load_registry(session, force_reload=True)
         entry = registry.blocks.get(qa_id)
-        if _is_frozen_entry(entry):
+        frozen = _is_frozen_entry(entry)
+
+        if context is not None and preserved_users:
+            if frozen:
+                # Successful freeze strips the active buffer; restore only this round's user.
+                context.set_messages(preserved_users, with_history=True)
+            elif original_messages is not None:
+                # Freeze returned None without strip; put the full pre-strip buffer back.
+                context.set_messages(original_messages, with_history=True)
+            logger.info(
+                "[QABlockAssemblyRail] orphan salvage preserved current-round user "
+                "session_id=%s qa_id=%s count=%s frozen=%s",
+                session_id,
+                qa_id,
+                len(preserved_users),
+                frozen,
+            )
+
+        # Persist only after restore so checkpoint never sees a stripped-without-user snapshot.
+        context_engine = resolve_context_engine(ctx.agent)
+        if context_engine is not None:
+            try:
+                await context_engine.save_contexts(session)
+                await post_agent_execute_for_session(session)
+            except Exception as exc:
+                logger.warning(
+                    "[QABlockAssemblyRail] orphan salvage checkpoint flush failed "
+                    "session_id=%s qa_id=%s: %s",
+                    session_id,
+                    qa_id,
+                    exc,
+                )
+
+        if frozen:
             if registry.current_qa_id == qa_id:
                 _clear_current_qa_pointer(session, registry, qa_id)
             logger.info(
@@ -517,7 +666,7 @@ class JiuClawQABlockAssemblyRail(DeepAgentRail):
             next_query = extract_next_user_query(context.get_messages())
             model = resolve_selector_model(agent)
             selector = QABlockSelector(self._config)
-            is_continuation = _is_task_continuation(ctx, next_query)
+            is_continuation = _is_task_continuation(ctx, next_query, session)
             try:
                 selected_qa_ids = await selector.select(
                     next_query,
@@ -554,6 +703,16 @@ class JiuClawQABlockAssemblyRail(DeepAgentRail):
         else:
             ctx.extra[_PRELOADED_QA_IDS_KEY] = []
             await layer.hydrate_history_into_window(context)
+
+        if _is_interrupt_resume_turn(session) and not extract_next_user_query(
+            context.get_messages()
+        ).strip():
+            logger.info(
+                "[QABlockAssemblyRail] skip QA allocate on interrupt resume with empty query "
+                "session_id=%s",
+                session_id,
+            )
+            return
 
         qa_id, _ = allocate_qa_id(registry)
         registry.current_qa_id = qa_id

--- a/jiuwenclaw/agentserver/deep_agent/rails/qa_block_freeze_rail.py
+++ b/jiuwenclaw/agentserver/deep_agent/rails/qa_block_freeze_rail.py
@@ -11,7 +11,8 @@ from typing import Any, Literal
 from openjiuwen.core.context_engine.qa_artifact.window import make_processor_ctx
 from openjiuwen.core.context_engine.qa_block.config import QABlockConfig
 from openjiuwen.core.context_engine.qa_block.freezer import FreezeCommitResult, QABlockFreezer
-from openjiuwen.core.context_engine.qa_block.registry import load_registry
+from openjiuwen.core.context_engine.qa_block.messages import extract_qa_native_messages
+from openjiuwen.core.context_engine.qa_block.registry import load_registry, save_registry
 from openjiuwen.core.context_engine.qa_block.selector import resolve_summarizer_model
 from openjiuwen.core.context_engine.qa_block.store import QABlockStore
 from openjiuwen.core.session.interaction.interactive_input import InteractiveInput
@@ -132,6 +133,55 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
             native_messages=native_messages,
         )
 
+    async def _clear_empty_current_qa_after_failed_freeze(
+        self,
+        session: Any,
+        context_engine: Any,
+        *,
+        session_id: str,
+        context: Any | None = None,
+        persist_context: bool = True,
+    ) -> None:
+        """Drop stale in-progress pointer when freeze had nothing to commit."""
+        registry = load_registry(session)
+        qa_id = registry.current_qa_id
+        if not qa_id:
+            return
+
+        if context is not None:
+            getter = getattr(context, "get_messages", None)
+            if callable(getter):
+                messages = getter() or []
+                native = extract_qa_native_messages(messages, registry)
+                if native:
+                    roles = {getattr(message, "role", None) for message in native}
+                    if "user" in roles or "tool" in roles:
+                        logger.info(
+                            "[QABlockFreezeRail] skip clear after failed freeze: "
+                            "native user/tool still present session_id=%s qa_id=%s",
+                            session_id,
+                            qa_id,
+                        )
+                        return
+
+        registry.current_qa_id = None
+        save_registry(session, registry)
+        clear_assembly_committed_qa_id(session)
+        if persist_context:
+            await context_engine.save_contexts(session)
+            await self._persist_freeze_checkpoint(session, session_id=session_id)
+        else:
+            # Registry pointer cleared; caller (orphan salvage) restores messages first,
+            # then persists context to avoid checkpointing a stripped-without-user buffer.
+            await self._persist_freeze_checkpoint(session, session_id=session_id)
+        logger.info(
+            "[QABlockFreezeRail] cleared empty current_qa_id after failed freeze "
+            "session_id=%s qa_id=%s persist_context=%s",
+            session_id,
+            qa_id,
+            persist_context,
+        )
+
     async def _persist_freeze_checkpoint(self, session: Any, *, session_id: str) -> None:
         """Flush registry after freeze; inner ReAct post_run may have checkpointed early."""
         try:
@@ -173,8 +223,14 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
         agent: Any,
         session: Any = None,
         status: Literal["completed", "interrupted"] = "interrupted",
+        persist_context: bool = True,
     ) -> None:
-        """Emergency freeze before plan cancel checkpoint."""
+        """Emergency freeze before plan cancel checkpoint.
+
+        ``persist_context=False`` skips ``save_contexts`` so callers (orphan salvage)
+        can restore temporarily stripped current-round user messages before persisting.
+        Registry/checkpoint flush still runs so ``current_qa_id`` updates are durable.
+        """
         if not self._config.enabled:
             return
         context_engine = resolve_context_engine(agent)
@@ -216,13 +272,26 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
         )
         if entry is not None:
             clear_assembly_committed_qa_id(actual_session)
-            await context_engine.save_contexts(actual_session)
-            await self._persist_freeze_checkpoint(actual_session, session_id=session_id)
+            if persist_context:
+                await context_engine.save_contexts(actual_session)
+                await self._persist_freeze_checkpoint(actual_session, session_id=session_id)
+            else:
+                await self._persist_freeze_checkpoint(actual_session, session_id=session_id)
             logger.info(
-                "[QABlockFreezeRail] cancel sync freeze done session_id=%s qa_id=%s status=%s",
+                "[QABlockFreezeRail] cancel sync freeze done session_id=%s qa_id=%s status=%s "
+                "persist_context=%s",
                 session_id,
                 entry.qa_id,
                 status,
+                persist_context,
+            )
+        else:
+            await self._clear_empty_current_qa_after_failed_freeze(
+                actual_session,
+                context_engine,
+                session_id=session_id,
+                context=context,
+                persist_context=persist_context,
             )
 
     async def _freeze_session(
@@ -297,6 +366,12 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
             post_commit=lambda commit, s=session, c=context: self._on_freeze_commit(s, c, commit),
         )
         if entry is None:
+            await self._clear_empty_current_qa_after_failed_freeze(
+                session,
+                context_engine,
+                session_id=session_id,
+                context=context,
+            )
             return
 
         clear_assembly_committed_qa_id(session)

--- a/tests/unit_tests/agentserver/test_qa_block_assembly_rail.py
+++ b/tests/unit_tests/agentserver/test_qa_block_assembly_rail.py
@@ -33,6 +33,7 @@ _spec.loader.exec_module(_module)
 JiuClawQABlockAssemblyRail = _module.JiuClawQABlockAssemblyRail
 PENDING_ORPHAN_SALVAGE_KEY: str = getattr(_module, "_PENDING_ORPHAN_SALVAGE_KEY")
 ASSEMBLY_COMMITTED_QA_ID_KEY: str = getattr(_module, "_ASSEMBLY_COMMITTED_QA_ID_KEY")
+INTERRUPT_RESUME_TURN_KEY: str = getattr(_module, "_INTERRUPT_RESUME_TURN_KEY")
 _is_task_continuation = _module._is_task_continuation
 _last_n_history_qa_ids = _module._last_n_history_qa_ids
 
@@ -180,6 +181,57 @@ class TestQABlockAssemblyRailGuard(unittest.IsolatedAsyncioTestCase):
                 await self.rail.before_model_call(ctx)
                 mock_allocate.assert_not_called()
 
+    async def test_before_invoke_repairs_empty_orphan_without_salvage(self) -> None:
+        ctx = _make_model_call_ctx(self.session, messages=[])
+        ctx.inputs = InvokeInputs(query="new question")
+        registry = _registry_with_active_qa("qa_005")
+
+        with patch.object(_module, "load_registry", return_value=registry):
+            with patch.object(_module, "save_registry") as mock_save:
+                with patch.object(_module, "post_agent_execute_for_session", new=AsyncMock()):
+                    await self.rail.before_invoke(ctx)
+
+        self.assertIsNone(registry.current_qa_id)
+        self.assertIsNone(self.session.get_state(PENDING_ORPHAN_SALVAGE_KEY))
+        mock_save.assert_called_once()
+
+    async def test_before_invoke_defers_orphan_when_context_unavailable(self) -> None:
+        """before_invoke often has no context; must not skip salvage blindly."""
+        ctx = AgentCallbackContext(
+            agent=SimpleNamespace(),
+            inputs=InvokeInputs(query="new question"),
+            session=self.session,
+        )
+        registry = _registry_with_active_qa("qa_005")
+
+        with patch.object(_module, "load_registry", return_value=registry):
+            with patch.object(_module, "save_registry") as mock_save:
+                await self.rail.before_invoke(ctx)
+
+        self.assertEqual(registry.current_qa_id, "qa_005")
+        self.assertEqual(self.session.get_state(PENDING_ORPHAN_SALVAGE_KEY), "qa_005")
+        mock_save.assert_not_called()
+
+    async def test_before_invoke_defers_orphan_with_native_work(self) -> None:
+        ctx = _make_model_call_ctx(self.session, messages=_qa_messages("qa_005"))
+        ctx.inputs = InvokeInputs(query="new question")
+        registry = _registry_with_active_qa("qa_005")
+        entry = QABlockEntry(
+            qa_id="qa_005",
+            qa_index=5,
+            status="interrupted",
+            message_count=2,
+        )
+        registry.blocks["qa_005"] = entry
+
+        with patch.object(_module, "load_registry", return_value=registry):
+            with patch.object(_module, "save_registry") as mock_save:
+                await self.rail.before_invoke(ctx)
+
+        self.assertEqual(registry.current_qa_id, "qa_005")
+        self.assertEqual(self.session.get_state(PENDING_ORPHAN_SALVAGE_KEY), "qa_005")
+        mock_save.assert_not_called()
+
     async def test_before_invoke_defers_orphan_without_freeze_rail(self) -> None:
         ctx = AgentCallbackContext(
             agent=SimpleNamespace(),
@@ -187,6 +239,13 @@ class TestQABlockAssemblyRailGuard(unittest.IsolatedAsyncioTestCase):
             session=self.session,
         )
         registry = _registry_with_active_qa("qa_005")
+        entry = QABlockEntry(
+            qa_id="qa_005",
+            qa_index=5,
+            status="interrupted",
+            message_count=1,
+        )
+        registry.blocks["qa_005"] = entry
 
         with patch.object(_module, "load_registry", return_value=registry):
             with patch.object(_module, "save_registry") as mock_save:
@@ -236,8 +295,13 @@ class TestQABlockAssemblyRailGuard(unittest.IsolatedAsyncioTestCase):
         salvaged.current_qa_id = "qa_006"
         self.rail.attach_freeze_rail(freeze_rail)
         self.session.update_state({PENDING_ORPHAN_SALVAGE_KEY: "qa_006"})
+        ctx.agent.context_engine.save_contexts = AsyncMock()
 
-        with patch.object(_module, "load_registry", side_effect=[registry, salvaged, salvaged, salvaged]):
+        with patch.object(
+            _module,
+            "load_registry",
+            side_effect=[registry, registry, salvaged, salvaged, salvaged],
+        ):
             with patch.object(_module, "maybe_compact_catalog_l1", return_value=salvaged):
                 with patch.object(
                     _module,
@@ -246,12 +310,15 @@ class TestQABlockAssemblyRailGuard(unittest.IsolatedAsyncioTestCase):
                 ):
                     with patch.object(_module, "allocate_qa_id", return_value=("qa_010", 10)) as mock_allocate:
                         with patch.object(_module, "save_registry"):
-                            with patch.object(_module, "QABlockLayer") as mock_layer_cls:
-                                layer = MagicMock()
-                                layer.build_window_qas.return_value = []
-                                mock_layer_cls.return_value = layer
-                                layer.hydrate_history_into_window = AsyncMock()
-                                await self.rail.before_model_call(ctx)
+                            with patch.object(
+                                _module, "post_agent_execute_for_session", new=AsyncMock()
+                            ):
+                                with patch.object(_module, "QABlockLayer") as mock_layer_cls:
+                                    layer = MagicMock()
+                                    layer.build_window_qas.return_value = []
+                                    mock_layer_cls.return_value = layer
+                                    layer.hydrate_history_into_window = AsyncMock()
+                                    await self.rail.before_model_call(ctx)
 
         freeze_rail.freeze_current_qa_sync.assert_awaited_once()
         self.assertIsNone(self.session.get_state(PENDING_ORPHAN_SALVAGE_KEY))
@@ -400,6 +467,114 @@ class TestQABlockAssemblyRailGuard(unittest.IsolatedAsyncioTestCase):
         mock_allocate.assert_called_once()
         self.assertEqual(registry.current_qa_id, "qa_011")
 
+    async def test_interrupt_resume_keeps_unfrozen_qa_without_allocate(self) -> None:
+        registry = _registry_with_active_qa("qa_003")
+        registry.blocks["qa_003"] = QABlockEntry(
+            qa_id="qa_003",
+            qa_index=3,
+            status="interrupted",
+        )
+        self.session.update_state({INTERRUPT_RESUME_TURN_KEY: True})
+        ctx = _make_model_call_ctx(self.session, messages=[])
+
+        with patch.object(_module, "load_registry", return_value=registry):
+            with patch.object(_module, "allocate_qa_id") as mock_allocate:
+                await self.rail.before_model_call(ctx)
+                mock_allocate.assert_not_called()
+
+        self.assertEqual(registry.current_qa_id, "qa_003")
+
+    async def test_interrupt_resume_stale_pointer_with_query_reallocates(self) -> None:
+        """Resume turn + no commit/native work + non-empty query → do not keep stale QA."""
+        registry = _registry_with_active_qa("qa_003")
+        registry.blocks["qa_003"] = QABlockEntry(
+            qa_id="qa_003",
+            qa_index=3,
+            status="interrupted",
+        )
+        self.session.update_state({INTERRUPT_RESUME_TURN_KEY: True})
+        # Only hydrated history for another QA → no active work for qa_003, but has user text.
+        ctx = _make_model_call_ctx(
+            self.session,
+            messages=[_history_message("qa_001", "follow up question")],
+        )
+        rail = JiuClawQABlockAssemblyRail(QABlockConfig(enabled=True, selector_enabled=False))
+
+        with patch.object(_module, "load_registry", return_value=registry):
+            with patch.object(_module, "maybe_compact_catalog_l1", return_value=registry):
+                with patch.object(
+                    _module,
+                    "reconcile_orphan_l0_blocks",
+                    new=AsyncMock(return_value=(registry, [])),
+                ):
+                    with patch.object(_module, "allocate_qa_id", return_value=("qa_004", 4)) as mock_allocate:
+                        with patch.object(_module, "save_registry"):
+                            with patch.object(_module, "QABlockLayer") as mock_layer_cls:
+                                layer = MagicMock()
+                                layer.build_window_qas.return_value = []
+                                mock_layer_cls.return_value = layer
+                                layer.hydrate_history_into_window = AsyncMock()
+                                await rail.before_model_call(ctx)
+
+        mock_allocate.assert_called_once()
+        self.assertEqual(registry.current_qa_id, "qa_004")
+
+    async def test_orphan_salvage_preserves_current_round_user(self) -> None:
+        ctx = _make_model_call_ctx(
+            self.session,
+            messages=[UserMessage(content="new user turn")],
+        )
+        registry = _registry_with_active_qa("qa_006")
+        freeze_rail = SimpleNamespace(freeze_current_qa_sync=AsyncMock())
+        salvaged = _frozen_registry("qa_006")
+        salvaged.current_qa_id = None
+        self.rail.attach_freeze_rail(freeze_rail)
+        self.session.update_state({PENDING_ORPHAN_SALVAGE_KEY: "qa_006"})
+        set_messages = MagicMock()
+        ctx.context.set_messages = set_messages
+        ctx.context.get_messages.return_value = [UserMessage(content="new user turn")]
+        ctx.agent.context_engine.save_contexts = AsyncMock()
+        ctx.agent.context_engine.get_history_qa_buffer.return_value = {}
+
+        with patch.object(
+            _module,
+            "load_registry",
+            side_effect=[registry, registry, salvaged, salvaged, salvaged],
+        ):
+            with patch.object(_module, "maybe_compact_catalog_l1", return_value=salvaged):
+                with patch.object(
+                    _module,
+                    "reconcile_orphan_l0_blocks",
+                    new=AsyncMock(return_value=(salvaged, [])),
+                ):
+                    with patch.object(_module, "allocate_qa_id", return_value=("qa_010", 10)):
+                        with patch.object(_module, "save_registry"):
+                            with patch.object(
+                                _module, "post_agent_execute_for_session", new=AsyncMock()
+                            ):
+                                with patch.object(_module, "QABlockLayer") as mock_layer_cls:
+                                    layer = MagicMock()
+                                    layer.build_window_qas.return_value = []
+                                    mock_layer_cls.return_value = layer
+                                    layer.hydrate_history_into_window = AsyncMock()
+                                    await self.rail.before_model_call(ctx)
+
+        freeze_rail.freeze_current_qa_sync.assert_awaited_once()
+        self.assertEqual(
+            freeze_rail.freeze_current_qa_sync.await_args.kwargs.get("persist_context"),
+            False,
+        )
+        ctx.agent.context_engine.save_contexts.assert_awaited()
+        restored_calls = [
+            call
+            for call in set_messages.call_args_list
+            if call.args and isinstance(call.args[0], list) and call.args[0]
+        ]
+        self.assertTrue(restored_calls)
+        restored = restored_calls[-1].args[0]
+        self.assertEqual(len(restored), 1)
+        self.assertEqual(getattr(restored[0], "content", ""), "new user turn")
+
     async def test_resume_empty_context_clears_stale_pointer_and_assembles(self) -> None:
         registry = _registry_with_active_qa("qa_008")
         ctx = _make_model_call_ctx(
@@ -493,6 +668,18 @@ class TestIsTaskContinuation(unittest.TestCase):
         )
         result = _is_task_continuation(ctx, "   \n\t  ")
         self.assertTrue(result)
+
+    def test_empty_query_with_interrupt_resume_session_returns_true(self) -> None:
+        session = FakeSession()
+        session.update_state({INTERRUPT_RESUME_TURN_KEY: True})
+        ctx = _make_ctx_for_continuation()
+        self.assertTrue(_is_task_continuation(ctx, "", session))
+
+    def test_non_empty_query_with_interrupt_resume_session_returns_false(self) -> None:
+        session = FakeSession()
+        session.update_state({INTERRUPT_RESUME_TURN_KEY: True})
+        ctx = _make_ctx_for_continuation()
+        self.assertFalse(_is_task_continuation(ctx, "follow up", session))
 
     def test_no_resume_key_in_extra_with_empty_query_returns_false(self) -> None:
         ctx = _make_ctx_for_continuation()

--- a/tests/unit_tests/agentserver/test_qa_block_freeze_rail.py
+++ b/tests/unit_tests/agentserver/test_qa_block_freeze_rail.py
@@ -12,7 +12,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from openjiuwen.core.context_engine.qa_block.freezer import FreezeCommitResult
-from openjiuwen.core.context_engine.qa_block.schema import QABlockEntry
+from openjiuwen.core.context_engine.qa_block.schema import QABlockEntry, QABlockRegistry
 from openjiuwen.core.session.interaction.interactive_input import InteractiveInput
 from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, InvokeInputs
@@ -193,6 +193,55 @@ class TestQABlockFreezeRailInteractiveResume(unittest.IsolatedAsyncioTestCase):
             await self.rail.after_invoke(ctx)
 
         self.freeze_mock.assert_not_awaited()
+
+    async def test_failed_freeze_clears_empty_current_qa_id(self) -> None:
+        ctx, context_engine, session = _make_interactive_freeze_ctx()
+        registry = QABlockRegistry(session_id="session-1", current_qa_id="qa_stale", next_qa_index=2)
+        self.freeze_mock.return_value = None
+
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "clear_assembly_committed_qa_id"), patch.object(
+            _module, "QABlockStore", return_value=MagicMock()
+        ), patch.object(_module, "load_registry", return_value=registry), patch.object(
+            _module, "save_registry"
+        ) as mock_save, patch.object(
+            _module, "post_agent_execute_for_session", new_callable=AsyncMock
+        ) as mock_flush:
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_awaited_once()
+        self.assertIsNone(registry.current_qa_id)
+        mock_save.assert_called_once()
+        mock_flush.assert_awaited_once()
+        context_engine.save_contexts.assert_awaited()
+
+    async def test_failed_freeze_skips_save_contexts_when_persist_context_false(self) -> None:
+        context_engine = MagicMock()
+        context_engine.get_context.return_value = MagicMock(context_id=lambda: "ctx-1")
+        context_engine.get_history_qa_buffer.return_value = []
+        context_engine.save_contexts = AsyncMock()
+        session = SimpleNamespace(get_session_id=lambda: "session-1", get_state=lambda *_a, **_k: None)
+        registry = QABlockRegistry(session_id="session-1", current_qa_id="qa_stale", next_qa_index=2)
+        self.freeze_mock.return_value = None
+        agent = SimpleNamespace()
+
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "clear_assembly_committed_qa_id"), patch.object(
+            _module, "QABlockStore", return_value=MagicMock()
+        ), patch.object(_module, "load_registry", return_value=registry), patch.object(
+            _module, "save_registry"
+        ), patch.object(_module, "post_agent_execute_for_session", new_callable=AsyncMock):
+            await self.rail.freeze_current_qa_sync(
+                "session-1",
+                agent=agent,
+                session=session,
+                persist_context=False,
+            )
+
+        self.assertIsNone(registry.current_qa_id)
+        context_engine.save_contexts.assert_not_awaited()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug
问题：
权限确认续跑（InteractiveInput）或 checkpoint 残留未 freeze 的 current_qa_id 时，会触发 orphan salvage 误清除本轮 user、空 query 新开空 QA、或 freeze 无 native 内容仍留脏指针，最终导致 LLM 请求仅含 system 角色（81001 /「这次处理没有顺利完成」）。commit c0d84c78 仅覆盖「权限 resume 成功收尾」路径，无法防止上述边角链路在新旧 session 上自我污染。

修复方案：

1、 before_invoke：空/无 salvage 价值的 orphan 直接清指针 + flush checkpoint，不走 destructive salvage
2、 interrupt resume 轮沿用未 freeze QA，禁止空 query 新开 QA
3、 task loop 空 query 时按 session 标记触发 Selector 历史 preload fallback
4、 orphan salvage 前剥离并 freeze 后恢复本轮无 qa_id 的 UserMessage
5、 freeze 无 entry 时清 current_qa_id 并 flush（HITL/仍中断 skip 路径不变）
预期效果：

权限「总是允许」续跑及后续普通 chat 不再连环 system-only
用户无需强制开新 session；旧 session 空脏指针可在入口自动 repair
与 c0d84c78 形成完整闭环：成功收尾 freeze + 失败/脏态止血
ask_user_question 中断 keep QA 语义不回退

验证结果：
包含权限审批的长任务后续请求正常
![image.png](https://raw.gitcode.com/user-images/assets/9297832/46fce0b6-f820-4312-b441-2023181fbc4d/image.png 'image.png')

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->