### PR TITLE
fix:skill_turbo工具executor概率没有读写workspace目录权限

### DIFF
--- a/jiuwenclaw/agentserver/deep_agent/interface_deep.py
+++ b/jiuwenclaw/agentserver/deep_agent/interface_deep.py
@@ -6473,6 +6473,10 @@ class JiuWenClawDeepAdapter:
             "audio_model_config": self._audio_model_config,
             "video_model_enabled": bool(self._video_model_config),
             "image_gen_enabled": bool(self._image_gen_enabled),
+            # 显式传入主 agent 的 sys_operation，确保 SkillTurbo 使用主 agent 的不受限 sysop
+            # （restrict_to_sandbox=False），而非走 Runner.resource_mgr.get_sys_operation()
+            # 无参数路径取到残留 subagent 的受限 sysop（restrict_to_sandbox=True）。
+            "sys_operation": self._sys_operation,
         }
 
     def _create_skill_turbo_fallback_handler(self) -> Any:

--- a/jiuwenclaw/agentserver/tools/subagent_executor/executor.py
+++ b/jiuwenclaw/agentserver/tools/subagent_executor/executor.py
@@ -722,6 +722,20 @@ Approach each task methodically and deliver high-quality results.
             )
         finally:
             reset_current_fork_agent_executor(executor_token)
+            # 清理 create_deep_agent 自动注册的子代理 sysop，防止 resource_mgr 残留
+            # 受限 sysop（restrict_to_sandbox=True）污染后续 skill_turbo 的 sysop 解析。
+            sysop_id = f"fork_{task.role_id}_{task.task_id}"
+            try:
+                remove_result = Runner.resource_mgr.remove_sys_operation(sysop_id)
+                if hasattr(remove_result, "is_err") and remove_result.is_err():
+                    logger.warning(
+                        "[ForkAgent] remove sys_operation failed: %s",
+                        remove_result.msg(),
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[ForkAgent] remove sys_operation raised: %s", exc,
+                )
 
     async def execute_spawn(
         self,
@@ -873,6 +887,21 @@ Approach each task methodically and deliver high-quality results.
             )
         finally:
             reset_current_fork_agent_executor(executor_token)
