### PR TITLE
feat(a2a): separate reasoning from answer in A2A responses

### DIFF
--- a/docs/en/A2A.md
+++ b/docs/en/A2A.md
@@ -60,6 +60,7 @@ uv sync --extra a2a
 | `A2A_SERVER_APP_NAME` | `JiuwenSwarm Gateway A2A Server` | Agent Card `name` |
 | `A2A_SERVER_APP_DESCRIPTION` | `A2A ingress for JiuwenSwarm Gateway` | Agent Card `description` |
 | `A2A_SERVER_APP_VERSION` | `0.1.0` | Agent Card `version` |
+| `A2A_SERVER_EXPOSE_REASONING` | `true` (enabled by default) | when enabled, reasoning (thinking) content is emitted as working-state `TaskStatusUpdateEvent` (see §6.2); set to `false`/`0`/`no`/`off` to drop it |
 
 AgentServer connectivity still follows existing gateway config (for example `AGENT_SERVER_URL`) and is independent from the A2A listening endpoint.
 
@@ -116,8 +117,11 @@ Inbound A2A `message.parts` are mapped into internal `Message.params.query` and 
 
 | Internal | A2A |
 |------|-----|
-| `payload.content`, tool-related events, etc. | `Part(text=...)`, etc. |
+| `payload.content`, tool-related events, etc. | `Part(text=...)`, etc., written into the `response` artifact |
 | `payload.files[]` | `Part` url / data / raw fields |
+| reasoning content (`chat.reasoning`, or `chat.delta` with `source_chunk_type == "llm_reasoning"`) | see below |
+
+**Separating reasoning from the answer**: reasoning content never enters the `response` artifact. By default (`A2A_SERVER_EXPOSE_REASONING` enabled) it is emitted as working-state `TaskStatusUpdateEvent`s whose `status.message.parts[].metadata` carries `{"jiuwen_thought": true}` (mirroring Google ADK's `adk_thought` convention), so callers can structurally render or ignore it. Set to `false`/`0`/`no`/`off` to drop it.
 
 ---
 

--- a/docs/zh/A2A.md
+++ b/docs/zh/A2A.md
@@ -60,6 +60,7 @@ uv sync --extra a2a
 | `A2A_SERVER_APP_NAME` | `JiuwenSwarm Gateway A2A Server` | Agent Card `name` |
 | `A2A_SERVER_APP_DESCRIPTION` | `A2A ingress for JiuwenSwarm Gateway` | Agent Card `description` |
 | `A2A_SERVER_APP_VERSION` | `0.1.0` | Agent Card `version` |
+| `A2A_SERVER_EXPOSE_REASONING` | `true`（默认开启） | 开启后思考（reasoning）内容以 working 状态的 `TaskStatusUpdateEvent` 输出（见 §6.2）；设为 `false`/`0`/`no`/`off` 时直接丢弃 |
 
 AgentServer 连接仍由网关既有逻辑配置（例如 `AGENT_SERVER_URL` 等），与 A2A 监听端口独立。
 
@@ -116,8 +117,11 @@ flowchart LR
 
 | 内部 | A2A |
 |------|-----|
-| `payload.content`、工具相关事件等 | `Part(text=...)` 等 |
+| `payload.content`、工具相关事件等 | `Part(text=...)` 等，写入 `response` artifact |
 | `payload.files[]` | `Part` 的 url / data / raw 等 |
+| 思考内容（`chat.reasoning` 或 `chat.delta` 且 `source_chunk_type == "llm_reasoning"`） | 见下 |
+
+**思考与正文的区分**：思考内容不会写入 `response` artifact。默认（`A2A_SERVER_EXPOSE_REASONING` 开启）以 working 状态的 `TaskStatusUpdateEvent` 输出，`status.message.parts[].metadata` 携带 `{"jiuwen_thought": true}` 标记（对齐 Google ADK 的 `adk_thought` 惯例），调用方可结构化识别或忽略；设为 `false`/`0`/`no`/`off` 时直接丢弃。
 
 ---
 

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -1391,6 +1391,8 @@ async def _run(
                 os.getenv("A2A_SERVER_APP_VERSION", "0.1.0")
             ).strip()
                         or "0.1.0",
+            expose_reasoning=str(os.getenv("A2A_SERVER_EXPOSE_REASONING", "true")).strip().lower()
+                             not in {"0", "false", "no", "off"},
         ),
         _DummyBus(),
     )

