### PR TITLE
fix: isolation_venv 添加到file_guard授信区

### DIFF
--- a/jiuwenclaw/agentserver/permissions/file_guard.py
+++ b/jiuwenclaw/agentserver/permissions/file_guard.py
@@ -108,7 +108,52 @@ def merged_file_guard_config(permissions: dict[str, Any]) -> dict[str, Any]:
     ted = fg.get("trusted_exec_directory")
     if not isinstance(ted, list):
         fg["trusted_exec_directory"] = []
+    _inject_system_default_trust(fg)
     return fg
+
+
+def _inject_system_default_trust(fg: dict[str, Any]) -> None:
+    """将系统基础设施路径注入 file_guard 默认信任配置。
+
+    ``isolation_venv/Scripts``（或 ``isolation_venv/bin``）是系统自己管理的
+    隔离虚拟环境，不是用户数据，不应被当作"外部路径"弹窗。
+    如果用户已显式配置了信任路径，本注入视为兜底，不覆盖用户配置。
+    """
+    try:
+        from jiuwenclaw.runtime import get_runtime_venv_dir
+
+        venv_dir = get_runtime_venv_dir()
+        scripts_dir = _posix_str(venv_dir / ("Scripts" if os.name == "nt" else "bin"))
+        if not scripts_dir:
+            return
+
+        ted = fg.get("trusted_exec_directory")
+        if not isinstance(ted, list):
+            ted = []
+            fg["trusted_exec_directory"] = ted
+
+        # 仅当该路径尚未被显式配置时注入。用精确 posix 路径比较（与
+        # _trusted_matches 一致），避免 substring matching 把超集路径
+        # （如 Scripts-backup）误判为已配置而跳过注入。
+        already_trusted = False
+        for raw in ted:
+            if not isinstance(raw, str):
+                continue
+            try:
+                prefix = _posix_str(Path(_expand_path_str(raw.strip())))
+            except (OSError, RuntimeError):
+                continue
+            if scripts_dir == prefix or scripts_dir.startswith(prefix + "/"):
+                already_trusted = True
+                break
+        if not already_trusted:
+            ted.append(scripts_dir)
+            logger.info(
+                "[file_guard] system_default_trust added path=%s",
+                scripts_dir,
+            )
+    except Exception:
+        logger.debug("[file_guard] system_default_trust skip", exc_info=True)
 
 
 def _expand_path_str(s: str) -> str:

--- a/tests/unit_tests/agentserver/test_file_guard.py
+++ b/tests/unit_tests/agentserver/test_file_guard.py
@@ -1,7 +1,7 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 
 """Unit tests for ``file_guard`` (phase 1)."""