+            # 清理 create_deep_agent 自动注册的子代理 sysop，防止 resource_mgr 残留
+            # 受限 sysop（restrict_to_sandbox=True）污染后续 skill_turbo 的 sysop 解析。
+            # sysop id 格式见 factory.py: "{card.name}_{card.id}"。
+            sysop_id = f"spawn_{task.role_id}_{task.task_id}"
+            try:
+                remove_result = Runner.resource_mgr.remove_sys_operation(sysop_id)
+                if hasattr(remove_result, "is_err") and remove_result.is_err():
+                    logger.warning(
+                        "[SpawnAgent] remove sys_operation failed: %s",
+                        remove_result.msg(),
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[SpawnAgent] remove sys_operation raised: %s", exc,
+                )
 
     async def _create_spawn_agent(
         self,


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind <label>

  ## Subagent Sandbox 权限问题修复

## 问题概述

PPT pipeline 中 skill 模式和 skill_turbo 模式的文件工具（skill_tool / write_file / read_file）在 sandbox 限制下出现 Access denied 报错，导致技能指令无法加载、文件无法写入，PPT 质量严重受损。

## 根因分析

### 1. skill 模式：skill_tool 报 Access denied

**现象**：spawn subagent 调用 skill_tool 读取 SKILL.md 时报 `outside sandbox`，sandbox 列表为 `[jiuwenclaw_workspace, jiuwenclaw_workspace]`（fallback 值）。

**根因（双层）**：

- **工具层**：`_inherit_tools_for_spawn` 先将父 agent 的 skill_tool ToolCard 放入子 ability_manager，但后续 `JiuWenSkillUseRail.init()` 的 qualify 循环会 `remove` 掉继承的父 card、换成子代理自己的限名 card。因此 skill_tool 最终用的是**子代理 sysop**（restrict_to_sandbox=True）。
- **sysop 层**：executor.py 传了 `allowed_paths=[ws, *skill_dirs]`，但旧版 openjiuwen 的 `create_deep_agent` 中 `allowed_paths` 不是命名参数，通过 `**config_kwargs` 流入 `DeepAgentConfig` 后被丢弃。子 sysop 的 `sandbox_root=None` → fallback 到 `[get_workspace(), get_project_root()]` = `[jiuwenclaw_workspace]`，不包含 skills 目录（D 盘）。

**对比**：同模式下 write_file 未报错，因为 `FileSystemRail` 没有 qualify 循环，子代理 WriteFileTool 实例在 resource_mgr 和 ability_manager 两层都被拒绝（重名 + dedup），最终保留了继承的父 agent 实例（sysop_父, restrict=False）。

### 2. skill_turbo 模式：write_file/read_file 报 Access denied

**现象**：skill_turbo executor 调用 write_file 写 workspace 输出目录时报 `outside sandbox`，tool_call_id 格式为 `skill_turbo-tc-write_file-{hash}-{idx}`。

**根因**：

- `build_skill_turbo_config` **没有传 `sys_operation`**，turbo 的 `_resolve_sys_operation()` 走 fallback 路径：`Runner.resource_mgr.get_sys_operation()` 无参数返回 `list(set)`，取 `sys_ops[0]`——顺序取决于 Python hash randomization，可能取到**残留 subagent 的受限 sysop**（restrict=True）。
- `tools_loader._load_oj_filesystem` 创建全新的 WriteFileTool 实例，传入 turbo 解析的 sysop。由于 turbo 不经过 `_inherit_tools_for_spawn` 继承父 agent 工具，write_file 无法"蹭"父 agent 的不受限 sysop。
- 进程运行越久、创建过的 subagent 越多，残留的 restrict=True sysop 越多，turbo 取到错误 sysop 的概率越高。

### 3. 残留 sysop 污染 resource_mgr

`create_deep_agent`（openjiuwen factory.py:262）在子代理未显式传入 `sys_operation` 时，自动调用 `Runner.resource_mgr.add_sys_operation(sysop_card)` 注册一个受限 sysop。但 `execute_spawn` / `execute_fork` 的 finally 块**从不清理**，导致受限 sysop 永久残留。

## 修改方案

### 修改1：skill_turbo 显式传入主 agent 的 sysop

**文件**：`jiuwenclaw/agentserver/deep_agent/interface_deep.py` 的 `build_skill_turbo_config()`

```python
return {
    ...
    "sys_operation": self._sys_operation,  # 新增
}
```

**效果**：`_resolve_sys_operation()` 走优先级1（config["sys_operation"]），直接返回主 agent 的不受限 sysop（restrict=False），不再走 `get_sys_operation()` 无参数路径。

**覆盖范围**：skill_turbo 模式的所有文件工具（write_file/read_file/glob/grep 等）不再受 sandbox 限制。

### 修改2：subagent 结束时清理残留 sysop

**文件**：`jiuwenclaw/agentserver/tools/subagent_executor/executor.py` 的 `execute_spawn()` 和 `execute_fork()` 外层 finally 块

```python
finally:
    reset_current_fork_agent_executor(executor_token)
    sysop_id = f"spawn_{task.role_id}_{task.task_id}"  # fork: f"fork_..."
    try:
        remove_result = Runner.resource_mgr.remove_sys_operation(sysop_id)
        if hasattr(remove_result, "is_err") and remove_result.is_err():
            logger.warning("[SpawnAgent] remove sys_operation failed: %s", remove_result.msg())
    except Exception as exc:
        logger.warning("[SpawnAgent] remove sys_operation raised: %s", exc)
```

**效果**：subagent 结束后（无论成功/超时/异常），其受限 sysop 从 resource_mgr 中移除，不再污染后续 skill_turbo 的 sysop 解析。`remove_sys_operation` 内部会自动清理该 sysop 关联的工具。

**安全模式**：复用 `interface_deep.py` 既有模式（try/except + is_err() 兜底），对不存在的 sysop id 是 no-op。

## 两个修改的关系

| 修改 | 解决的问题 | 防御层 |
|------|-----------|--------|
| 修改1 | skill_turbo 取错 sysop | 第一层：让 turbo 直接用主 sysop，不依赖 resource_mgr |
| 修改2 | resource_mgr 残留污染 | 第二层：即使第一层失效，resource_mgr 中也没有残留的受限 sysop 可被取到 |

## 验证要点

- skill_turbo 模式下 write_file 写 workspace 输出目录不再报 Access denied
- skill 模式下 skill_tool 读 SKILL.md 不再报 Access denied（需配合 openjiuwen PR 1882）
- subagent 结束后 `Runner.resource_mgr` 中无残留受限 sysop
- 长时间运行多 session 后 turbo 仍能取到正确的 sysop
  

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->