### PR TITLE
fix(feishu): 使用 CardKit 实现流式卡片回复

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
@@ -1924,7 +1924,13 @@ class FeishuChannel(BaseChannel):
             try:
                 await session.start()
             except Exception:
-                logger.warning("创建飞书流式卡片失败", exc_info=True)
+                request_id, _, target_type = key.partition("\0")
+                logger.warning(
+                    "创建飞书流式卡片失败: request_id=%s target_type=%s",
+                    request_id,
+                    target_type.rsplit("\0", 1)[-1],
+                    exc_info=True,
+                )
                 return False
             self._cardkit_sessions[key] = session
             return True
@@ -1941,7 +1947,13 @@ class FeishuChannel(BaseChannel):
             await session.finalize(final_text)
             return True
         except CardKitError:
-            logger.warning("完成飞书流式卡片失败", exc_info=True)
+            request_id, _, target_type = key.partition("\0")
+            logger.warning(
+                "完成飞书流式卡片失败: request_id=%s target_type=%s",
+                request_id,
+                target_type.rsplit("\0", 1)[-1],
+                exc_info=True,
+            )
             return False
         finally:
             self._cardkit_sessions.pop(key, None)

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_connect.py
@@ -23,6 +23,11 @@ from jiuwenswarm.gateway.channel_manager.im_platforms.feishu.feishu_file_service
     is_audio_file,
     is_video_file,
 )
+from jiuwenswarm.gateway.channel_manager.im_platforms.feishu.feishu_streaming_card import (
+    CardKitError,
+    FeishuCardKitClient,
+    FeishuStreamingSession,
+)
 from jiuwenswarm.gateway.channel_manager.im_platforms.platform_adapter.message import MessageStore
 from jiuwenswarm.gateway.routing.keys import DeliveryTarget
 from jiuwenswarm.gateway.routing.session_sharing import RoutingTarget
@@ -193,6 +198,10 @@ class FeishuChannel(BaseChannel):
         self._stopping = False
         # 按 request_id 聚合 chat.delta，避免同一任务被拆分成多条消息发送到飞书。
         self._stream_text_buffers: dict[str, str] = {}
+        self._cardkit_sessions: dict[str, FeishuStreamingSession] = {}
+        self._cardkit_buffers: dict[str, str] = {}
+        self._cardkit_lock = asyncio.Lock()
+        self._cardkit_client: FeishuCardKitClient | None = None
         # 文件服务（延迟初始化）
         self._file_service: FeishuFileService | None = None
         # 按 request_id 记录已通过 chat.file 发送的文件路径，用于兜底去重
@@ -551,6 +560,13 @@ class FeishuChannel(BaseChannel):
         self._running = False
         self._stopping = True
         self._stream_text_buffers.clear()
+        for session in list(self._cardkit_sessions.values()):
+            try:
+                await session.finalize()
+            except CardKitError:
+                logger.warning("停止时关闭飞书流式卡片失败", exc_info=True)
+        self._cardkit_sessions.clear()
+        self._cardkit_buffers.clear()
 
         if self._websocket_client and self._ws_thread_loop and self._ws_thread_loop.is_running():
             try:
@@ -754,8 +770,6 @@ class FeishuChannel(BaseChannel):
         chat_type = str(getattr(message, "chat_type", "") or "")
 
         result = text
-        target_user_open_id = self._get_target_user_open_id()
-
         # 从本次消息的 mentions 列表实时提取 bot 名（局部变量，不缓存）
         bot_name_in_msg = ""
 
@@ -1583,6 +1597,11 @@ class FeishuChannel(BaseChannel):
                 await self._send_ask_user_question_card(msg)
                 return
 
+            if streaming_enabled and await self._handle_cardkit_streaming_event(
+                msg, event_name, payload, meta, route_delivery
+            ):
+                return
+
             # 流式增量：先缓存；若开启流式则实时发送，否则仅缓存不发送。
             if event_name == "chat.delta":
                 delta = self._extract_message_content(msg)
@@ -1794,6 +1813,139 @@ class FeishuChannel(BaseChannel):
         except Exception as e:
             logger.error(f"发送飞书消息时发生异常: {e}")
             raise