--- a/jiuwenswarm/gateway/channel_manager/protocol/a2a/a2a_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/protocol/a2a/a2a_connect.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from jiuwenswarm.gateway.channel_manager.base import BaseChannel
+from jiuwenswarm.common.e2a.acp.acp_tool_updates import is_reasoning_event
 from jiuwenswarm.common.schema.message import EventType, Message, ReqMethod
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,11 @@ try:
     from a2a.server.agent_execution import AgentExecutor as _AgentExecutorBase
 except ImportError:
     _AgentExecutorBase = object
+
+# Part-level metadata key marking reasoning/thought content, mirroring the
+# convention popularized by Google ADK (`adk_thought`). A2A itself has no
+# first-class thought field; `Part.metadata` is the official extension point.
+A2A_THOUGHT_METADATA_KEY = "jiuwen_thought"
 
 
 def _raise_missing_a2a_sdk(exc: ImportError) -> None:
@@ -38,6 +44,12 @@ class A2AChannelConfig:
     app_name: str = "JiuwenSwarm Gateway A2A Server"
     app_description: str = "A2A ingress for JiuwenSwarm Gateway"
     app_version: str = "0.1.0"
+    # When True (default), reasoning (thinking) content is streamed to A2A
+    # callers as working-state TaskStatusUpdateEvent messages whose parts
+    # carry the `jiuwen_thought` metadata marker. When False, reasoning is
+    # dropped. Reasoning is never written into the final `response` artifact
+    # either way.
+    expose_reasoning: bool = True
 
 
 @dataclass
