### PR TITLE
fix(cli): remove invalid file= kwarg from logging calls

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/browser_start_client.py
+++ b/jiuwenswarm/agents/harness/common/tools/browser_start_client.py
@@ -28,7 +28,6 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -321,7 +320,7 @@ def main() -> int:
     try:
         return start_browser(dry_run=args.dry_run, config_file=args.config)
     except Exception as exc:
-        logger.info(f"Failed to start Chrome: {exc}", file=sys.stderr)
+        logger.error("Failed to start Chrome: %s", exc)
         return 1
 
 

--- a/jiuwenswarm/channels/acp/app_acp.py
+++ b/jiuwenswarm/channels/acp/app_acp.py
@@ -76,7 +76,7 @@ def _build_parser() -> argparse.ArgumentParser:
 def run_acp(args: argparse.Namespace) -> int:
     prompt = " ".join(list(args.args or [])).strip()
     if not prompt:
-        logger.warning("acp prompt is required", file=sys.stderr)
+        logger.warning("acp prompt is required")
         return 2
 
     request_id = f"acp_cli_{uuid.uuid4().hex[:12]}"


### PR DESCRIPTION
Paired: [GitHub #940](https://github.com/openJiuwen-ai/jiuwenswarm/pull/940) ↔ [GitCode !3940](https://gitcode.com/openJiuwen/jiuwenswarm/pull/3940)

## What

Two `logger.*()` calls pass `file=sys.stderr`. That is a `print()` keyword — `logging.Logger` does not accept it.

## Why it breaks

`Logger.warning(msg, **kwargs)` forwards `kwargs` straight to `Logger._log()`, whose signature only accepts `exc_info`, `stack_info`, `stacklevel` and `extra`. Anything else raises:

```
TypeError: Logger._log() got an unexpected keyword argument 'file'
```

The dispatch is guarded by `if self.isEnabledFor(level)`, so the bug is level-dependent: the message is silently dropped while the level is filtered, and the call raises as soon as the level is enabled. Both outcomes lose the message the code meant to emit, and neither reaches the `return` on the following line.

### 1. `jiuwenswarm/channels/acp/app_acp.py:79` — user-facing crash

```python
def run_acp(args: argparse.Namespace) -> int:
    prompt = " ".join(list(args.args or [])).strip()
    if not prompt:
        logger.warning("acp prompt is required", file=sys.stderr)
        return 2                                   # unreachable
```

WARNING is enabled under Python's default config, and `main()` in the same file calls `logging.basicConfig(level=logging.INFO)` before dispatching to `run_acp`. So running the `acp` subcommand with no prompt always raises. Reproduced on `develop`:

```python
>>> import logging, argparse
>>> logging.basicConfig(level=logging.INFO)
>>> from jiuwenswarm.channels.acp.app_acp import run_acp
>>> run_acp(argparse.Namespace(args=[], session_id=None, workspace_dir=None, gateway_url=None))
TypeError: Logger._log() got an unexpected keyword argument 'file'
```

The user gets a traceback instead of the `acp prompt is required` hint, and the process never exits with the intended code 2.

### 2. `jiuwenswarm/agents/harness/common/tools/browser_start_client.py:324` — hides the original error

```python
    try:
        return start_browser(dry_run=args.dry_run, config_file=args.config)
    except Exception as exc:
        logger.info(f"Failed to start Chrome: {exc}", file=sys.stderr)
        return 1
```

This one sits inside an `except` block. When INFO is enabled the `TypeError` propagates out of the handler and **replaces the original Chrome launch failure**, so the reason Chrome could not start never reaches the user. When INFO is filtered, the diagnostic is dropped entirely and `return 1` still runs. Either way the error path fails at its one job.

## Changes

| File | Change |
| --- | --- |
| `channels/acp/app_acp.py` | drop the invalid `file=` kwarg |
| `tools/browser_start_client.py` | drop `file=`; raise `info` → `error`; use lazy `%s` formatting |
| `tools/browser_start_client.py` | remove the now-unused `import sys` |

`logger.error` is used for the Chrome failure because a launch failure is not informational — the original `file=sys.stderr` shows the author intended it as error output, and INFO is filtered in many deployments. Lazy `%s` formatting matches the convention used elsewhere in the repo (e.g. `tools/acp_chat/tool.py:47`).

Removing `import sys` is required, not cosmetic: that `file=sys.stderr` was its only remaining use in the module, so keeping it would leave a `F401 'sys' imported but unused` for the static-check stage. Confirmed with pyflakes before and after; no other module imports `sys` from here. (Context: `import sys` was added for this line via issue #38 — the import was correct, the call site it served was not.)

## How to test

```bash
uv run pytest tests/unit_tests/ tests/unit/
python -m pyflakes jiuwenswarm/channels/acp/app_acp.py \
                   jiuwenswarm/agents/harness/common/tools/browser_start_client.py
```

Verified locally on Python 3.12: the `run_acp` snippet above now returns `2` and logs the hint, and the Chrome failure path logs `Failed to start Chrome: <original exception>` while preserving `return 1`. Both modules still import cleanly and their public entry points (`main`, `start_browser`, `run_acp`) are unchanged.

No behaviour changes beyond the error paths described above.