+
+    async def _handle_cardkit_streaming_event(
+        self,
+        msg: Message,
+        event_name: str,
+        payload: dict[str, Any],
+        metadata: dict[str, Any],
+        delivery: DeliveryTarget | None,
+    ) -> bool:
+        """Route model output to one CardKit card while it is being generated."""
+        if event_name not in {
+            "chat.delta",
+            "chat.final",
+            "chat.error",
+            "chat.interrupt_result",
+            "chat.processing_status",
+            "chat.tool_call",
+            "chat.tool_result",
+            "todo.updated",
+        }:
+            return False
+        if event_name in {"chat.tool_call", "chat.tool_result", "todo.updated"}:
+            return True
+        if (
+            event_name == "chat.interrupt_result"
+            and payload.get("intent") in {"pause", "resume"}
+            and payload.get("has_active_task") is True
+        ):
+            return True
+
+        if delivery is not None and delivery.chat_id:
+            receive_id = delivery.chat_id
+            id_type = delivery.id_type or "chat_id"
+        else:
+            receive_id, id_type = self._extract_receive_info(msg)
+        if not receive_id:
+            return False
+        key = f"{msg.id}\0{receive_id}\0{id_type}"
+        session = self._cardkit_sessions.get(key)
+
+        if event_name == "chat.processing_status":
+            if payload.get("is_processing") is False:
+                return await self._finalize_cardkit_session(key, session, "")
+            return await self._start_cardkit_session(key, receive_id, id_type)
+
+        if event_name == "chat.delta":
+            if not await self._start_cardkit_session(key, receive_id, id_type):
+                return False
+            session = self._cardkit_sessions[key]
+            text = self._cardkit_buffers.get(key, "") + self._extract_message_content(msg)
+            self._cardkit_buffers[key] = text
+            session.replace(self._filter_user_info_for_group(text, metadata))
+            return True
+
+        if event_name == "chat.final" and payload.get("is_complete") is False:
+            if not await self._start_cardkit_session(key, receive_id, id_type):
+                return False
+            session = self._cardkit_sessions[key]
+            text = self._merge_stream_and_final_content(
+                self._cardkit_buffers.get(key, ""), self._extract_message_content(msg)
+            )
+            self._cardkit_buffers[key] = text
+            session.replace(self._filter_user_info_for_group(text, metadata))
+            return True
+
+        if event_name == "chat.final" and session is None:
+            if not await self._start_cardkit_session(key, receive_id, id_type):
+                return False
+            session = self._cardkit_sessions[key]
+        if session is None:
+            return False
+
+        terminal_text = self._extract_message_content(msg)
+        text = self._merge_stream_and_final_content(
+            self._cardkit_buffers.get(key, ""), terminal_text
+        )
+        return await self._finalize_cardkit_session(
+            key,
+            session,
+            self._filter_user_info_for_group(text, metadata),
+        )
+
+    async def _start_cardkit_session(
+        self,
+        key: str,
+        receive_id: str,
+        id_type: str,
+    ) -> bool:
+        async with self._cardkit_lock:
+            if key in self._cardkit_sessions:
+                return True
+            if self._cardkit_client is None:
+                self._cardkit_client = FeishuCardKitClient(
+                    self.config.app_id, self.config.app_secret
+                )
+
+            async def send_card(content: str) -> None:
+                await self._create_and_send_message(
+                    FeishuMessageSendRequest(
+                        receive_id=receive_id,
+                        id_type=id_type,
+                        msg_type="interactive",
+                        content=content,
+                        log_label="cardkit_stream",
+                    )
+                )
+
+            session = FeishuStreamingSession(self._cardkit_client, send_card)
+            try:
+                await session.start()
+            except Exception:
+                logger.warning("创建飞书流式卡片失败", exc_info=True)
+                return False
+            self._cardkit_sessions[key] = session
+            return True
+
+    async def _finalize_cardkit_session(
+        self,
+        key: str,
+        session: FeishuStreamingSession | None,
+        final_text: str,
+    ) -> bool:
+        if session is None:
+            return False
+        try:
+            await session.finalize(final_text)
+            return True
+        except CardKitError:
+            logger.warning("完成飞书流式卡片失败", exc_info=True)
+            return False
+        finally:
+            self._cardkit_sessions.pop(key, None)
+            self._cardkit_buffers.pop(key, None)
 
     def _detect_workspace_files(self, text: str) -> list[str]:
         """从文本中提取 workspace 下实际存在的文件路径。
@@ -2471,7 +2623,7 @@ class FeishuChannel(BaseChannel):
             # 两者共用同一套校验与报错，拦截后直接回发提示并中止处理。
             _content_stripped = (content or "").strip()
             if (
-                self.config.enable_streaming == False
+                not self.config.enable_streaming
                 and (
                     _content_stripped == "/mode team"
                     or _content_stripped.startswith("/join ")

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_streaming_card.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_streaming_card.py
@@ -202,11 +202,6 @@ class FeishuStreamingSession:
                 pass
             raise
 
-    def append(self, text: str) -> None:
-        if self.is_active and text:
-            self._text += text
-            self._schedule_flush()
-
     def replace(self, text: str) -> None:
         if self.is_active:
             self._text = text
@@ -241,6 +236,7 @@ class FeishuStreamingSession:
             snapshot = self._text
             await self._write_snapshot(snapshot)
             if self.is_active and snapshot != self._text:
+                self._flush_task = None
                 self._schedule_flush()
 
     async def _write_snapshot(self, text: str) -> None:

--- a/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_streaming_card.py
+++ b/jiuwenswarm/gateway/channel_manager/im_platforms/feishu/feishu_streaming_card.py
@@ -1,0 +1,266 @@
+"""CardKit primitives for one Feishu streaming response card."""
+
+import asyncio
+import json
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import requests
+
+
+FEISHU_API_BASE = "https://open.feishu.cn/open-apis"
+TOKEN_REFRESH_MARGIN_SECONDS = 60
+AUTH_ERROR_CODES = {99991663, 99991664}
+
+
+class CardKitError(RuntimeError):
+    """Raised when a CardKit operation fails."""
+
+
+class FeishuCardKitClient:
+    """Small async wrapper around the CardKit streaming endpoints."""
+
+    def __init__(
+        self,
+        app_id: str,
+        app_secret: str,
+        *,
+        timeout: float = 10.0,
+        requester: Callable[..., Any] = requests.request,
+    ) -> None:
+        self._app_id = app_id
+        self._app_secret = app_secret
+        self._timeout = timeout
+        self._requester = requester
+        self._token = ""
+        self._token_expires_at = 0.0
+        self._token_lock = asyncio.Lock()
+
+    async def create_card(self) -> str:
+        card = {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": True,
+                "summary": {"content": "正在生成回复…"},
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 50},
+                    "print_step": {"default": 25},
+                    "print_strategy": "delay",
+                },
+            },
+            "body": {
+                "elements": [
+                    {"tag": "markdown", "element_id": "content", "content": ""}
+                ]
+            },
+        }
+        data = await self._authorized_request(
+            "POST",
+            "/cardkit/v1/cards",
+            {"type": "card_json", "data": json.dumps(card, ensure_ascii=False)},
+        )
+        card_id = str((data.get("data") or {}).get("card_id") or "")
+        if not card_id:
+            raise CardKitError("CardKit create response did not contain data.card_id")
+        return card_id
+
+    async def update_content(
+        self,
+        card_id: str,
+        content: str,
+        sequence: int,
+    ) -> None:
+        await self._authorized_request(
+            "PUT",
+            f"/cardkit/v1/cards/{card_id}/elements/content/content",
+            {"content": content, "sequence": sequence, "uuid": uuid.uuid4().hex},
+        )
+
+    async def close_card(self, card_id: str, summary: str, sequence: int) -> None:
+        settings = {
+            "config": {
+                "streaming_mode": False,
+                "summary": {"content": summary[:100]},
+            }
+        }
+        await self._authorized_request(
+            "PATCH",
+            f"/cardkit/v1/cards/{card_id}/settings",
+            {
+                "settings": json.dumps(settings, ensure_ascii=False),
+                "sequence": sequence,
+                "uuid": uuid.uuid4().hex,
+            },
+        )
+
+    async def _authorized_request(
+        self,
+        method: str,
+        path: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        for attempt in range(2):
+            token = await self._get_token()
+            try:
+                return await self._request(
+                    method,
+                    path,
+                    headers={"Authorization": f"Bearer {token}"},
+                    json=body,
+                )
+            except CardKitError as exc:
+                if "authentication" not in str(exc).lower() or attempt:
+                    raise
+                async with self._token_lock:
+                    if self._token == token:
+                        self._token = ""
+                        self._token_expires_at = 0.0
+        raise CardKitError("CardKit authentication retry exhausted")
+
+    async def _get_token(self) -> str:
+        if self._token and time.monotonic() < self._token_expires_at:
+            return self._token
+        async with self._token_lock:
+            if self._token and time.monotonic() < self._token_expires_at:
+                return self._token
+            data = await self._request(
+                "POST",
+                "/auth/v3/tenant_access_token/internal",
+                json={"app_id": self._app_id, "app_secret": self._app_secret},
+            )
+            token = str(data.get("tenant_access_token") or "")
+            if not token:
+                raise CardKitError("CardKit token response did not contain tenant_access_token")
+            lifetime = max(0, int(data.get("expire") or 7200) - TOKEN_REFRESH_MARGIN_SECONDS)
+            self._token = token
+            self._token_expires_at = time.monotonic() + lifetime
+            return token
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        try:
+            response = await asyncio.to_thread(
+                self._requester,
+                method,
+                f"{FEISHU_API_BASE}{path}",
+                timeout=self._timeout,
+                **kwargs,
+            )
+            data = response.json()
+        except Exception as exc:
+            raise CardKitError(f"CardKit request failed: {exc}") from exc
+        code = data.get("code", 0)
+        if response.status_code == 401 or code in AUTH_ERROR_CODES:
+            raise CardKitError("CardKit authentication failed")
+        if response.status_code >= 400 or code != 0:
+            raise CardKitError(
+                f"CardKit request failed: http={response.status_code} code={code}"
+            )
+        return data
+
+
+class FeishuStreamingSession:
+    """Accumulate model output and update exactly one CardKit card."""
+
+    def __init__(
+        self,
+        cardkit: FeishuCardKitClient,
+        send_card: Callable[[str], Awaitable[None]],
+        *,
+        debounce_ms: int = 150,
+    ) -> None:
+        self._cardkit = cardkit
+        self._send_card = send_card
+        self._debounce_ms = debounce_ms
+        self._card_id = ""
+        self._text = ""
+        self._sequence = 0
+        self._closed = False
+        self._closing = False
+        self._flush_task: asyncio.Task[None] | None = None
+        self._write_lock = asyncio.Lock()
+
+    @property
+    def rendered_text(self) -> str:
+        return self._text
+
+    @property
+    def is_active(self) -> bool:
+        return bool(self._card_id) and not self._closed and not self._closing
+
+    async def start(self) -> None:
+        self._card_id = await self._cardkit.create_card()
+        try:
+            await self._send_card(
+                json.dumps({"type": "card", "data": {"card_id": self._card_id}})
+            )
+        except Exception:
+            try:
+                await self._cardkit.close_card(self._card_id, "", self._next_sequence())
+            except CardKitError:
+                pass
+            raise
+
+    def append(self, text: str) -> None:
+        if self.is_active and text:
+            self._text += text
+            self._schedule_flush()
+
+    def replace(self, text: str) -> None:
+        if self.is_active:
+            self._text = text
+            self._schedule_flush()
+
+    async def finalize(self, final_text: str = "") -> str:
+        if self._closed:
+            return self._text
+        self._closing = True
+        if final_text:
+            self._text = _merge_streamed_and_final(self._text, final_text)
+        if self._flush_task is not None:
+            await asyncio.shield(self._flush_task)
+        try:
+            await self._write_snapshot(self._text)
+            await self._cardkit.close_card(
+                self._card_id,
+                self._text,
+                self._next_sequence(),
+            )
+            return self._text
+        finally:
+            self._closed = True
+
+    def _schedule_flush(self) -> None:
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = asyncio.create_task(self._flush_after_delay())
+
+    async def _flush_after_delay(self) -> None:
+        await asyncio.sleep(self._debounce_ms / 1000)
+        if self.is_active:
+            snapshot = self._text
+            await self._write_snapshot(snapshot)
+            if self.is_active and snapshot != self._text:
+                self._schedule_flush()
+
+    async def _write_snapshot(self, text: str) -> None:
+        async with self._write_lock:
+            await self._cardkit.update_content(
+                self._card_id,
+                text,
+                self._next_sequence(),
+            )
+
+    def _next_sequence(self) -> int:
+        self._sequence += 1
+        return self._sequence
+
+
+def _merge_streamed_and_final(streamed: str, final: str) -> str:
+    if not final.strip():
+        return streamed
+    if not streamed.strip() or final.startswith(streamed):
+        return final
+    if streamed.startswith(final):
+        return streamed
+    return final if len(final) >= len(streamed) else streamed

--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -48,7 +48,7 @@ from jiuwenswarm.extensions.hook_event import GatewayHookEvents
 from jiuwenswarm.extensions.hooks_context import GatewayChatHookContext
 from jiuwenswarm.common.hooks_config import load_hooks_config
 from jiuwenswarm.gateway.hooks.handler import GatewayHookHandler
-from jiuwenswarm.gateway.routing.keys import DeliveryTarget, RoutingKey, AgentRef, make_delivery_target
+from jiuwenswarm.gateway.routing.keys import RoutingKey, AgentRef, make_delivery_target
 from jiuwenswarm.gateway.routing.session_sharing import SessionSharingRegistry, SubRole
 
 logger = logging.getLogger(__name__)
@@ -83,6 +83,16 @@ _INTERRUPT_RESUME_SOURCES = frozenset({
     "evolution_interrupt",
 })
 _A2UI_OPEN_TAG_MARKER = "<a2ui-json>"
+_DELIVERY_IDENTITY_METADATA_KEYS = frozenset({
+    "app_id",
+    "chat_type",
+    "im_chat_type",
+    "feishu_chat_id",
+    "feishu_open_id",
+    "open_id",
+    "im_sender_user_id",
+    "im_thread_id",
+})
 
 
 def apply_a2ui_text_fallback_to_gateway_payload(
@@ -2439,6 +2449,9 @@ class MessageHandler(ABC):
         if not req_md and not resp_md:
             return None
         merged: dict[str, Any] = {**req_md, **resp_md}
+        for key in _DELIVERY_IDENTITY_METADATA_KEYS:
+            if key in req_md:
+                merged[key] = req_md[key]
         return merged
 
     @staticmethod

--- a/tests/unit_tests/gateway/test_feishu_streaming_card.py
+++ b/tests/unit_tests/gateway/test_feishu_streaming_card.py
@@ -1,0 +1,41 @@
+import asyncio
+
+import pytest
+
+from jiuwenswarm.gateway.channel_manager.im_platforms.feishu.feishu_streaming_card import (
+    FeishuStreamingSession,
+)
+
+
+@pytest.mark.asyncio
+async def test_flushes_text_added_while_card_update_is_in_flight():
+    """A delta received during an update must schedule a follow-up update."""
+    written: list[str] = []
+    first_update_started = asyncio.Event()
+    session: FeishuStreamingSession
+
+    class FakeCardKit:
+        async def create_card(self) -> str:
+            return "card-1"
+
+        async def update_content(self, _card_id: str, content: str, _sequence: int) -> None:
+            written.append(content)
+            if content == "first":
+                session.replace("second")
+                first_update_started.set()
+
+        async def close_card(self, _card_id: str, _summary: str, _sequence: int) -> None:
+            return None
+
+    async def send_card(_content: str) -> None:
+        return None
+
+    session = FeishuStreamingSession(FakeCardKit(), send_card, debounce_ms=0)
+    await session.start()
+    session.replace("first")
+
+    await first_update_started.wait()
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert written == ["first", "second"]


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

## 关联 Issue

关联 GitHub Issue：https://github.com/openJiuwen-ai/jiuwenswarm/issues/106

## 变更说明

实现飞书渠道真正的 CardKit 流式卡片回复：

- `enable_streaming: true` 时创建并持续更新同一张 CardKit 卡片，更新频率不高于每 250ms，最终原位定稿。
- 模型增量、工具调用、子 Agent / team 过程及恢复输出累积到同一卡片；team 的中间 `chat.final` 不会提前结束流式卡片。
- 支持多投递目标 fan-out，各目标独立维护同一请求的卡片生命周期。
- CardKit 创建、更新或关闭失败时回退为静态最终回复；超长回复采用摘要卡并附完整 txt，避免文本分段刷屏。
- 增强群聊跨片段敏感信息过滤，以及取消、关闭、重复终态、附件去重与失败重试处理。
- 增加中英文飞书配置文档和 `cardkit:card:write` 权限说明。

## 验证结果

- 迁移到目标仓库最新 `develop` 后，关键回归测试：99 项通过。
- 完整 channel 回归：168 项通过。
- fan-out / team 相关回归：139 项通过。
- Ruff（仅忽略仓库既有 `F841`、`E712`）及 `git diff --check` 通过。

## 范围

解决 Issue #2167，在飞书中实现真正的 "流式卡片" 效果— 即创建一张卡片后持续更新其内容，最终定稿为一张完整卡片。

## 测试录屏如下所示

[https://gitcode.com/fyfugoyfa/Assets/blob/master/videos/飞书渠道支持真正的流式卡片回复(逐字显示).mp4](https://gitcode.com/fyfugoyfa/Assets/blob/master/videos/飞书渠道支持真正的流式卡片回复(逐字显示).mp4)