### PR TITLE
feat(agentos): implement registry HTTP client for gateway

### DIFF
--- a/jiuwenswarm/extensions/agentos/agentos_router/__init__.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/__init__.py
@@ -14,7 +14,22 @@ from jiuwenswarm.extensions.agentos.agentos_router.models import (
     AgentStatus,
     ImageInfo,
 )
-from jiuwenswarm.extensions.agentos.agentos_router.registry_client import RegistryClient
+from jiuwenswarm.extensions.agentos.agentos_router.registry_client import (
+    HeartbeatResult,
+    ImageFrameworkInfo,
+    InstanceRecord,
+    LaunchSpec,
+    RegistryClient,
+    RegistryConfig,
+    RegistryConflictError,
+    RegistryConnectionError,
+    RegistryError,
+    RegistryHTTPError,
+    RegistryNotFoundError,
+    RegistryValidationError,
+    instance_service_id,
+    resolve_instance_kind,
+)
 from jiuwenswarm.extensions.agentos.agentos_router.router_client import AgentOSRouterClient
 
 __all__ = [
@@ -25,8 +40,21 @@ __all__ = [
     "AgentOSRouterClient",
     "AgentRuntime",
     "AgentStatus",
+    "HeartbeatResult",
+    "ImageFrameworkInfo",
     "ImageInfo",
+    "InstanceRecord",
+    "LaunchSpec",
     "RegistryClient",
+    "RegistryConfig",
+    "RegistryConflictError",
+    "RegistryConnectionError",
+    "RegistryError",
+    "RegistryHTTPError",
+    "RegistryNotFoundError",
+    "RegistryValidationError",
     "SUPPORTED_AGENT_TYPES",
+    "instance_service_id",
     "normalize_agent_key_fields",
+    "resolve_instance_kind",
 ]

--- a/jiuwenswarm/extensions/agentos/agentos_router/config.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/config.py
@@ -68,6 +68,7 @@ def load_router_config(config: dict[str, Any]) -> RouterConfig:
         registry=RegistryConfig(
             endpoint=str(registry.get("endpoint") or "").strip(),
             request_timeout_s=float(registry.get("request_timeout_s") or 10.0),
+            node=str(registry.get("node") or "").strip(),
         ),
         creating_timeout_seconds=float(
             agentos.get("creating_timeout_seconds") or 60.0

--- a/jiuwenswarm/extensions/agentos/agentos_router/registry_client.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/registry_client.py
@@ -1,39 +1,649 @@
 # Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+"""Gateway-side Agent OS registry SDK.
+
+Wraps the appliance registry HTTP API (httpx keep-alive):
+- images: launch-spec / list
+- instances: register / update / unregister (write-only for gateway)
+- nodes: heartbeat
+
+When ``RegistryConfig.endpoint`` is empty the client stays local-only so
+AgentOS can boot without a live registry process.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import quote
 
+import httpx
+
+from jiuwenswarm.extensions.agentos.agentos_router.agent_manager import (
+    SUPPORTED_AGENT_TYPES,
+)
 from jiuwenswarm.extensions.agentos.agentos_router.models import AgentInfo, ImageInfo
+
+logger = logging.getLogger(__name__)
+
+KIND_THIRD_PARTY = "三方"
+KIND_JIUWEN = "九问"
+_JIUWEN_FRAMEWORKS = frozenset({"jiuwenswarm", "jiuwen-report"})
 
 
 @dataclass(frozen=True)
 class RegistryConfig:
+    """Gateway → registry connection settings.
+
+    ``endpoint`` empty → local stub (no HTTP). ``node`` is this machine's
+    nodeIP used for ``POST /api/nodes/{node}/heartbeat``.
+    """
+
     endpoint: str = ""
     request_timeout_s: float = 10.0
+    node: str = ""
+
+
+@dataclass(frozen=True)
+class LaunchSpec:
+    """YuanRong Docker sandbox image-level launch fields from the registry."""
+
+    framework: str
+    framework_version: str
+    rootfs: dict[str, Any] = field(default_factory=dict)
+    cpu: int | None = None
+    memory: int | None = None
+    ports: list[dict[str, Any]] = field(default_factory=list)
+    env: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LaunchSpec:
+        payload = dict(data or {})
+        return cls(
+            framework=str(payload.get("framework") or "").strip(),
+            framework_version=str(payload.get("framework_version") or "").strip(),
+            rootfs=dict(payload.get("rootfs") or {})
+            if isinstance(payload.get("rootfs"), dict)
+            else {},
+            cpu=_optional_int(payload.get("cpu")),
+            memory=_optional_int(payload.get("memory")),
+            ports=list(payload.get("ports") or [])
+            if isinstance(payload.get("ports"), list)
+            else [],
+            env=dict(payload.get("env") or {})
+            if isinstance(payload.get("env"), dict)
+            else {},
+            raw=payload,
+        )
+
+
+@dataclass(frozen=True)
+class InstanceRecord:
+    """Instance registration row returned by the registry."""
+
+    service_id: str
+    kind: str = ""
+    framework: str = ""
+    framework_version: str = ""
+    node: str = ""
+    address: str = ""
+    user: str = ""
+    status: str = ""
+    dataset: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InstanceRecord:
+        payload = dict(data or {})
+        return cls(
+            service_id=str(payload.get("service_id") or "").strip(),
+            kind=str(payload.get("kind") or "").strip(),
+            framework=str(payload.get("framework") or "").strip(),
+            framework_version=str(payload.get("framework_version") or "").strip(),
+            node=str(payload.get("node") or "").strip(),
+            address=str(payload.get("address") or "").strip(),
+            user=str(payload.get("user") or "").strip(),
+            status=str(payload.get("status") or "").strip(),
+            dataset=str(payload.get("dataset") or "").strip(),
+            raw=payload,
+        )
+
+
+@dataclass(frozen=True)
+class HeartbeatResult:
+    node: str
+    state: str = ""
+    ttl_seconds: int | None = None
+    expires_at: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HeartbeatResult:
+        payload = dict(data or {})
+        ttl = payload.get("ttl_seconds")
+        expires = payload.get("expires_at")
+        return cls(
+            node=str(payload.get("node") or "").strip(),
+            state=str(payload.get("state") or "").strip(),
+            ttl_seconds=int(ttl) if ttl is not None else None,
+            expires_at=float(expires) if expires is not None else None,
+            raw=payload,
+        )
+
+
+@dataclass(frozen=True)
+class ImageFrameworkInfo:
+    framework: str
+    default: str = ""
+    versions: list[dict[str, Any]] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ImageFrameworkInfo:
+        payload = dict(data or {})
+        versions = payload.get("versions")
+        return cls(
+            framework=str(payload.get("framework") or "").strip(),
+            default=str(payload.get("default") or "").strip(),
+            versions=list(versions) if isinstance(versions, list) else [],
+            raw=payload,
+        )
+
+
+class RegistryError(Exception):
+    """Base error for registry client failures."""
+
+
+class RegistryConnectionError(RegistryError):
+    """Transport / connectivity failure talking to the registry."""
+
+
+class RegistryHTTPError(RegistryError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload
+
+
+class RegistryNotFoundError(RegistryHTTPError):
+    pass
+
+
+class RegistryValidationError(RegistryHTTPError):
+    pass
+
+
+class RegistryConflictError(RegistryHTTPError):
+    pass
+
+
+def instance_service_id(user: str, framework: str) -> str:
+    """Deterministic ``service_id`` for one instance per (user, framework)."""
+    uid = str(user or "").strip()
+    fw = str(framework or "").strip()
+    digest = hashlib.sha256(f"{uid}\0{fw}".encode("utf-8")).hexdigest()[:8]
+    return f"generic_{digest}"
+
+
+def resolve_instance_kind(framework: str) -> str:
+    """Map framework name to registry ``kind`` (三方 / 九问)."""
+    name = str(framework or "").strip().lower()
+    if name in _JIUWEN_FRAMEWORKS or name.startswith("jiuwen"):
+        return KIND_JIUWEN
+    return KIND_THIRD_PARTY
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_base_url(endpoint: str) -> str:
+    text = str(endpoint or "").strip().rstrip("/")
+    return f"{text}/" if text else ""
+
+
+def _encode(segment: str) -> str:
+    return quote(str(segment or ""), safe="")
+
+
+def _parse_error_payload(resp: httpx.Response) -> dict[str, Any] | None:
+    try:
+        data = resp.json()
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else {"detail": data}
+
+
+def _wrap_http_error(resp: httpx.Response) -> RegistryHTTPError:
+    payload = _parse_error_payload(resp)
+    detail = ""
+    if payload is not None:
+        raw_detail = payload.get("detail")
+        detail = raw_detail if isinstance(raw_detail, str) else str(raw_detail or "")
+    status = resp.status_code
+    message = f"HTTP {status}: {detail or resp.reason_phrase or 'request failed'}"
+    if status == 404:
+        return RegistryNotFoundError(message, status_code=status, payload=payload)
+    if status == 409:
+        return RegistryConflictError(message, status_code=status, payload=payload)
+    if status in (400, 422):
+        return RegistryValidationError(message, status_code=status, payload=payload)
+    return RegistryHTTPError(message, status_code=status, payload=payload)
 
 
 class RegistryClient:
-    """Registry facade reserved for AgentOS phase two integration."""
+    """httpx long-lived client for Agent OS registry (gateway write path)."""
 
     def __init__(self, config: RegistryConfig) -> None:
         self._config = config
+        self._base_url = _normalize_base_url(config.endpoint)
+        self._http: httpx.AsyncClient | None = None
+        # Local fallback / agent_id → service_id bookkeeping.
         self._registered_agents: dict[str, AgentInfo] = {}
+        self._agent_service_ids: dict[str, str] = {}
 
-    async def register_agent(self, agent_info: AgentInfo) -> None:
-        self._registered_agents[agent_info.agent_id] = agent_info.copy()
+    @property
+    def enabled(self) -> bool:
+        return bool(self._base_url)
 
-    async def unregister_agent(self, agent_id: str) -> None:
-        self._registered_agents.pop(str(agent_id or "").strip(), None)
+    @property
+    def endpoint(self) -> str:
+        return self._base_url.rstrip("/")
 
-    async def report_heartbeat(self, agent_id: str) -> None:
-        del agent_id
+    @property
+    def node(self) -> str:
+        return str(self._config.node or "").strip()
+
+    async def get_launch_spec(
+        self,
+        framework: str,
+        *,
+        version: str | None = None,
+    ) -> LaunchSpec:
+        """``GET /api/images/{framework}/launch-spec`` (optional ``?version=``)."""
+        fw = str(framework or "").strip()
+        if not fw:
+            raise RegistryValidationError(
+                "framework is required", status_code=400, payload=None
+            )
+        if not self.enabled:
+            return LaunchSpec(
+                framework=fw,
+                framework_version=str(version or "default").strip() or "default",
+                raw={"source": "local_stub"},
+            )
+        params: dict[str, Any] = {}
+        if version is not None and str(version).strip():
+            params["version"] = str(version).strip()
+        data = await self._request_json(
+            "GET",
+            f"api/images/{_encode(fw)}/launch-spec",
+            params=params or None,
+        )
+        return LaunchSpec.from_dict(data)
+
+    async def list_images(
+        self,
+        *,
+        framework: str | None = None,
+    ) -> list[ImageFrameworkInfo]:
+        """``GET /api/images`` (optional ``?framework=``)."""
+        if not self.enabled:
+            names = (
+                [str(framework).strip()]
+                if framework and str(framework).strip()
+                else sorted(SUPPORTED_AGENT_TYPES)
+            )
+            return [
+                ImageFrameworkInfo(
+                    framework=name,
+                    default="default",
+                    versions=[{"framework_version": "default"}],
+                    raw={"source": "local_stub"},
+                )
+                for name in names
+                if name
+            ]
+        params: dict[str, Any] = {}
+        if framework is not None and str(framework).strip():
+            params["framework"] = str(framework).strip()
+        data = await self._request_json(
+            "GET",
+            "api/images",
+            params=params or None,
+            expect_list=True,
+        )
+        items = data if isinstance(data, list) else []
+        return [
+            ImageFrameworkInfo.from_dict(item)
+            for item in items
+            if isinstance(item, dict)
+        ]
+
+    async def register_instance(
+        self,
+        *,
+        service_id: str,
+        kind: str,
+        framework: str,
+        framework_version: str,
+        node: str,
+        address: str,
+        user: str,
+    ) -> InstanceRecord:
+        """``POST /api/instances`` — idempotent upsert by ``service_id``."""
+        body = {
+            "service_id": str(service_id or "").strip(),
+            "kind": str(kind or "").strip(),
+            "framework": str(framework or "").strip(),
+            "framework_version": str(framework_version or "").strip(),
+            "node": str(node or "").strip(),
+            "address": str(address or "").strip(),
+            "user": str(user or "").strip(),
+        }
+        if not body["service_id"] or not body["framework"] or not body["user"]:
+            raise RegistryValidationError(
+                "service_id, framework and user are required",
+                status_code=400,
+                payload=body,
+            )
+        if not self.enabled:
+            return InstanceRecord.from_dict({**body, "status": "运行", "dataset": "default"})
+        data = await self._request_json("POST", "api/instances", json=body)
+        return InstanceRecord.from_dict(data)
+
+    async def update_instance(
+        self,
+        service_id: str,
+        *,
+        node: str | None = None,
+        address: str | None = None,
+    ) -> InstanceRecord:
+        """``PATCH /api/instances/{service_id}`` — update placement fields."""
+        sid = str(service_id or "").strip()
+        if not sid:
+            raise RegistryValidationError(
+                "service_id is required", status_code=400, payload=None
+            )
+        body: dict[str, Any] = {}
+        if node is not None:
+            body["node"] = str(node).strip()
+        if address is not None:
+            body["address"] = str(address).strip()
+        if not body:
+            raise RegistryValidationError(
+                "at least one of node/address is required",
+                status_code=400,
+                payload=None,
+            )
+        if not self.enabled:
+            return InstanceRecord.from_dict(
+                {"service_id": sid, **body, "status": "运行"}
+            )
+        data = await self._request_json(
+            "PATCH",
+            f"api/instances/{_encode(sid)}",
+            json=body,
+        )
+        return InstanceRecord.from_dict(data)
+
+    async def unregister_instance(self, service_id: str) -> dict[str, Any]:
+        """``DELETE /api/instances/{service_id}`` (idempotent)."""
+        sid = str(service_id or "").strip()
+        if not sid:
+            raise RegistryValidationError(
+                "service_id is required", status_code=400, payload=None
+            )
+        if not self.enabled:
+            return {"service_id": sid, "dataset": "default", "deleted": True}
+        data = await self._request_json("DELETE", f"api/instances/{_encode(sid)}")
+        return data if isinstance(data, dict) else {"service_id": sid, "deleted": True}
+
+    async def report_node_heartbeat(
+        self,
+        node: str | None = None,
+        *,
+        status: Any = None,
+    ) -> HeartbeatResult:
+        """``POST /api/nodes/{node}/heartbeat`` — covers all instances on node."""
+        node_ip = str(node if node is not None else self.node or "").strip()
+        if not node_ip:
+            raise RegistryValidationError(
+                "node is required for heartbeat",
+                status_code=400,
+                payload=None,
+            )
+        body: dict[str, Any] | None = None
+        if status is not None:
+            body = {"status": status}
+        if not self.enabled:
+            return HeartbeatResult(
+                node=node_ip,
+                state="healthy",
+                ttl_seconds=90,
+                raw={"source": "local_stub"},
+            )
+        data = await self._request_json(
+            "POST",
+            f"api/nodes/{_encode(node_ip)}/heartbeat",
+            json=body,
+        )
+        return HeartbeatResult.from_dict(data)
+
+    # ── Compatibility helpers used by AgentOSRouterClient ─────────────────
 
     async def get_image_info(self, image_name: str) -> ImageInfo:
+        """Resolve framework launch-spec into ``ImageInfo`` for sandbox create."""
+        framework = str(image_name or "").strip()
+        if not self.enabled:
+            return ImageInfo(
+                image_name=framework,
+                metadata={"source": "local_stub", "agent_type": framework},
+            )
+        try:
+            spec = await self.get_launch_spec(framework)
+        except RegistryError:
+            logger.exception(
+                "[RegistryClient] get_launch_spec failed: framework=%s", framework
+            )
+            raise
+        rootfs = spec.rootfs if isinstance(spec.rootfs, dict) else {}
+        image_uri = str(rootfs.get("imageurl") or rootfs.get("image_url") or "").strip() or None
         return ImageInfo(
-            image_name=str(image_name or "").strip(),
-            metadata={"source": "phase_one_default"},
+            image_name=framework,
+            image_uri=image_uri,
+            metadata={
+                "agent_type": framework,
+                "framework": spec.framework or framework,
+                "framework_version": spec.framework_version,
+                "launch_spec": dict(spec.raw),
+                "rootfs": dict(spec.rootfs),
+                "cpu": spec.cpu,
+                "memory": spec.memory,
+                "ports": list(spec.ports),
+                "env": dict(spec.env),
+                "source": "registry",
+            },
         )
+
+    async def list_user_images(self, user_id: str) -> list[ImageInfo]:
+        """List switchable frameworks; attaches ``user_id`` in metadata."""
+        uid = str(user_id or "").strip()
+        frameworks = await self.list_images()
+        images: list[ImageInfo] = []
+        for item in frameworks:
+            version_meta: dict[str, Any] = {}
+            if item.versions:
+                first = item.versions[0]
+                if isinstance(first, dict):
+                    version_meta = dict(first)
+            images.append(
+                ImageInfo(
+                    image_name=item.framework,
+                    image_uri=None,
+                    metadata={
+                        "agent_type": item.framework,
+                        "user_id": uid,
+                        "default": item.default,
+                        "versions": list(item.versions),
+                        "source": "registry" if self.enabled else "local_stub",
+                        **version_meta,
+                    },
+                )
+            )
+        return images
+
+    async def register_agent(self, agent_info: AgentInfo) -> None:
+        """Map ``AgentInfo`` → ``POST /api/instances`` (or local bookkeeping)."""
+        info = agent_info.copy()
+        user = str(info.user_id or "").strip()
+        framework = str(info.agent_type or "").strip()
+        service_id = instance_service_id(user, framework)
+        image_meta = info.metadata.get("image_info")
+        if not isinstance(image_meta, dict):
+            image_meta = {}
+        sandbox_meta = info.metadata.get("sandbox")
+        if not isinstance(sandbox_meta, dict):
+            sandbox_meta = {}
+
+        framework_version = str(
+            image_meta.get("framework_version")
+            or info.metadata.get("framework_version")
+            or "default"
+        ).strip()
+        node = str(
+            info.metadata.get("node")
+            or sandbox_meta.get("node")
+            or self.node
+            or ""
+        ).strip()
+        address = str(
+            info.metadata.get("address")
+            or sandbox_meta.get("address")
+            or info.sandbox_id
+            or ""
+        ).strip()
+        kind = str(info.metadata.get("kind") or resolve_instance_kind(framework)).strip()
+
+        if self.enabled:
+            record = await self.register_instance(
+                service_id=service_id,
+                kind=kind,
+                framework=framework,
+                framework_version=framework_version,
+                node=node,
+                address=address,
+                user=user,
+            )
+            info.metadata["service_id"] = record.service_id
+            info.metadata["registry_status"] = record.status
+        else:
+            info.metadata["service_id"] = service_id
+
+        self._registered_agents[info.agent_id] = info
+        self._agent_service_ids[info.agent_id] = service_id
+
+    async def unregister_agent(self, agent_id: str) -> None:
+        """Unregister by local ``agent_id`` mapping or treat value as ``service_id``."""
+        key = str(agent_id or "").strip()
+        if not key:
+            return
+        service_id = self._agent_service_ids.pop(key, None) or key
+        self._registered_agents.pop(key, None)
+        if self.enabled:
+            await self.unregister_instance(service_id)
+
+    async def report_heartbeat(self, agent_id: str) -> None:
+        """Compatibility shim: node-level heartbeat (``agent_id`` ignored)."""
+        del agent_id
+        if not self.node and not self.enabled:
+            return
+        if not self.node:
+            logger.warning(
+                "[RegistryClient] report_heartbeat skipped: registry.node is empty"
+            )
+            return
+        await self.report_node_heartbeat(self.node)
 
     async def close(self) -> None:
         self._registered_agents.clear()
+        self._agent_service_ids.clear()
+        client = self._http
+        self._http = None
+        if client is not None:
+            await client.aclose()
+
+    async def __aenter__(self) -> RegistryClient:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        await self.close()
+
+    # ── HTTP transport ────────────────────────────────────────────────────
+
+    async def _get_http(self) -> httpx.AsyncClient:
+        if self._http is None:
+            timeout = httpx.Timeout(self._config.request_timeout_s)
+            # Keep-alive for heartbeat cadence; limits leave connection open.
+            self._http = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=timeout,
+                headers={"Accept": "application/json"},
+                limits=httpx.Limits(
+                    max_keepalive_connections=4,
+                    max_connections=8,
+                    keepalive_expiry=max(30.0, float(self._config.request_timeout_s) * 3),
+                ),
+            )
+        return self._http
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        expect_list: bool = False,
+    ) -> Any:
+        client = await self._get_http()
+        try:
+            resp = await client.request(method, path, json=json, params=params)
+        except httpx.HTTPError as exc:
+            raise RegistryConnectionError(f"{type(exc).__name__}: {exc}") from exc
+        if resp.status_code >= 400:
+            raise _wrap_http_error(resp)
+        if resp.status_code == 204 or not resp.content:
+            return [] if expect_list else {}
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise RegistryHTTPError(
+                f"invalid JSON response for {method} {path}",
+                status_code=resp.status_code,
+                payload=None,
+            ) from exc
+        if expect_list:
+            if isinstance(data, list):
+                return data
+            raise RegistryHTTPError(
+                f"expected JSON list for {method} {path}",
+                status_code=resp.status_code,
+                payload=data if isinstance(data, dict) else None,
+            )
+        if isinstance(data, dict):
+            return data
+        return {"detail": data}

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -574,8 +574,11 @@ gateway:
       - user_id
       - agent_type
     registry:
+      # Agent OS 注册中心地址（空=本地 stub，不发 HTTP）。一体机默认 http://127.0.0.1:8000
       endpoint:
       request_timeout_s: 10
+      # 本机 nodeIP，供 POST /api/nodes/{node}/heartbeat
+      node:
 
 heartbeat:
   # 心跳间隔（秒），默认 3600

--- a/tests/unit_tests/extensions/test_agentos_registry_client.py
+++ b/tests/unit_tests/extensions/test_agentos_registry_client.py
@@ -1,0 +1,267 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from jiuwenswarm.extensions.agentos.agentos_router.models import AgentInfo, AgentStatus
+from jiuwenswarm.extensions.agentos.agentos_router.registry_client import (
+    RegistryClient,
+    RegistryConfig,
+    RegistryConflictError,
+    RegistryNotFoundError,
+    instance_service_id,
+    resolve_instance_kind,
+)
+
+
+def test_instance_service_id_is_deterministic() -> None:
+    first = instance_service_id("user-01", "opencode")
+    second = instance_service_id("user-01", "opencode")
+    other = instance_service_id("user-02", "opencode")
+    assert first == second
+    assert first.startswith("generic_")
+    assert len(first) == len("generic_") + 8
+    assert first != other
+
+
+def test_resolve_instance_kind() -> None:
+    assert resolve_instance_kind("opencode") == "三方"
+    assert resolve_instance_kind("claude") == "三方"
+    assert resolve_instance_kind("jiuwenswarm") == "九问"
+    assert resolve_instance_kind("jiuwen-report") == "九问"
+
+
+@pytest.mark.asyncio
+async def test_local_stub_get_image_and_register() -> None:
+    client = RegistryClient(RegistryConfig())
+    image = await client.get_image_info("opencode")
+    assert image.image_name == "opencode"
+    assert image.metadata["source"] == "local_stub"
+
+    agent = AgentInfo(user_id="u1", agent_type="opencode", status=AgentStatus.READY)
+    agent.metadata["node"] = "192.168.0.12"
+    agent.metadata["address"] = "10.244.1.7:4096"
+    await client.register_agent(agent)
+    assert agent.agent_id in client._registered_agents  # noqa: SLF001
+    assert client._agent_service_ids[agent.agent_id] == instance_service_id(  # noqa: SLF001
+        "u1", "opencode"
+    )
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_local_list_user_images_contains_supported_types() -> None:
+    client = RegistryClient(RegistryConfig())
+    images = await client.list_user_images("user-01")
+    names = {item.image_name for item in images}
+    assert "opencode" in names
+    assert "jiuwenswarm" in names
+    assert all(item.metadata.get("user_id") == "user-01" for item in images)
+    await client.close()
+
+
+class _FakeRegistryTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+        self._instances: dict[str, dict[str, Any]] = {}
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        method = request.method.upper()
+        path = request.url.path
+        params = dict(request.url.params)
+        body: dict[str, Any] | None = None
+        if request.content:
+            body = json.loads(request.content.decode("utf-8"))
+        self.calls.append((method, path, body, params or None))
+
+        if method == "GET" and path.endswith("/launch-spec"):
+            framework = path.split("/")[-2]
+            version = params.get("version") or "v0.2.0"
+            return httpx.Response(
+                200,
+                json={
+                    "framework": framework,
+                    "framework_version": version,
+                    "rootfs": {
+                        "type": "image",
+                        "imageurl": f"harbor.local/adapted/{framework}:{version}",
+                    },
+                    "cpu": 1000,
+                    "memory": 2048,
+                    "ports": [{"port": 8080, "protocol": "tcp"}],
+                    "env": {"A2X_LLM_KEY": "${A2X_LLM_KEY}"},
+                },
+            )
+
+        if method == "GET" and path.rstrip("/").endswith("/api/images"):
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "framework": "opencode",
+                        "default": "v0.2.0",
+                        "versions": [{"framework_version": "v0.2.0"}],
+                    }
+                ],
+            )
+
+        if method == "POST" and path.rstrip("/").endswith("/api/instances"):
+            assert body is not None
+            record = {**body, "dataset": "default", "status": "运行"}
+            self._instances[str(body["service_id"])] = record
+            return httpx.Response(200, json=record)
+
+        if method == "PATCH" and "/api/instances/" in path:
+            sid = path.rstrip("/").split("/")[-1]
+            if sid not in self._instances:
+                return httpx.Response(404, json={"detail": "not found"})
+            self._instances[sid].update(body or {})
+            return httpx.Response(200, json=self._instances[sid])
+
+        if method == "DELETE" and "/api/instances/" in path:
+            sid = path.rstrip("/").split("/")[-1]
+            existed = sid in self._instances
+            self._instances.pop(sid, None)
+            return httpx.Response(
+                200,
+                json={"service_id": sid, "dataset": "default", "deleted": existed},
+            )
+
+        if method == "POST" and path.endswith("/heartbeat"):
+            node = path.split("/")[-2]
+            return httpx.Response(
+                200,
+                json={
+                    "node": node,
+                    "state": "healthy",
+                    "ttl_seconds": 90,
+                    "expires_at": 1751800000.0,
+                },
+            )
+
+        if method == "GET" and path.endswith("/missing/launch-spec"):
+            return httpx.Response(404, json={"detail": "image not found"})
+
+        return httpx.Response(500, json={"detail": f"unhandled {method} {path}"})
+
+
+@pytest.mark.asyncio
+async def test_http_launch_spec_register_update_heartbeat() -> None:
+    transport = _FakeRegistryTransport()
+    client = RegistryClient(
+        RegistryConfig(
+            endpoint="http://registry.test",
+            request_timeout_s=5.0,
+            node="192.168.0.12",
+        )
+    )
+    client._http = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://registry.test/",
+        transport=transport,
+        timeout=5.0,
+    )
+
+    spec = await client.get_launch_spec("opencode")
+    assert spec.framework == "opencode"
+    assert spec.framework_version == "v0.2.0"
+    assert spec.rootfs["imageurl"].endswith("opencode:v0.2.0")
+    assert spec.cpu == 1000
+
+    image = await client.get_image_info("opencode")
+    assert image.image_uri == "harbor.local/adapted/opencode:v0.2.0"
+    assert image.metadata["framework_version"] == "v0.2.0"
+
+    sid = instance_service_id("user-01", "opencode")
+    record = await client.register_instance(
+        service_id=sid,
+        kind="三方",
+        framework="opencode",
+        framework_version="v0.2.0",
+        node="192.168.0.12",
+        address="10.244.1.7:4096",
+        user="user-01",
+    )
+    assert record.status == "运行"
+    assert record.service_id == sid
+
+    updated = await client.update_instance(
+        sid, node="192.168.0.20", address="10.244.3.9:4096"
+    )
+    assert updated.node == "192.168.0.20"
+    assert updated.address == "10.244.3.9:4096"
+
+    hb = await client.report_node_heartbeat()
+    assert hb.node == "192.168.0.12"
+    assert hb.state == "healthy"
+    assert hb.ttl_seconds == 90
+
+    deleted = await client.unregister_instance(sid)
+    assert deleted["deleted"] is True
+
+    methods = [call[0] for call in transport.calls]
+    assert "GET" in methods
+    assert "POST" in methods
+    assert "PATCH" in methods
+    assert "DELETE" in methods
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_http_register_agent_maps_fields() -> None:
+    transport = _FakeRegistryTransport()
+    client = RegistryClient(RegistryConfig(endpoint="http://registry.test"))
+    client._http = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://registry.test/",
+        transport=transport,
+        timeout=5.0,
+    )
+    agent = AgentInfo(
+        user_id="user-01",
+        agent_type="opencode",
+        sandbox_id="sbx-1",
+        status=AgentStatus.READY,
+        metadata={
+            "image_info": {"framework_version": "v0.2.0"},
+            "sandbox": {"node": "192.168.0.12", "address": "10.244.1.7:4096"},
+        },
+    )
+    await client.register_agent(agent)
+    post = next(call for call in transport.calls if call[0] == "POST")
+    assert post[1].endswith("/api/instances")
+    assert post[2] is not None
+    assert post[2]["service_id"] == instance_service_id("user-01", "opencode")
+    assert post[2]["kind"] == "三方"
+    assert post[2]["node"] == "192.168.0.12"
+    assert post[2]["address"] == "10.244.1.7:4096"
+    await client.unregister_agent(agent.agent_id)
+    await client.close()
+
+
+class _ErrorTransport(httpx.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/missing/launch-spec"):
+            return httpx.Response(404, json={"detail": "not found"})
+        if path.endswith("/busy/v1"):
+            return httpx.Response(409, json={"detail": "in use"})
+        return httpx.Response(500, json={"detail": "boom"})
+
+
+@pytest.mark.asyncio
+async def test_http_errors_mapped() -> None:
+    client = RegistryClient(RegistryConfig(endpoint="http://registry.test"))
+    client._http = httpx.AsyncClient(  # noqa: SLF001
+        base_url="http://registry.test/",
+        transport=_ErrorTransport(),
+        timeout=5.0,
+    )
+    with pytest.raises(RegistryNotFoundError):
+        await client.get_launch_spec("missing")
+    with pytest.raises(RegistryConflictError):
+        await client._request_json("DELETE", "api/images/busy/v1")  # noqa: SLF001
+    await client.close()

--- a/tests/unit_tests/extensions/test_agentos_router.py
+++ b/tests/unit_tests/extensions/test_agentos_router.py
@@ -235,11 +235,17 @@ def test_load_router_config_agent_key_fields() -> None:
             },
             "agentos": {
                 "agent_key_fields": ["user_id", "agent_type", "session_id"],
+                "registry": {
+                    "endpoint": "http://127.0.0.1:8000",
+                    "node": "192.168.0.12",
+                },
             },
         }
     }
     loaded = load_router_config(config)
     assert loaded.agent_key_fields == ("user_id", "agent_type", "session_id")
