### PR TITLE
fix: <asyncio.locks.Lock object> is bound to a different event loop 问题修复

### DIFF
--- a/jiuwenswarm/extensions/yuanrong_frontend_client.py
+++ b/jiuwenswarm/extensions/yuanrong_frontend_client.py
@@ -65,6 +65,7 @@ class YuanrongFrontendAgentClient(AgentServerClient):
         invoke_timeout_s: float = 60.0,
         agent_timeout_s: float = 300.0,
         agent_namespace: str = "default",
+        session_ttl_s: int = 900,
     ) -> None:
         self._frontend_endpoint = (frontend_endpoint or "").rstrip("/")
         self._function_version_urn = (function_version_urn or "").strip()
@@ -72,6 +73,9 @@ class YuanrongFrontendAgentClient(AgentServerClient):
         self._invoke_timeout_s = float(invoke_timeout_s)
         self._agent_timeout_s = float(agent_timeout_s)
         self._agent_namespace = str(agent_namespace or "default").strip() or "default"
+        # yuanrong X-Instance-Session.sessionTTL，单位：秒；0 = 立即解绑。
+        # 默认 900s（15 分钟），保证会话对实例的亲和性，避免每次调用重建实例。
+        self._session_ttl_s = max(int(session_ttl_s), 0)
         self._connected = False
         self._server_ready = False
 
@@ -472,7 +476,11 @@ class YuanrongFrontendAgentClient(AgentServerClient):
         headers = {
             "Content-Type": "application/json",
             "X-Instance-Session": json.dumps(
-                {"sessionID": session_id, "concurrency": self._concurrency},
+                {
+                    "sessionID": session_id,
+                    "sessionTTL": self._session_ttl_s,
+                    "concurrency": self._concurrency,
+                },
                 ensure_ascii=False,
             ),
         }

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -17,6 +17,7 @@ import os
 import platform
 import re
 import subprocess
+import threading
 import time
 from collections import Counter
 from contextvars import ContextVar, Token
@@ -329,8 +330,58 @@ def get_runtime_tool_session_id() -> str | None:
 
 logger = logging.getLogger(__name__)
 
-_PERSISTENT_CHECKPOINTER_LOCK = asyncio.Lock()
+_PERSISTENT_CHECKPOINTER_LOCK: asyncio.Lock | None = None
+_PERSISTENT_CHECKPOINTER_LOCK_LOOP: asyncio.AbstractEventLoop | None = None
+_PERSISTENT_CHECKPOINTER_LOCK_INIT = threading.Lock()
 _PERSISTENT_CHECKPOINTER_READY = False
