### PR TITLE
fix(qa-block): 首次权限 ASK 跳过 freeze，保证弹窗期间QA同轮 keep

### DIFF
--- a/jiuwenclaw/agentserver/deep_agent/rails/qa_block_freeze_rail.py
+++ b/jiuwenclaw/agentserver/deep_agent/rails/qa_block_freeze_rail.py
@@ -15,7 +15,6 @@ from openjiuwen.core.context_engine.qa_block.messages import extract_qa_native_m
 from openjiuwen.core.context_engine.qa_block.registry import load_registry, save_registry
 from openjiuwen.core.context_engine.qa_block.selector import resolve_summarizer_model
 from openjiuwen.core.context_engine.qa_block.store import QABlockStore
-from openjiuwen.core.session.interaction.interactive_input import InteractiveInput
 from openjiuwen.core.single_agent.interrupt.state import INTERRUPTION_KEY
 from openjiuwen.core.single_agent.rail.base import AgentCallbackContext, InvokeInputs
 from openjiuwen.harness.rails.base import DeepAgentRail
@@ -28,8 +27,6 @@ from jiuwenclaw.agentserver.deep_agent.plan_pause_helpers import (
 from jiuwenclaw.agentserver.deep_agent.rails.qa_block_assembly_rail import (
     clear_assembly_committed_qa_id,
 )
-
-from jiuwenclaw.agentserver.deep_agent.rails.utils import is_ask_user_question_interrupt
 
 logger = logging.getLogger(__name__)
 
@@ -49,16 +46,14 @@ def infer_qa_status(ctx: AgentCallbackContext) -> Literal["completed", "interrup
     return "completed"
 
 
-def _is_ask_user_question_interrupt(ctx: AgentCallbackContext) -> bool:
-    """检测中断是否为工具权限确认弹窗(ask_user_question/popup)。
+def _clear_session_interruption_key(session: Any) -> None:
+    """Clear leftover HITL interrupt marker after a settled freeze.
 
-    与用户主动取消(CancelledError)不同：
-    - 工具权限弹窗：result_type="interrupt" + 包含 interrupt_ids
-    - 用户主动取消：不设置 result，直接抛 CancelledError
-
-    这类中断应跳过QA卸载，沿用当前上下文。
+    Skip-freeze paths must NOT call this — secondary ASK keep relies on the key.
     """
-    return is_ask_user_question_interrupt(ctx)
+    updater = getattr(session, "update_state", None)
+    if callable(updater):
+        updater({INTERRUPTION_KEY: None})
 
 
 class JiuClawQABlockFreezeRail(DeepAgentRail):
@@ -320,25 +315,38 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
             logger.info("[QABlockFreezeRail] freeze skipped: context not in pool session_id=%s", session_id)
             return
 
-        # 弹窗交互(ask_user_question)中断时不卸载QA，沿用当前上下文
-        if _is_ask_user_question_interrupt(ctx):
-            logger.info("[QABlockFreezeRail] skip freeze for ask_user_question interrupt session_id=%s", session_id)
-            return
-
-        # 弹窗确认恢复：仅当仍处于中断时跳过 freeze。
-        # stream 外层 result 常为 None，不能再据此 skip，否则成功收尾会留下孤儿 QA。
-        # invoke 看 result_type=interrupt；stream 以 session INTERRUPTION_KEY 为准。
-        if isinstance(ctx.inputs, InvokeInputs) and isinstance(ctx.inputs.query, InteractiveInput):
+        # 弹窗/权限 HITL 中断期间不卸载 QA，沿用当前上下文（同轮 keep）。
+        # 覆盖：首次普通 query ASK、InteractiveInput 续跑中再次中断。
+        # 成功收尾：result 明确非 interrupt 时不因残留 INTERRUPTION_KEY 误 skip（stale key）；
+        # 且 freeze 成功后清 key。二次 ASK（result=interrupt 或 result 未决 + key）仍 skip，不清 key。
+        # stream 外层 result 常为 None，故未决时仍看 session INTERRUPTION_KEY。
+        if isinstance(ctx.inputs, InvokeInputs):
             result = getattr(ctx.inputs, "result", None)
-            still_interrupted = (
-                (isinstance(result, dict) and result.get("result_type") == "interrupt")
-                or bool(session.get_state(INTERRUPTION_KEY))
+            result_is_interrupt = (
+                isinstance(result, dict) and result.get("result_type") == "interrupt"
+            )
+            result_settled = (
+                isinstance(result, dict)
+                and bool(result.get("result_type"))
+                and result.get("result_type") != "interrupt"
+            )
+            has_interrupt_key = bool(session.get_state(INTERRUPTION_KEY))
+            still_interrupted = result_is_interrupt or (
+                has_interrupt_key and not result_settled
             )
             if still_interrupted:
-                logger.info(
-                    "[QABlockFreezeRail] skip freeze for popup confirmation resume session_id=%s",
-                    session_id,
-                )
+                if isinstance(result, dict) and "interrupt_ids" in result:
+                    logger.info(
+                        "[QABlockFreezeRail] skip freeze for ask_user_question interrupt "
+                        "session_id=%s",
+                        session_id,
+                    )
+                else:
+                    logger.info(
+                        "[QABlockFreezeRail] skip freeze while session interrupted "
+                        "session_id=%s",
+                        session_id,
+                    )
                 return
 
         workspace_root = ""
@@ -372,12 +380,15 @@ class JiuClawQABlockFreezeRail(DeepAgentRail):
                 session_id=session_id,
                 context=context,
             )
+            # Turn is settled enough to attempt freeze; drop stale interrupt marker.
+            _clear_session_interruption_key(session)
             return
 
         clear_assembly_committed_qa_id(session)
         ctx.extra[_FREEZE_DONE_KEY] = entry.qa_id
         await context_engine.save_contexts(session)
         await self._persist_freeze_checkpoint(session, session_id=session_id)
+        _clear_session_interruption_key(session)
         logger.info(
             "[QABlockFreezeRail] freeze committed session_id=%s qa_id=%s status=%s persist=%s",
             session_id,

--- a/tests/unit_tests/agentserver/test_qa_block_freeze_rail.py
+++ b/tests/unit_tests/agentserver/test_qa_block_freeze_rail.py
@@ -46,17 +46,26 @@ def _on_freeze_commit(rail: Any, session: Any, context: Any, commit: FreezeCommi
     getattr(rail, "_on_freeze_commit")(session, context, commit)
 
 
-def _make_interactive_freeze_ctx(
-    *, interruption: Any = None
+def _make_freeze_ctx(
+    *,
+    query: Any = None,
+    interruption: Any = None,
 ) -> tuple[AgentCallbackContext, Any, Any]:
-    state = {INTERRUPTION_KEY: interruption} if interruption is not None else {}
+    state: dict[str, Any] = {}
+    if interruption is not None:
+        state[INTERRUPTION_KEY] = interruption
 
     def get_state(key: str, default: Any = None) -> Any:
         return state.get(key, default)
 
+    def update_state(updates: dict[str, Any]) -> None:
+        state.update(updates)
+
     session = SimpleNamespace(
         get_session_id=lambda: "session-1",
         get_state=get_state,
+        update_state=update_state,
+        _state=state,
     )
     context = MagicMock()
     context.context_id.return_value = "ctx-1"
@@ -65,12 +74,20 @@ def _make_interactive_freeze_ctx(
     context_engine.get_history_qa_buffer.return_value = []
     context_engine.save_contexts = AsyncMock()
     agent = SimpleNamespace()
+    if query is None:
+        query = InteractiveInput()
     ctx = AgentCallbackContext(
         agent=agent,
-        inputs=InvokeInputs(query=InteractiveInput()),
+        inputs=InvokeInputs(query=query),
         session=session,
     )
     return ctx, context_engine, session
+
+
+def _make_interactive_freeze_ctx(
+    *, interruption: Any = None
+) -> tuple[AgentCallbackContext, Any, Any]:
+    return _make_freeze_ctx(interruption=interruption)
 
 
 class TestQABlockFreezeRailProduceSchedule(unittest.IsolatedAsyncioTestCase):
@@ -242,6 +259,85 @@ class TestQABlockFreezeRailInteractiveResume(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(registry.current_qa_id)
         context_engine.save_contexts.assert_not_awaited()
+
+
+class TestQABlockFreezeRailFirstAskPlainQuery(unittest.IsolatedAsyncioTestCase):
+    """First permission ASK on a normal user query must not freeze (same-QA keep)."""
+
+    def setUp(self) -> None:
+        self.rail = JiuClawQABlockFreezeRail()
+        self.rail.workspace = SimpleNamespace(root_path="/tmp/ws")
+        self.freeze_mock = AsyncMock(return_value=_make_commit().entry)
+        self.rail._freezer = SimpleNamespace(freeze=self.freeze_mock)
+        self.rail._maybe_await_overview_before_freeze = AsyncMock()
+
+    async def test_plain_query_skips_when_session_interrupted(self) -> None:
+        ctx, context_engine, _session = _make_freeze_ctx(
+            query="请读取桌面文件并总结",
+            interruption=SimpleNamespace(original_query="paused"),
+        )
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "QABlockStore", return_value=MagicMock()):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_not_awaited()
+
+    async def test_plain_query_skips_when_result_type_interrupt(self) -> None:
+        ctx, context_engine, _session = _make_freeze_ctx(query="请发送文件给我")
+        ctx.inputs.result = {"result_type": "interrupt", "interrupt_ids": ["call_1"]}
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "QABlockStore", return_value=MagicMock()):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_not_awaited()
+
+    async def test_plain_query_freezes_when_not_interrupted(self) -> None:
+        ctx, context_engine, _session = _make_freeze_ctx(query="你好")
+        ctx.inputs.result = {"result_type": "answer", "output": "hi"}
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "clear_assembly_committed_qa_id"), patch.object(
+            _module, "QABlockStore", return_value=MagicMock()
+        ), patch.object(_module, "post_agent_execute_for_session", new_callable=AsyncMock):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_awaited_once()
+
+    async def test_settled_result_with_stale_key_freezes_and_clears_key(self) -> None:
+        """Explicit answer + leftover INTERRUPTION_KEY → freeze and clear (not mis-skip)."""
+        stale = SimpleNamespace(original_query="stale")
+        ctx, context_engine, session = _make_freeze_ctx(
+            query="今天天气怎么样",
+            interruption=stale,
+        )
+        ctx.inputs.result = {"result_type": "answer", "output": "sunny"}
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "clear_assembly_committed_qa_id"), patch.object(
+            _module, "QABlockStore", return_value=MagicMock()
+        ), patch.object(_module, "post_agent_execute_for_session", new_callable=AsyncMock):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_awaited_once()
+        self.assertIsNone(session.get_state(INTERRUPTION_KEY))
+
+    async def test_secondary_ask_keeps_interrupt_key(self) -> None:
+        """Second ASK during resume: skip freeze and do NOT clear INTERRUPTION_KEY."""
+        pending = SimpleNamespace(original_query="still waiting")
+        ctx, context_engine, session = _make_freeze_ctx(
+            query=InteractiveInput(),
+            interruption=pending,
+        )
+        ctx.inputs.result = {"result_type": "interrupt", "interrupt_ids": ["call_2"]}
+        with patch.object(_module, "resolve_context_engine", return_value=context_engine), patch.object(
+            _module, "resolve_summarizer_model", return_value=None
+        ), patch.object(_module, "QABlockStore", return_value=MagicMock()):
+            await self.rail.after_invoke(ctx)
+
+        self.freeze_mock.assert_not_awaited()
+        self.assertIs(session.get_state(INTERRUPTION_KEY), pending)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind bug
## 问题
普通用户消息（query 为字符串）触发工具权限 ASK 时，QA freeze 的 skip 条件只覆盖 InteractiveInput 续跑路径，首次 ASK 仍会 `freeze ... status=completed`，把进行中 QA 卸掉。用户点「允许」后只能新开 qa，无法严格同轮 keep（与 0017b978/1c2f41f8 意图不一致）。

## 解决方案
在 `qa_block_freeze_rail._freeze_session` 中，对任意 `InvokeInputs`：当 `result_type=interrupt` 或 session 存在 `INTERRUPTION_KEY` 时统一 skip freeze；成功收尾（中断已清）仍走正常 freeze（兼容 c0d84c78）。补充首次普通 query ASK 相关 UT。

## 预期
- 弹窗期间不卸载进行中 QA，严格同轮 keep
- 点「允许」后续跑沿用同一 `qa_id`（配合既有 keep 逻辑）
- 任务成功收尾后仍正常 freeze + 落盘
- 无中断的普通回合行为不变；cancel 显式 freeze 路径不受影响

自验证：
多次ask和权限审批后，后续会话无异常：
![image.png](https://raw.gitcode.com/user-images/assets/9297832/d534c6db-891b-42e6-9eb7-d9eafcb65e6d/image.png 'image.png')
![image.png](https://raw.gitcode.com/user-images/assets/9297832/2b554ad3-0c77-4005-a97b-d2e31387d6cb/image.png 'image.png')

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->