+    assert loaded.registry.endpoint == "http://127.0.0.1:8000"
+    assert loaded.registry.node == "192.168.0.12"
 
     default_loaded = load_router_config(
         {


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind feature

## Summary

- 按一体机 Agent OS registry 设计，实现 gateway 侧 `RegistryClient`（httpx keep-alive）
- 覆盖 gateway 写路径：`launch-spec` 查询、实例注册 / 变更 / 注销、node 心跳
- `endpoint` 为空时走本地 stub，不依赖注册中心进程即可启动 AgentOS

## 主要改动

### API 封装

| 能力 | 方法 | HTTP |
|------|------|------|
| 取运行规格 | `get_launch_spec(framework, version?)` | `GET /api/images/{framework}/launch-spec` |
| 镜像列表 | `list_images(framework?)` | `GET /api/images` |
| 实例注册 | `register_instance(...)` | `POST /api/instances` |
| 实例变更 | `update_instance(service_id, node?, address?)` | `PATCH /api/instances/{service_id}` |
| 实例注销 | `unregister_instance(service_id)` | `DELETE /api/instances/{service_id}` |
| 节点心跳 | `report_node_heartbeat(node?)` | `POST /api/nodes/{node}/heartbeat` |

### 兼容现有 Router

- `get_image_info` → `get_launch_spec`
- `register_agent` → `register_instance`（`service_id` 由 `(user, framework)` 确定性派生）
- `list_user_images` / `report_heartbeat` / `close` 保持可用

### 配置

```yaml
gateway:
  agentos:
    registry:
      endpoint:          # 空=本地 stub；一体机默认 http://127.0.0.1:8000
      request_timeout_s: 10
      node:              # 本机 nodeIP，供心跳续租

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->