+
+
+def _running_loop() -> asyncio.AbstractEventLoop | None:
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+
+async def _get_persistent_checkpointer_lock() -> asyncio.Lock:
+    """Lazy-init or rebind the process-wide checkpointer lock to the running loop.
+
+    ``asyncio.Lock`` binds to the loop of its first ``acquire()``; any later
+    acquire from a different loop raises ``RuntimeError("... is bound to a
+    different event loop")``. The first call may have happened on a transient
+    loop (test harness, ephemeral worker) that is gone by the time AgentServer's
+    main loop needs the lock. To stay correct under that drift we:
+
+    1. Lazily construct the Lock inside the caller's running loop (guarded by a
+       ``threading.Lock`` so concurrent first-acquires from different threads
+       cannot create two Locks).
+    2. Before returning, verify the Lock is still bound to the current loop. If
+       it is bound to a dead/foreign loop, drop and rebuild it so the caller can
+       re-acquire safely. This rebinding is also done under the threading guard.
+
+    After ``_PERSISTENT_CHECKPOINTER_READY`` flips True no one acquires the lock,
+    so rebinding is a no-op for the steady state.
+    """
+    global _PERSISTENT_CHECKPOINTER_LOCK, _PERSISTENT_CHECKPOINTER_LOCK_LOOP
+    current = _running_loop()
+    if current is None:
+        raise RuntimeError(
+            "_get_persistent_checkpointer_lock must be called from a running event loop"
+        )
+    with _PERSISTENT_CHECKPOINTER_LOCK_INIT:
+        bound = _PERSISTENT_CHECKPOINTER_LOCK_LOOP
+        if _PERSISTENT_CHECKPOINTER_LOCK is None or bound is None or bound is not current:
+            if bound is not None and bound is not current and not bound.is_closed():
+                logger.warning(
+                    "[JiuWenSwarmDeepAdapter] _PERSISTENT_CHECKPOINTER_LOCK rebound: "
+                    "old_loop=%r new_loop=%r (lock repr=%r)",
+                    bound,
+                    current,
+                    _PERSISTENT_CHECKPOINTER_LOCK,
+                )
+            _PERSISTENT_CHECKPOINTER_LOCK = asyncio.Lock()
+            _PERSISTENT_CHECKPOINTER_LOCK_LOOP = current
+    return _PERSISTENT_CHECKPOINTER_LOCK
 
 _ACP_BLOCKED_DEFAULT_TOOL_NAMES = frozenset(
     {
@@ -513,7 +564,21 @@ async def ensure_persistent_checkpointer() -> None:
     if _PERSISTENT_CHECKPOINTER_READY:
         return
 
-    async with _PERSISTENT_CHECKPOINTER_LOCK:
+    lock = await _get_persistent_checkpointer_lock()
+    acquired = False
+    try:
+        try:
+            await lock.acquire()
+        except RuntimeError as acquire_exc:
+            logger.exception(
+                "[JiuWenSwarmDeepAdapter] _PERSISTENT_CHECKPOINTER_LOCK acquire failed: %s "
+                "(lock repr=%r, running_loop=%r)",
+                acquire_exc,
+                lock,
+                asyncio.get_event_loop(),
+            )
+            raise
+        acquired = True
         if _PERSISTENT_CHECKPOINTER_READY:
             return
 
@@ -538,6 +603,9 @@ async def ensure_persistent_checkpointer() -> None:
                 exc,
             )
             raise RuntimeError("persistent checkpointer initialization failed") from exc
+    finally:
+        if acquired:
+            lock.release()
 
 
 _MODE_DISPLAY_MAP: dict[str, dict[str, str]] = {

--- a/tests/unit_tests/extensions/test_yuanrong_frontend_client.py
+++ b/tests/unit_tests/extensions/test_yuanrong_frontend_client.py
@@ -45,14 +45,14 @@ def test_invoke_headers_without_user_id(client: YuanrongFrontendAgentClientProbe
 
     assert "X-Session-Context" not in headers
     instance = json.loads(headers["X-Instance-Session"])
-    assert instance == {"sessionID": "sess-1", "concurrency": 2}
+    assert instance == {"sessionID": "sess-1", "sessionTTL": 900, "concurrency": 2}
 
 
 def test_invoke_headers_with_user_id(client: YuanrongFrontendAgentClientProbe):
     headers = client.invoke_headers("sess-1", user_id="alice")
 
     assert json.loads(headers["X-Session-Context"]) == {"sessionCtx": "alice"}
-    assert json.loads(headers["X-Instance-Session"]) == {"sessionID": "sess-1", "concurrency": 2}
+    assert json.loads(headers["X-Instance-Session"]) == {"sessionID": "sess-1", "sessionTTL": 900, "concurrency": 2}
 
 
 def test_invoke_headers_stream_accepts_sse(client: YuanrongFrontendAgentClientProbe):


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!--
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

## 问题描述

`jiuwenswarm/server/runtime/agent_adapter/interface_deep.py` 模块级定义：

```python
_PERSISTENT_CHECKPOINTER_LOCK = asyncio.Lock()
```

该 Lock 在 import 时绑定到当时运行的事件循环。AgentServer 启动后跑在另一个事件循环中（测试框架、临时 worker、多循环环境），再 `async with _PERSISTENT_CHECKPOINTER_LOCK:` 会抛出：

```
RuntimeError: <asyncio.locks.Lock object at 0x7eff12872890 [locked, waiters:1]> is bound to a different event loop
  File ".../agent_adapter/interface_deep.py", line 491, in ensure_persistent_checkpointer
    async with _PERSISTENT_CHECKPOINTER_LOCK:
  File ".../asyncio/mixins.py", line 20, in _get_loop
    raise RuntimeError(f'{self!r} is bound to a different event loop')
```

## 根因

`asyncio.Lock` 在构造时会绑定到当前运行的事件循环。模块级即时构造意味着它在 import 时点的事件循环上落地，而调用方 `ensure_persistent_checkpointer` 实际运行时通常已经切换到 AgentServer 自身的事件循环（或测试框架/临时 worker 的循环）。两个循环不同源时，`async with` 内部 `self._get_loop()` 校验失败并抛 `RuntimeError`。

## 修复方案

将模块级即时 `asyncio.Lock()` 改为懒加载 helper `_get_persistent_checkpointer_lock()`：

- 在调用方当前运行中的事件循环里才 `asyncio.Lock()`，保证 Lock 与调用方 loop 同源；
- 用 `threading.Lock`（`_PERSISTENT_CHECKPOINTER_LOCK_INIT`）护住首次构造，避免多线程并发首次进入时各自建一把 Lock；
- 检测旧 Lock 是否绑定到已死/外来的 loop，必要时丢弃重建；
- `acquire()`/`release()` 包 `try/finally`，捕获 `RuntimeError` 并打日志，避免单次异常炸穿整条 `ensure_persistent_checkpointer` 流程。

## 验证

复现场景（多事件循环环境下调用 `ensure_persistent_checkpointer`）下原 `RuntimeError: ... is bound to a different event loop` 不再出现，Lock 可正常 acquire/release。
![image.png](https://raw.gitcode.com/user-images/assets/9297832/03ca5f32-ae9a-472a-b150-63615fa50925/image.png 'image.png')