### PR TITLE
fix(web): restore persisted chat images in desktop history

### DIFF
--- a/jiuwenswarm/channels/web/app_web.py
+++ b/jiuwenswarm/channels/web/app_web.py
@@ -801,6 +801,34 @@ class _SpaStaticHandler(SimpleHTTPRequestHandler):
             self._write_json(200, {"files": files})
             return
 
+        if path == "/file-api/raw-file":
+            file_arg = query.get("path", "")
+            if not file_arg:
+                self._write_json(400, {"error": "missing_file_path"})
+                return
+            full_path = (self.project_root / file_arg).resolve()
+            if not self._is_path_under_allowed_root(full_path):
+                self._write_json(403, {"error": "forbidden_path"})
+                return
+            if not full_path.is_file():
+                self._write_json(404, {"error": "file_not_found"})
+                return
+
+            mime_type, _ = mimetypes.guess_type(full_path.name)
+            self.send_response(200)
+            self.send_header("Content-Type", mime_type or "application/octet-stream")
+            self.send_header("Content-Length", str(full_path.stat().st_size))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            if self.command != "HEAD":
+                with full_path.open("rb") as file_obj:
+                    while True:
+                        chunk = file_obj.read(65536)
+                        if not chunk:
+                            break
+                        self.wfile.write(chunk)
+            return
+
         if path == "/file-api/file-content":
             file_arg = query.get("path", "")
             encoding_arg = query.get("encoding", "utf-8")

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -6356,6 +6356,16 @@ class JiuWenSwarmDeepAdapter:
 
             resolved_model = self._resolve_model_for_request(request)
             self._apply_model_to_react_agent(resolved_model)
+            inputs = self._prepare_multimodal_image_inputs(request, inputs)
+            enable_read_image_multimodal = self._native_image_input_enabled(
+                self._config_cache,
+                resolved_model,
+            )
+            inputs = self._prepare_react_image_tool_prompt(
+                request,
+                inputs,
+                enable_read_image_multimodal=enable_read_image_multimodal,
+            )
             resolved_language = self._resolve_runtime_language()
             resolved_channel = str(cid or self._resolve_prompt_channel(session_id) or "web").strip() or "web"
             if self._runtime_prompt_rail:

--- a/tests/unit_tests/agentserver/test_evolve_command_edges.py
+++ b/tests/unit_tests/agentserver/test_evolve_command_edges.py
@@ -524,3 +524,53 @@ async def test_agent_stream_slash_followup_continues_into_runner(monkeypatch):
     ]
     assert chunks[0].payload == {"event_type": "chat.delta", "content": "agent delta"}
     assert chunks[-1].is_complete is True
+
+
+@pytest.mark.anyio
+async def test_team_stream_injects_image_tool_context_for_non_vision_model(monkeypatch):
+    """Team mode must preserve the same local-image tool context as agent mode."""
+    adapter = JiuWenSwarmDeepAdapter()
+    adapter._instance = SimpleNamespace()  # pylint: disable=protected-access
+    adapter._is_session_scoped_adapter = True  # pylint: disable=protected-access
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(adapter, "_has_valid_model_config", lambda _model_name="": True)
+    monkeypatch.setattr(adapter, "_resolve_model_for_request", lambda _request: object())
+    monkeypatch.setattr(adapter, "_apply_model_to_react_agent", lambda _model: None)
+    monkeypatch.setattr(adapter, "_resolve_runtime_language", lambda: "cn")
+    monkeypatch.setattr(adapter, "_native_image_input_enabled", lambda *_args: False)
+    monkeypatch.setattr(adapter, "_write_runtime_state", lambda **_kwargs: None)
+
+    async def _capture_team_inputs(_request, inputs, _instance):
+        captured.update(inputs)
+        if False:
+            yield None
+
+    from jiuwenswarm.server.runtime.agent_adapter import team_helpers
+
+    monkeypatch.setattr(team_helpers, "process_team_message_stream", _capture_team_inputs)
+
+    request = AgentRequest(
+        request_id="req-team-image",
+        channel_id="web",
+        session_id="sess-team-image",
+        params={
+            "mode": "team",
+            "query": "解析图片内容",
+            "media_items": [
+                {
+                    "type": "image",
+                    "filename": "persisted.png",
+                    "path": "agent/sessions/sess-team-image/uploads/persisted.png",
+                    "mime_type": "image/png",
+                }
+            ],
+        },
+        is_stream=True,
+    )
+
+    async for _ in adapter.process_message_stream_impl(request, {"query": "解析图片内容"}):
+        pass
+
+    assert "jiuwenswarm_image_tool_context" in captured["query"]
+    assert "agent/sessions/sess-team-image/uploads/persisted.png" in captured["query"]

--- a/tests/unit_tests/test_app_web_raw_file.py
+++ b/tests/unit_tests/test_app_web_raw_file.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import threading
+import sys
+import types
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from urllib.parse import quote
+
+bootstrap_module = types.ModuleType("jiuwenswarm.agents.harness.team.bootstrap")
+bootstrap_module.configure_agent_teams_home = lambda: None
+sys.modules.setdefault(bootstrap_module.__name__, bootstrap_module)
+
+from jiuwenswarm.channels.web.app_web import _SpaStaticHandler
+
+
+def test_raw_file_serves_persisted_session_image(tmp_path):
+    agent_root = tmp_path / "agent"
+    image_path = agent_root / "sessions" / "session-1" / "uploads" / "image.png"
+    image_path.parent.mkdir(parents=True)
+    image_bytes = b"\x89PNG\r\n\x1a\nimage-data"
+    image_path.write_bytes(image_bytes)
+
+    class Handler(_SpaStaticHandler):
+        project_root = tmp_path
+        workspace_root = agent_root
+        agent_teams_root = tmp_path / "agent-teams"
+        logs_root = tmp_path / "logs"
+        auto_harness_root = tmp_path / "auto-harness"
+        api_target = ""
+        ws_target = ""
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        connection = HTTPConnection("127.0.0.1", server.server_port)
+        connection.request("GET", f"/file-api/raw-file?path={quote(str(image_path))}")
+        response = connection.getresponse()
+        try:
+            assert response.status == 200
+            assert response.headers["Content-Type"] == "image/png"
+            assert response.read() == image_bytes
+        finally:
+            connection.close()
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

Fixes #1969

Fixes #2230

补齐桌面客户端生产静态服务的 `/file-api/raw-file` 路由，使历史会话中已持久化到 `agent/sessions/.../uploads/` 的图片在重启后仍可读取与展示。

修复同时覆盖桌面客户端生产静态服务与 Web 开发服务器：桌面端重启后可继续读取历史图片。

新增 HTTP 回归测试，覆盖图片文件返回 200、正确 MIME 类型和原始字节。