@@ -81,6 +93,8 @@ class _A2AAgentExecutor(_AgentExecutorBase):
         from a2a.helpers import new_text_status_update_event
         from a2a.types import (
             Artifact,
+            Message as A2AMessage,
+            Role,
             TaskArtifactUpdateEvent,
             TaskState,
             TaskStatus,
@@ -129,11 +143,47 @@ class _A2AAgentExecutor(_AgentExecutorBase):
             artifact_started = False
             while True:
                 response_msg = await pending.queue.get()
-                response_parts = self._channel.message_to_a2a_parts(
-                    response_msg,
-                    fallback_to_text=False,
-                )
                 is_terminal = self._channel.is_terminal_message(response_msg)
+                is_reasoning = self._channel.is_reasoning_message(response_msg)
+
+                # Reasoning never enters the response artifact. When exposed,
+                # it is streamed as working-state status updates with thought
+                # metadata so callers can render or ignore it structurally.
+                if not is_terminal and is_reasoning:
+                    if self._channel.config.expose_reasoning:
+                        thought_parts = self._channel.message_to_a2a_parts(
+                            response_msg,
+                            fallback_to_text=False,
+                        )
+                        if thought_parts:
+                            await event_queue.enqueue_event(
+                                TaskStatusUpdateEvent(
+                                    task_id=task_id,
+                                    context_id=context_id,
+                                    status=TaskStatus(
+                                        state=TaskState.TASK_STATE_WORKING,
+                                        message=A2AMessage(
+                                            message_id=f"{task_id}_thought_{uuid.uuid4().hex[:8]}",
+                                            task_id=task_id,
+                                            context_id=context_id,
+                                            role=Role.ROLE_AGENT,
+                                            parts=thought_parts,
+                                        ),
+                                    ),
+                                )
+                            )
+                    continue
+
+                # A terminal reasoning chunk still closes the task but must
+                # not leak thinking text into the response artifact.
+                response_parts = (
+                    []
+                    if is_reasoning
+                    else self._channel.message_to_a2a_parts(
+                        response_msg,
+                        fallback_to_text=False,
+                    )
+                )
                 if (
                     is_terminal
                     and not response_parts
@@ -390,6 +440,12 @@ class A2AChannel(BaseChannel):
         return ""
 
     @staticmethod
+    def is_reasoning_message(msg: Message) -> bool:
+        """Whether the message carries reasoning (thinking) content."""
+        payload = msg.payload if isinstance(msg.payload, dict) else {}
+        return is_reasoning_event(msg.event_type, payload)
+
+    @staticmethod
     def message_to_a2a_parts(msg: Message, *, fallback_to_text: bool = True) -> list[Any]:
         """Map internal message payload to A2A response parts."""
         from a2a.types import Part
@@ -402,13 +458,17 @@ class A2AChannel(BaseChannel):
             error_text = str(payload.get("error") or payload.get("content") or "agent request failed")
             return [Part(text=error_text)]
 
+        thought_metadata = (
+            {A2A_THOUGHT_METADATA_KEY: True} if A2AChannel.is_reasoning_message(msg) else None
+        )
+
         content = payload.get("content")
         if isinstance(content, str) and content.strip():
             normalized_content = content.strip()
             if not A2AChannel.is_completion_sentinel_text(normalized_content):
-                parts.append(Part(text=normalized_content))
+                parts.append(Part(text=normalized_content, metadata=thought_metadata))
         elif content is not None and not isinstance(content, (dict, list)):
-            parts.append(Part(text=str(content)))
+            parts.append(Part(text=str(content), metadata=thought_metadata))
         result = payload.get("result")
         if isinstance(result, str) and result.strip():
             normalized_result = result.strip()

--- a/tests/unit_tests/channel/test_a2a_channel.py
+++ b/tests/unit_tests/channel/test_a2a_channel.py
@@ -3,7 +3,12 @@ import time
 
 import pytest
 
-from jiuwenswarm.gateway.channel_manager.protocol.a2a.a2a_connect import A2AChannel, A2AChannelConfig
+from jiuwenswarm.gateway.channel_manager.protocol.a2a.a2a_connect import (
+    A2A_THOUGHT_METADATA_KEY,
+    A2AChannel,
+    A2AChannelConfig,
+    _A2AAgentExecutor,
+)
 from jiuwenswarm.common.schema.message import EventType, Message
 
 
@@ -302,3 +307,208 @@ def test_executor_empty_query_emits_failed_task_lifecycle():
         assert status_event.status.state == TaskState.TASK_STATE_FAILED
 
     asyncio.run(_run())
+
+
+def _make_message(
+    *,
+    payload: dict,
+    event_type: EventType,
+    msg_id: str = "req-r",
+) -> Message:
+    return Message(
+        id=msg_id,
+        type="event",
+        channel_id="a2a",
+        session_id="s1",
+        params={},
+        timestamp=time.time(),
+        ok=True,
+        payload=payload,
+        event_type=event_type,
+    )
+
+
+def test_is_reasoning_message_detection():
+    reasoning_event = _make_message(
+        payload={"content": "let me think"},
+        event_type=EventType.CHAT_REASONING,
+    )
+    reasoning_delta = _make_message(
+        payload={"content": "thinking", "source_chunk_type": "llm_reasoning"},
+        event_type=EventType.CHAT_DELTA,
+    )
+    plain_delta = _make_message(
+        payload={"content": "answer"},
+        event_type=EventType.CHAT_DELTA,
+    )
+
+    assert A2AChannel.is_reasoning_message(reasoning_event) is True
+    assert A2AChannel.is_reasoning_message(reasoning_delta) is True
+    assert A2AChannel.is_reasoning_message(plain_delta) is False
+
+
+def test_message_to_a2a_parts_marks_thought_metadata():
+    pytest.importorskip("a2a.types")
+
+    reasoning_msg = _make_message(
+        payload={"content": "let me think"},
+        event_type=EventType.CHAT_REASONING,
+    )
+    plain_msg = _make_message(
+        payload={"content": "final answer"},
+        event_type=EventType.CHAT_DELTA,
+    )
+
+    thought_parts = A2AChannel.message_to_a2a_parts(reasoning_msg, fallback_to_text=False)
+    plain_parts = A2AChannel.message_to_a2a_parts(plain_msg, fallback_to_text=False)
+
+    assert len(thought_parts) == 1
+    assert dict(thought_parts[0].metadata)[A2A_THOUGHT_METADATA_KEY] is True
+    assert len(plain_parts) == 1
+    assert A2A_THOUGHT_METADATA_KEY not in dict(plain_parts[0].metadata)
+
+
+class _FakeEventQueue:
+    def __init__(self):
+        self.events = []
+        self.closed = False
+
+    async def enqueue_event(self, event):
+        self.events.append(event)
+
+    async def close(self, immediate: bool = False):
+        self.closed = True
+
+
+class _FakeContext:
+    def __init__(self, query: str = "hello"):
+        from a2a.types import Message as A2AMessage, Part, Role
+
+        self.task_id = "task-1"
+        self.context_id = "ctx-1"
+        self.current_task = None
+        self.message = A2AMessage(
+            role=Role.ROLE_USER,
+            parts=[Part(text=query)],
+            message_id="m-fake",
+            task_id=self.task_id,
+            context_id=self.context_id,
+        )
+        self.metadata = {}
+
+    def get_user_input(self):
+        return "hello"
+
+
+def _run_executor_with_stream(channel: A2AChannel, stream: list[Message]):
+    """Drive _A2AAgentExecutor.execute with a scripted message stream."""
+    pytest.importorskip("a2a.types")
+    executor = _A2AAgentExecutor(channel)
+    event_queue = _FakeEventQueue()
+
+    async def on_message(msg: Message):
+        pending = channel._pending[str(msg.id)]
+        for item in stream:
+            replayed = Message(**{**item.__dict__, "id": msg.id})
+            await pending.queue.put(replayed)
+
+    async def _run():
+        channel.on_message(on_message)
+        await executor.execute(_FakeContext(), event_queue)
+
+    asyncio.run(_run())
+    return event_queue
+
+
+def _stream_reasoning_then_final() -> list[Message]:
+    return [
+        _make_message(
+            payload={"content": "let me think", "source_chunk_type": "llm_reasoning"},
+            event_type=EventType.CHAT_DELTA,
+        ),
+        _make_message(
+            payload={"content": "final answer", "is_complete": True},
+            event_type=EventType.CHAT_FINAL,
+        ),
+    ]
+
+
+def _thought_status_updates(events) -> list:
+    """Status updates whose message parts carry the thought metadata marker."""
+    from a2a.types import TaskStatusUpdateEvent
+
+    result = []
+    for event in events:
+        if not isinstance(event, TaskStatusUpdateEvent):
+            continue
+        if not event.status.HasField("message"):
+            continue
+        for part in event.status.message.parts:
+            if dict(part.metadata).get(A2A_THOUGHT_METADATA_KEY):
+                result.append(event)
+                break
+    return result
+
+
+def test_executor_streams_reasoning_as_thought_status_updates_by_default():
+    pytest.importorskip("a2a.types")
+    from a2a.types import TaskArtifactUpdateEvent
+
+    channel = build_channel()
+    event_queue = _run_executor_with_stream(channel, _stream_reasoning_then_final())
+
+    artifact_events = [e for e in event_queue.events if isinstance(e, TaskArtifactUpdateEvent)]
+    assert len(artifact_events) == 1
+    assert [p.text for p in artifact_events[0].artifact.parts] == ["final answer"]
+
+    thought_updates = _thought_status_updates(event_queue.events)
+    assert len(thought_updates) == 1
+    thought_parts = list(thought_updates[0].status.message.parts)
+    assert thought_parts[0].text == "let me think"
+    assert dict(thought_parts[0].metadata)[A2A_THOUGHT_METADATA_KEY] is True
+
+
+def test_executor_drops_reasoning_when_disabled():
+    pytest.importorskip("a2a.types")
+    from a2a.types import TaskArtifactUpdateEvent
+
+    channel = A2AChannel(A2AChannelConfig(enabled=False, expose_reasoning=False), DummyBus())
+    event_queue = _run_executor_with_stream(channel, _stream_reasoning_then_final())
+
+    artifact_events = [e for e in event_queue.events if isinstance(e, TaskArtifactUpdateEvent)]
+    assert len(artifact_events) == 1
+    artifact_texts = [p.text for p in artifact_events[0].artifact.parts]
+    assert artifact_texts == ["final answer"]
+    assert _thought_status_updates(event_queue.events) == []
+
+
+def test_executor_terminal_reasoning_chunk_does_not_leak_into_artifact():
+    pytest.importorskip("a2a.types")
+    from a2a.types import TaskArtifactUpdateEvent, TaskState
+
+    channel = build_channel()
+    stream = [
+        _make_message(
+            payload={"content": "answer part"},
+            event_type=EventType.CHAT_DELTA,
+        ),
+        _make_message(
+            payload={
+                "content": "trailing thought",
+                "source_chunk_type": "llm_reasoning",
+                "is_complete": True,
+            },
+            event_type=EventType.CHAT_DELTA,
+        ),
+    ]
+    event_queue = _run_executor_with_stream(channel, stream)
+
+    artifact_events = [e for e in event_queue.events if isinstance(e, TaskArtifactUpdateEvent)]
+    all_texts = [p.text for e in artifact_events for p in e.artifact.parts]
+    assert "trailing thought" not in all_texts
+    assert "answer part" in all_texts
+    final_states = [
+        e.status.state for e in event_queue.events
+        if not isinstance(e, TaskArtifactUpdateEvent)
+    ]
+    assert TaskState.TASK_STATE_COMPLETED in final_states


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind feature

## Summary

在 A2A 入站响应中区分**思考过程（reasoning）**与**正文答案（response artifact）**。思考内容永不写入 `response` artifact；通过 `A2A_SERVER_EXPOSE_REASONING` 控制是否向调用方暴露思考流。

## 背景

Gateway 内部已能识别 `chat.reasoning` / `llm_reasoning`，但 A2A 此前将所有文本扁平化为 `response` artifact，调用方无法区分思考与正文。本 PR 采用：

1. **通道分离**：思考走 `TaskStatusUpdateEvent`，正文走 `TaskArtifactUpdateEvent`
2. **Part.metadata**：思考 part 标记 `{"jiuwen_thought": true}`（对齐 ADK `adk_thought` 惯例）

## 变更

| 文件 | 说明 |
|------|------|
| `a2a_connect.py` | reasoning 识别与分流；思考不进 artifact |
| `app_gateway.py` | 读取 `A2A_SERVER_EXPOSE_REASONING` |
| `docs/zh/A2A.md`、`docs/en/A2A.md` | 环境变量与映射文档 |
| `test_a2a_channel.py` | 新增 reasoning 单测 |

| `A2A_SERVER_EXPOSE_REASONING` | 思考 | 正文 |
|-------------------------------|------|------|
| `false` | 丢弃 | `artifactUpdate` / `response` |
| `true`（默认） | `statusUpdate` + `jiuwen_thought` | `artifactUpdate` / `response` |

---

## 使用说明

### 环境变量（`~/.jiuwenswarm/config/.env`）

```bash
A2A_SERVER_ENABLED=true
A2A_SERVER_HOST=127.0.0.1
A2A_SERVER_PORT=19100
A2A_SERVER_EXPOSE_REASONING=true   # 或 false，默认true
```

`A2A_SERVER_EXPOSE_REASONING` 接受 `true` / `1` / `yes` / `on` 为开启。

### 启动

```bash
jiuwenswarm-start app
```

### 流式验证

```bash
curl -sS -N -X POST "http://127.0.0.1:19100/a2a" \
  -H 'Content-Type: application/json' \
  -H 'Accept: text/event-stream' \
  -H 'A2A-Version: 1.0' \
  -d '{
    "jsonrpc": "2.0",
    "id": "1",
    "method": "SendStreamingMessage",
    "params": {
      "message": {
        "messageId": "m1",
        "contextId": "c1",
        "role": "ROLE_USER",
        "parts": [{"text": "23*47=? 请先思考再回答"}]
      }
    }
  }' | tee /tmp/a2a.log
```

### 结果判读

- **`EXPOSE_REASONING=true`**：`statusUpdate` 含 `"metadata": {"jiuwen_thought": true}`；正文仅在 `artifactUpdate` / `response`
- **`EXPOSE_REASONING=false`**：`grep -c jiuwen_thought /tmp/a2a.log` 为 0，仅 `Processing...` + 正文

---

## Test plan

- [x] `pytest tests/unit_tests/channel/test_a2a_channel.py`（13 passed）
- [x] `EXPOSE_REASONING=true`：思考与正文分离
- [x] `EXPOSE_REASONING=false`：思考不输出，正文正常
- [x] 默认关闭，对现有客户端无行为变化

## 兼容性

- 默认关闭 `A2A_SERVER_EXPOSE_REASONING`，非 breaking change
- 需请求头 `A2A-Version: 1.0`（a2a-sdk 1.0）



**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->