### PR TITLE
fix(agent-adapter): persist cancelled todos on interrupt

### DIFF
--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -42,7 +42,11 @@ from openjiuwen.core.runner import Runner
 from openjiuwen.core.session.checkpointer import CheckpointerFactory
 from openjiuwen.core.session.checkpointer.checkpointer import CheckpointerConfig
 from openjiuwen.core.session.checkpointer.persistence import PersistenceCheckpointerProvider
-from openjiuwen.core.single_agent import AgentCard, ReActAgentConfig
+from openjiuwen.core.single_agent import (
+    AgentCard,
+    ReActAgentConfig,
+    create_agent_session,
+)
 from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
 from openjiuwen.core.sys_operation import (
     SysOperation,
@@ -6343,7 +6347,6 @@ class JiuWenSwarmDeepAdapter:
         """
         if self._instance is None:
             raise RuntimeError("DeepAgent instance is not initialized")
-        from openjiuwen.core.session.agent import create_agent_session
 
         session = create_agent_session(
             session_id=session_id,
@@ -8320,7 +8323,14 @@ class JiuWenSwarmDeepAdapter:
                     ids_to_cancel.append(todo.id)
 
             if ids_to_cancel:
-                await modify_tool._cancel_todos(ids_to_cancel, todos)
+                session = create_agent_session(
+                    session_id=session_id,
+                    card=getattr(self._instance, "card", None),
+                )
+                await modify_tool.invoke(
+                    {"action": "cancel", "ids": ids_to_cancel},
+                    session=session,
+                )
                 logger.info(
                     "[JiuWenSwarmDeepAdapter] 已将 session %s 的未完成任务标记为 cancelled",
                     session_id,

--- a/tests/unit_tests/agentserver/test_deep_adapter_interrupt.py
+++ b/tests/unit_tests/agentserver/test_deep_adapter_interrupt.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from openjiuwen.harness.schema.task import TodoItem, TodoStatus
 
 from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
 from jiuwenswarm.common.schema.agent import AgentRequest
@@ -63,6 +64,56 @@ def _make_adapter(**state: object) -> JiuWenSwarmDeepAdapter:
     for name, value in state.items():
         setattr(adapter, name, value)
     return adapter
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_todos_uses_public_tool_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel unfinished todos through TodoModifyTool.invoke, not its internals."""
+    from jiuwenswarm.agents.harness.common.tools.todo_compat import (
+        CompatibleTodoModifyTool,
+    )
+
+    todos = [
+        TodoItem(id="pending", status=TodoStatus.PENDING),
+        TodoItem(id="running", status=TodoStatus.IN_PROGRESS),
+        TodoItem(id="done", status=TodoStatus.COMPLETED),
+    ]
+    todo_tool = CompatibleTodoModifyTool(operation=MagicMock())
+    todo_tool.load_todos = AsyncMock(return_value=todos)
+    todo_tool.save_todos = AsyncMock()
+    todo_tool.invoke = AsyncMock(wraps=todo_tool.invoke)
+
+    resource_mgr = MagicMock()
+    resource_mgr.get_tool.return_value = todo_tool
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.agent_adapter.interface_deep.Runner.resource_mgr",
+        resource_mgr,
+    )
+
+    ability_manager = MagicMock()
+    ability_manager.get.return_value = MagicMock(id="todo_modify")
+    instance = MagicMock(ability_manager=ability_manager, card=None)
+    formatted_todos = [{"id": "pending", "status": "cancelled"}]
+    rail = MagicMock()
+    rail._format_todos_for_frontend.return_value = formatted_todos
+    adapter = _make_adapter(_instance=instance, _stream_event_rail=rail)
+
+    result = await adapter._cancel_pending_todos("session-1")
+
+    todo_tool.invoke.assert_awaited_once()
+    invoke_args, invoke_kwargs = todo_tool.invoke.await_args
+    assert invoke_args == ({"action": "cancel", "ids": ["pending", "running"]},)
+    assert invoke_kwargs["session"].get_session_id() == "session-1"
+    todo_tool.save_todos.assert_awaited_once_with("session-1", todos)
+    assert [todo.status for todo in todos] == [
+        TodoStatus.CANCELLED,
+        TodoStatus.CANCELLED,
+        TodoStatus.COMPLETED,
+    ]
+    rail._format_todos_for_frontend.assert_called_once_with(todos)
+    assert result == formatted_todos
 
 
 @pytest.mark.asyncio
@@ -440,8 +491,6 @@ def test_reset_runtime_cron_context_resets_shell_session(
         )
     )
     reset_shell_mock.assert_called_once_with(shell_token)
-
-
 def test_bind_runtime_cron_context_fills_locked_session_project_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Paired: [GitHub #906](https://github.com/openJiuwen-ai/jiuwenswarm/pull/906) ↔ [GitCode !3931](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/3931)

<!--
Thanks for sending a pull request!
If no reviewer is available, add the `openjiuwen-assistant` label.
-->

**What type of PR is this?**

/kind bug

**Related issue**

No matching GitHub issue or pull request was found after searching for `_cancel_todos`, `current_todos`, todo cancellation, and interrupt todo status.

**What changed and why**

When a DeepAgent run is interrupted, `JiuWenSwarmDeepAdapter._cancel_pending_todos()` loads unfinished todos and tries to mark them as cancelled. The existing implementation calls the private method `TodoModifyTool._cancel_todos(ids_to_cancel, todos)`.

The agent-core revision pinned by JiuwenSwarm defines that private method as `_cancel_todos(session_id, ids, current_todos)`. The resulting `TypeError` is caught by the adapter, so the interrupt response can still report success while unfinished todos remain `pending` or `in_progress` and are not persisted.

This change:

- routes cancellation through the public `TodoModifyTool.invoke()` contract with `action="cancel"`;
- supplies a session created through the public `openjiuwen.core.single_agent.create_agent_session` export;
- adds a regression test covering the public call, persisted state changes, completed-todo preservation, and frontend formatting.

Using `invoke()` keeps validation, locking, and persistence semantics in agent-core instead of duplicating its internal cancellation logic in JiuwenSwarm. No dependency or lock-file change is required.

**Self-checklist**

- [x] **设计**: The fix is limited to replacing a drifting private call with the tool's public contract.
- [x] **测试**: Added a regression test that fails on the previous implementation and passes after the fix.
- [x] **验证**: Reproduced against the current `develop` baseline and its pinned agent-core revision.
- [x] **接口**: No external API or protocol changes.
- [x] **文档**: No user-facing documentation change is required.

**Reproduction and validation**

Current baseline:

- JiuwenSwarm: `636cf73db48283d2c270ba9a84e71b2de97911b7`
- pinned agent-core: `1bf14832bc4e89a29ed0c090c96650c18b83b1b9`

Before the fix:

```text
TodoModifyTool._cancel_todos() missing 1 required positional argument: 'current_todos'
todo_status=in_progress
save_calls=0
```

After the fix:

```text
todo_status=cancelled
save_calls=1
```

Checks run:

```text
pytest -o addopts='' -o log_cli=false tests/unit_tests/agentserver/test_deep_adapter_interrupt.py -q
6 passed

ruff check --ignore E402 jiuwenswarm/server/runtime/agent_adapter/interface_deep.py tests/unit_tests/agentserver/test_deep_adapter_interrupt.py
All checks passed

git diff --check
passed
```

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2408
<!-- /bot1-related-issues -->