-
+import os
 from jiuwenclaw.agentserver.permissions.file_guard import (
     FileGuardChecker,
     merged_file_guard_config,
@@ -189,3 +189,98 @@ def test_persist_file_operations_allow_writes_to_live_path_not_frozen_constant(m
     live_global = live_saved["permissions"].get("file_guard", {}).get("global", {})
     assert live_global, "文件操作权限应写入实时配置的 file_guard.global"
     assert not frozen_saved["permissions"].get("file_guard", {}).get("global"), "诱饵文件不应被写入"
+
+
+# ---------- _inject_system_default_trust ----------
+
+
+def _patch_runtime_venv(monkeypatch, venv_dir):
+    """Patch ``jiuwenclaw.runtime.get_runtime_venv_dir`` 返回固定路径。"""
+    import importlib
+    runtime_mod = importlib.import_module("jiuwenclaw.runtime")
+    monkeypatch.setattr(runtime_mod, "get_runtime_venv_dir", lambda: venv_dir)
+
+
+def test_system_default_trust_injects_isolation_venv(monkeypatch, tmp_path):
+    """isolation_venv/Scripts（或 bin）在缺省配置时应被注入到 trusted_exec_directory。"""
+    venv_dir = tmp_path / "isolation_venv"
+    venv_dir.mkdir()
+    _patch_runtime_venv(monkeypatch, venv_dir)
+
+    fg = merged_file_guard_config({"file_guard": {"workspace": {"rw_enabled": True}}})
+    ted = fg["trusted_exec_directory"]
+    expected = (venv_dir / ("Scripts" if os.name == "nt" else "bin")).resolve().as_posix()
+    assert expected in ted, f"期望注入 {expected}, 实际 {ted}"
+
+
+def test_system_default_trust_skips_when_already_configured(monkeypatch, tmp_path):
+    """用户已显式配置 isolation_venv 路径时，不重复注入。"""
+    venv_dir = tmp_path / "isolation_venv"
+    venv_dir.mkdir()
+    _patch_runtime_venv(monkeypatch, venv_dir)
+    expected = (venv_dir / ("Scripts" if os.name == "nt" else "bin")).resolve().as_posix()
+
+    fg = merged_file_guard_config({
+        "file_guard": {
+            "workspace": {"rw_enabled": True},
+            "trusted_exec_directory": [expected],
+        },
+    })
+    ted = fg["trusted_exec_directory"]
+    assert ted.count(expected) == 1, f"已配置路径不应重复注入, 实际 {ted}"
+
+
+def test_system_default_trust_uses_exact_path_not_substring(monkeypatch, tmp_path):
+    """回归：去重检查用精确 posix 路径比较，不能用 substring matching。
+
+    用户配置了超集路径（如 isolation_venv/Scripts-backup），scripts_dir
+    （isolation_venv/Scripts）不应被 substring 误判为已配置而跳过注入。
+    """
+    venv_dir = tmp_path / "isolation_venv"
+    venv_dir.mkdir()
+    _patch_runtime_venv(monkeypatch, venv_dir)
+    expected = (venv_dir / ("Scripts" if os.name == "nt" else "bin")).resolve().as_posix()
+    # 构造超集路径：expected + "-backup"（不是 expected 的父目录，是兄弟路径）
+    superset = expected + "-backup"
+
+    fg = merged_file_guard_config({
+        "file_guard": {
+            "workspace": {"rw_enabled": True},
+            "trusted_exec_directory": [superset],
+        },
+    })
+    ted = fg["trusted_exec_directory"]
+    assert expected in ted, f"超集路径不应阻止注入, 实际 {ted}"
+    assert superset in ted, "用户配置的超集路径应保留"
+
+
+def test_system_default_trust_silent_on_runtime_error(monkeypatch):
+    """get_runtime_venv_dir 抛异常时静默跳过，不影响其他配置。"""
+    def _raise():
+        raise RuntimeError("venv unavailable")
+    import importlib
+    runtime_mod = importlib.import_module("jiuwenclaw.runtime")
+    monkeypatch.setattr(runtime_mod, "get_runtime_venv_dir", _raise)
+
+    fg = merged_file_guard_config({
+        "file_guard": {
+            "workspace": {"rw_enabled": True},
+            "trusted_exec_directory": ["/user/explicit/path"],
+        },
+    })
+    # 异常时不注入，但已配置路径保留，workspace 等其他配置不受影响
+    assert fg["trusted_exec_directory"] == ["/user/explicit/path"]
+    assert fg["workspace"]["rw_enabled"] is True
+
+
+def test_system_default_trust_exec_axis_only(monkeypatch, tmp_path):
+    """isolation_venv 只信任 exec 轴，不扩散到 read/write（不写入 global）。"""
+    venv_dir = tmp_path / "isolation_venv"
+    venv_dir.mkdir()
+    _patch_runtime_venv(monkeypatch, venv_dir)
+
+    fg = merged_file_guard_config({"file_guard": {"workspace": {"rw_enabled": True}}})
+    # exec 轴被注入
+    assert fg["trusted_exec_directory"]
+    # read/write 轴（global）不应因 isolation_venv 而新增条目
+    assert not fg.get("global"), f"isolation_venv 不应扩散到 global, 实际 {fg.get('global')}"


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug

  # 权限反复弹窗问题修复设计 v2

> 对应任务：古诗词 PDF 合成（session `officeclaw_d823f94dd6e09e1592da7ed8`）—— 系统弹窗 19 次、用户点击 18 次"总是允许"仍反复弹。

## 一、问题根因

### 三条路径，三层原因

通过日志分析，反复弹窗由三个层次的原因叠加导致：

| 层次 | 问题 | 说明 |
|---|---|---|
| **源头层** | 系统路径（`isolation_venv`）不在 file_guard 默认信任配置中，被当作"外部路径"处理 | 根本原因——系统基础设施路径应默认信任 |
| **判定层** | `approval_override` 命中 ALLOW 后，`file_guard` 因路径问题判 ASK，`strictest` 把结果压回 ASK | 直接原因——用户的选择被无视 |
| **体验层** | 权限弹窗中断 LLM 响应生成 + `pip --quiet` 空输出 + Python 环境不一致 → LLM 陷入循环 | 放大原因——用户要反复点 18 次 |

### read_file 的真相

read_file **没有失败**——它成功返回了（`success=True`），只是 PDF 是扫描版/图片版，每页只有 `## Page N` 占位符，没有文字内容。LLM 把"返回了空内容"误读成"工具没返回内容"，并把这个误读作为循环借口。

### LLM 循环的真相

整个 session 只有 1 次 read_file（循环前），循环期间没有任何 read_file 调用。但 LLM 的 reasoning 反复念叨"read_file didn't return content"——这是 LLM 在**引用循环前那次 read_file 的结果**作为"用 Python 提取文本"的理由。随着上下文压缩/丢失，LLM 把"空内容"退化为"没返回内容"，形成固定话术循环。

循环本质：LLM 对"扫描版 PDF 无法提取文本"这个不可解决的事实失去清晰认知 + `pip --quiet` 空输出误导 + Python 环境不一致导致 import 失败 → 陷入用固定话术反复装库的死循环。权限弹窗只是把这个循环暴露给用户。

## 二、修复方案

### 本次仅落地：改动 4 — isolation_venv 加入默认 file_guard 授信目录

**文件**：`jiuwenclaw/agentserver/permissions/file_guard.py`

**核心论证（消除 pip_env 与 file_guard 的设计矛盾）**：

`isolation_venv` 的引入（`jiuwenclaw/runtime/pip_env.py`）有明确设计目的——模块 docstring 写明 *"Isolated runtime venv for user/agent pip installs under the user workspace"*。核心机制：

1. **`rewrite_shell_command`（`pip_env.py:336`）主动拦截并改写 LLM 生成的 `pip install` / `python -m pip install` / 裸 `python` 调用**，把解释器重定向到 `isolation_venv\Scripts\python.exe`（`pip_env.py:285-333`）。
2. 改写后的命令里，python 路径是**系统塞进去的**，不是 LLM 选的。
3. `check_install_version_warnings`（`pip_env.py:420`）的警告文案"可能影响其他 agent"——说明该 venv 是**多 agent 共享**的，设计上预期被反复 install。

**矛盾点**：`pip_env` 一方面主动把命令改写为指向 isolation_venv 的 python（语义上表示"这是允许的、安全的执行环境"），另一方面 `file_guard` 又把这条**系统自己塞进去的路径**当成"工作区外路径"判 ASK → 弹窗。两个模块的设计意图打架了。

**弹窗在这个场景下完全无意义**：
- 用户**拒绝**也没用——命令已被 `pip_env` 改写，下次还是同一路径
- 用户**允许**也无需确认——路径由系统固定，不存在"用户对路径的自主选择"

**所以改动 4 的本质不是"给系统路径开后门"，而是消除这个模块间矛盾**——让 `file_guard` 与 `pip_env` 的设计意图一致：既然 `pip_env` 已认定"LLM 应该用 isolation_venv 的 python"，`file_guard` 就不该再把这个路径当外部路径。

**信任范围的精确收窄**：
- 仅把 `isolation_venv/Scripts`（Windows）或 `isolation_venv/bin`（Linux）加入 `trusted_exec_directory`（**exec 轴**）
- **不**加入 `global`（read/write 轴）——不信任往该目录写任意文件
- 即：✅ 执行 `isolation_venv\Scripts\python.exe` → ALLOW；❌ 往 `isolation_venv\Scripts\` 写 .exe → 仍 ASK
- 这没有破坏 file_guard 的白名单模型，只是承认了 `pip_env` 已建立的事实

**实现**：在 `merged_file_guard_config` 末尾调用 `_inject_system_default_trust`，通过 `jiuwenclaw.runtime.get_runtime_venv_dir()` 获取 venv 路径，仅当该路径未被用户显式配置时注入（不覆盖用户配置）。

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->