### PR TITLE
fix(skill_turbo/ppt): 修复 PPT 已发送但 LLM 偶发性重跑流程的问题

### DIFF
--- a/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/delivery.py
+++ b/jiuwenclaw/agentserver/skill_turbo/skill_codes/ppt/delivery.py
@@ -97,6 +97,11 @@ class DeliveryNode(PlanNode):
         else:
             delivery_status = "ok"
 
+        # 当 PPT 已成功发送给用户时，HTML 页面校验失败不应影响"任务已完成"判定：
+        # send_file_status=sent 表示用户已实际收到 PPT，task_completed 用于 __artifact__.info，
+        # 让 DeepAgent 主链路 LLM 能明确识别任务已完成，避免误调 skill_tool 重跑流程。
+        task_completed = send_file_status == "sent"
+
         need_artifact = send_file_status != "sent"
         artifact_tag = f"<!-- artifact:pptx {pages_dir} -->" if need_artifact and pages_dir else ""
 
@@ -105,10 +110,11 @@ class DeliveryNode(PlanNode):
         )
 
         logger.info(
-            "[P10] 交付完成 status=%s send=%s pptx=%s",
+            "[P10] 交付完成 status=%s send=%s pptx=%s task_completed=%s",
             delivery_status,
             send_file_status,
             pptx_filename,
+            task_completed,
         )
 
         return {
@@ -116,6 +122,19 @@ class DeliveryNode(PlanNode):
             "artifact_tag": artifact_tag,
             "send_file_status": send_file_status,
             "summary": summary,
+            # __artifact__ 字段供 SkillTurboExecutor._collect_node_artifact 提取，
+            # 记录到 _node_artifacts_holder，最终由 _build_artifact_summary 构建产物摘要，
+            # 追加到 skill_acceleration_exec 返回给 DeepAgent 主链路的 tool_result 中。
+            # 没有 __artifact__ 时产物摘要为空，LLM 偶发性因看不到产物证据而误调 skill_tool 重跑。
+            "__artifact__": {
+                "info": {
+                    "delivery_status": delivery_status,
+                    "send_file_status": send_file_status,
+                    "pptx_filename": pptx_filename,
+                    "task_completed": task_completed,
+                },
+                "files": [{"path": pptx_path}] if pptx_path else [],
+            },
         }
 
     async def _send_file(self, pptx_path: str) -> str:
@@ -244,12 +263,14 @@ class DeliveryNode(PlanNode):
     ) -> str:
         if status == "failed":
             return f"PPT 生成失败，HTML 页面目录：{pages_dir}"
+        # PPT 已发送给用户时，无论 pages_ok 是否通过，都明确说明"已发送"，
+        # 避免 delivery_status=partial 时的"部分完成"措辞让 LLM 误判任务未完成。
+        if send_file_status == "sent":
+            return f"PPT 已生成并发送给用户，页数：{page_count}，文件：{pptx_filename or '未生成'}"
         if status == "partial":
             return f"PPT 部分完成，页数：{page_count}，文件：{pptx_filename or '未生成'}"
         send_info = ""
-        if send_file_status == "sent":
-            send_info = "，已发送给用户"
-        elif send_file_status == "failed":
+        if send_file_status == "failed":
             send_info = "，文件发送失败"
         return f"PPT 生成完成，页数：{page_count}，文件：{pptx_filename}{send_info}"
 


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

# 问题根源及方案总结
## 问题现象
用户输入"把 D:\code\jiuwen-test\assets\files\ppt_004.docx 转成 PPT"，agent 生成了 2 个 PPT：

- 第一个 PPT（ 具身智能.pptx ）在 15:07:55 已通过 send_file_to_user 发送给用户
- 同一 session 内 LLM 又调用 skill_tool 重新跑了一遍完整 PPT 流程（Stage 1-9），到 16:48:36 才结束
## 问题根源
delivery.py 的 _execute() 返回值缺少 __artifact__ 字段 ，导致 DeepAgent 主链路 LLM 看不到 PPT 产物证据，偶发性误判任务未完成而重跑。

完整因果链：

1. delivery.py 的 _execute() 返回 delivery_status / send_file_status / summary ，但 没有 __artifact__ 字段 。
2. executor.py 的 _collect_node_artifact() 只识别 result.pop("__artifact__", None) ，P10 节点被跳过 → _node_artifacts_holder 为空。
3. skill_turbo_tools.py 的 _build_artifact_summary() 返回空字符串 → _wrap_skill_turbo_result() 构造的 tool_result 只有 "任务已完成" + 停止提示， 没有 PPT 文件路径 。
4. 偶现触发点 ： _check_pages() 偶发性返回 False（ list_dir / glob 返回空或 HTML 页面数量对不上 total_pages ）→ delivery_status="partial" → _build_summary() 返回 "PPT 部分完成" 措辞，且没体现"已发送"。
5. 三重信号叠加（无产物路径 + "部分完成"措辞 + 没体现"已发送"）让 LLM 偶发性误判"PPT 没真正完成" → 又调 skill_tool 想加载 SKILL.md 补救 → 触发权限弹窗 → 用户点"本次允许" → LLM 重跑整个 PPT 流程。
## 修复方案
修改 delivery.py 两处：

### 1. _execute() 返回值新增 __artifact__ 字段
修复后 LLM 看到的 tool_result 变为：

LLM 能看到具体的 PPT 文件路径和 task_completed=True ，不会再误调 skill_tool 。

### 2. _build_summary() 在 send_file_status=sent 时优先返回明确措辞
```
# 之前：delivery_status=partial 时返回"PPT 部分完成"，没体现"已发送"
# 之后：send_file_status=sent 时统一返回"PPT 已生成并发送给用户"
if send_file_status == "sent":
    return f"PPT 已生成并发送给用户，页数：{page_count}，文件：{pptx_filename 
    or '未生成'}"
```
## 影响面
- 只改了 pptx-craft 的 delivery 节点，不影响其他 skill。
- __artifact__ 是 executor 已有协议字段，只是 delivery 节点之前没用上。
- delivery_status=partial 状态保留用于日志/监控，只在给 LLM 的 tool_result 出口做了语义纠正。
- 向后兼容： task_completed 是新增 info 字段，不影响已有字段解析。
## 验证建议
- 复现 _check_pages 返回 False 的场景（mock list_dir / glob 返回空），验证修复后 LLM 不再重跑 PPT 流程。
- 验证产物摘要包含 PPT 文件路径和 task_completed=True 。