### PR TITLE
feat(gateway): add third-party agent switch RPC

### DIFF
--- a/jiuwenswarm/common/schema/message.py
+++ b/jiuwenswarm/common/schema/message.py
@@ -77,6 +77,8 @@ class ReqMethod(Enum):
     AGENTS_ENABLE = "agents.enable"
     AGENTS_DISABLE = "agents.disable"
     AGENTS_TOOLS_LIST = "agents.tools_list"
+    AGENT_SWITCH = "3rdagent.switch"
+    AGENT_LIST = "3rdagent.list"
 
     SKILLS_MARKETPLACE_LIST = "skills.marketplace.list"
     SKILLS_LIST = "skills.list"

--- a/jiuwenswarm/extensions/__init__.py
+++ b/jiuwenswarm/extensions/__init__.py
@@ -4,12 +4,14 @@ from jiuwenswarm.extensions.registry import ExtensionRegistry
 from jiuwenswarm.extensions.sdk.agent_server_client import AgentServerClientExtension
 from jiuwenswarm.extensions.sdk.base import BaseExtension
 from jiuwenswarm.extensions.sdk.crypto_utility import CryptoUtility
+from jiuwenswarm.extensions.sdk.third_agent import ThirdAgentExtension
 from jiuwenswarm.extensions.types import ExtensionConfig, ExtensionMetadata
 
 __all__ = [
     "BaseExtension",
     "AgentServerClientExtension",
     "CryptoUtility",
+    "ThirdAgentExtension",
     "ExtensionMetadata",
     "ExtensionConfig",
     "ExtensionRegistry",

--- a/jiuwenswarm/extensions/agentos/agentos_router/__init__.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/__init__.py
@@ -31,6 +31,7 @@ from jiuwenswarm.extensions.agentos.agentos_router.registry_client import (
     resolve_instance_kind,
 )
 from jiuwenswarm.extensions.agentos.agentos_router.router_client import AgentOSRouterClient
+from jiuwenswarm.extensions.agentos.agentos_router.third_agent import AgentOSThirdAgent
 
 __all__ = [
     "AgentCreatingTimeout",
@@ -38,6 +39,7 @@ __all__ = [
     "AgentManager",
     "AgentOSRouter",
     "AgentOSRouterClient",
+    "AgentOSThirdAgent",
     "AgentRuntime",
     "AgentStatus",
     "HeartbeatResult",

--- a/jiuwenswarm/extensions/agentos/agentos_router/extension.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/extension.py
@@ -11,17 +11,20 @@ from jiuwenswarm.extensions.agentos.agentos_router.config import (
 )
 from jiuwenswarm.extensions.agentos.agentos_router.registry_client import RegistryClient
 from jiuwenswarm.extensions.agentos.agentos_router.router_client import AgentOSRouterClient
+from jiuwenswarm.extensions.agentos.agentos_router.third_agent import AgentOSThirdAgent
 from jiuwenswarm.extensions.sdk.agent_server_client import (
     AgentServerClientExtension,
 )
+from jiuwenswarm.extensions.sdk.third_agent import ThirdAgentExtension
 from jiuwenswarm.extensions.yuanrong_frontend_client import (
     YuanrongFrontendAgentClient,
 )
 from jiuwenswarm.gateway.routing.agent_client import AgentServerClient
+from jiuwenswarm.gateway.routing.third_agent import ThirdAgent
 
 
-class AgentOSRouter(AgentServerClientExtension):
-    """AgentOS southbound Router extension."""
+class AgentOSRouter(AgentServerClientExtension, ThirdAgentExtension):
+    """AgentOS southbound Router extension (AgentServerClient + ThirdAgent)."""
 
     def __init__(self, config: RouterConfig) -> None:
         self._config = config
@@ -43,6 +46,7 @@ class AgentOSRouter(AgentServerClientExtension):
             self._registry_client,
             self._agent_manager,
         )
+        self._third_agent = AgentOSThirdAgent(self._router_client)
         self._closed = False
 
     async def initialize(self, config) -> None:
@@ -50,6 +54,9 @@ class AgentOSRouter(AgentServerClientExtension):
 
     def get_client(self) -> AgentServerClient:
         return self._router_client
+
+    def get_third_agent(self) -> ThirdAgent:
+        return self._third_agent
 
     async def shutdown(self) -> None:
         if self._closed:
@@ -64,4 +71,5 @@ async def register_extensions(registry):
         return []
     extension = AgentOSRouter(load_router_config(config))
     registry.register_agent_server_client(extension)
+    registry.register_third_agent(extension)
     return [extension]

--- a/jiuwenswarm/extensions/agentos/agentos_router/router_client.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/router_client.py
@@ -83,6 +83,8 @@ class AgentOSRouterClient(AgentServerClient):
             setter(handler)
 
     async def send_request(self, envelope: E2AEnvelope) -> AgentResponse:
+        # 3rdagent.list / 3rdagent.switch are handled by Gateway ThirdAgent
+        # (TUI local_handler), not via E2A send_request.
         try:
             runtime = await self._resolve_agent(envelope)
         except (ValueError, AgentCreatingTimeout) as exc:
@@ -101,6 +103,94 @@ class AgentOSRouterClient(AgentServerClient):
         runtime.attach_to_envelope(envelope)
         async for chunk in self._yuanrong.send_request_stream(envelope):
             yield chunk
+
+    async def thirdagent_list(
+        self,
+        *,
+        user_id: str,
+        current_agent_type: str = "",
+    ) -> dict[str, Any]:
+        """Handle ``3rdagent.list``: list switchable third-party agent images."""
+        uid = str(user_id or "").strip()
+        if not uid:
+            return {
+                "ok": False,
+                "error": "user_id is required for AgentOS routing",
+                "code": "BAD_REQUEST",
+            }
+        images = await self._registry.list_user_images(uid)
+        agents: list[dict[str, Any]] = []
+        for image in images:
+            agent_type = str(
+                (image.metadata or {}).get("agent_type") or image.image_name or ""
+            ).strip()
+            if not agent_type:
+                continue
+            agents.append(
+                {
+                    "agent_type": agent_type,
+                    "image_name": image.image_name,
+                    "image_uri": image.image_uri,
+                    "metadata": dict(image.metadata or {}),
+                }
+            )
+        current = str(current_agent_type or "").strip() or "jiuwenswarm"
+        return {
+            "ok": True,
+            "payload": {
+                "agents": agents,
+                "current_agent_type": current,
+            },
+        }
+
+    async def thirdagent_switch(
+        self,
+        *,
+        user_id: str,
+        agent_type: str,
+        session_id: str = "",
+    ) -> dict[str, Any]:
+        """Handle ``3rdagent.switch``: ensure agent exists without forwarding chat."""
+        uid = str(user_id or "").strip()
+        if not uid:
+            return {
+                "ok": False,
+                "error": "user_id is required for AgentOS routing",
+                "code": "BAD_REQUEST",
+            }
+        try:
+            normalized = AgentRuntime.normalize_agent_type(agent_type)
+        except ValueError as exc:
+            return {
+                "ok": False,
+                "error": str(exc),
+                "code": "UNSUPPORTED_AGENT_TYPE",
+            }
+        try:
+            runtime = await self._agent_manager.get_or_create_agent(
+                uid,
+                normalized,
+                key_values={"session_id": session_id} if session_id else None,
+                creator=self._create_agent,
+                metadata={"session_id": session_id} if session_id else None,
+            )
+        except (ValueError, AgentCreatingTimeout) as exc:
+            return {
+                "ok": False,
+                "error": str(exc),
+                "code": "INTERNAL_ERROR",
+            }
+        info = runtime.info
+        status = info.status.value if hasattr(info.status, "value") else str(info.status)
+        return {
+            "ok": True,
+            "payload": {
+                "agent_id": info.agent_id,
+                "agent_type": info.agent_type,
+                "sandbox_id": info.sandbox_id,
+                "status": status,
+            },
+        }
 
     async def shutdown(self) -> None:
         await self.disconnect()

--- a/jiuwenswarm/extensions/agentos/agentos_router/third_agent.py
+++ b/jiuwenswarm/extensions/agentos/agentos_router/third_agent.py
@@ -1,0 +1,49 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from jiuwenswarm.extensions.agentos.agentos_router.agent_manager import AgentRuntime
+from jiuwenswarm.gateway.routing.third_agent import ThirdAgent
+
+if TYPE_CHECKING:
+    from jiuwenswarm.extensions.agentos.agentos_router.router_client import (
+        AgentOSRouterClient,
+    )
+
+
+class AgentOSThirdAgent(ThirdAgent):
+    """AgentOS-backed third-party agent list/switch capability."""
+
+    def __init__(self, router_client: AgentOSRouterClient) -> None:
+        self._router = router_client
+
+    def normalize_agent_type(self, raw: Any) -> str:
+        return AgentRuntime.normalize_agent_type(raw)
+
+    async def thirdagent_list(
+        self,
+        *,
+        user_id: str,
+        current_agent_type: str = "",
+    ) -> dict[str, Any]:
+        return await self._router.thirdagent_list(
+            user_id=user_id,
+            current_agent_type=current_agent_type,
+        )
+
+    async def thirdagent_switch(
+        self,
+        *,
+        user_id: str,
+        agent_type: str,
+        session_id: str = "",
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del params
+        return await self._router.thirdagent_switch(
+            user_id=user_id,
+            agent_type=agent_type,
+            session_id=session_id,
+        )

--- a/jiuwenswarm/extensions/registry.py
+++ b/jiuwenswarm/extensions/registry.py
@@ -6,8 +6,10 @@ from jiuwenswarm.extensions.callback_compat import unregister_callback_sync
 from jiuwenswarm.gateway import AgentServerClient
 from jiuwenswarm.extensions.sdk.agent_server_client import AgentServerClientExtension
 from jiuwenswarm.extensions.sdk.crypto_utility import CryptoUtility
+from jiuwenswarm.extensions.sdk.third_agent import ThirdAgentExtension
 from jiuwenswarm.extensions.types import ExtensionConfig
 from jiuwenswarm.common.security.base_crypto import CryptoProvider
+from jiuwenswarm.gateway.routing.third_agent import ThirdAgent
 
 
 class ExtensionRegistry:
@@ -21,6 +23,7 @@ class ExtensionRegistry:
     ):
         self._agent_server_client: AgentServerClientExtension | None = None
         self._crypto_tool: CryptoUtility | None = None
+        self._third_agent: ThirdAgentExtension | None = None
         self._rpc_handlers: dict[str, Callable] = {}
         self.callback_framework = callback_framework
         self._config = ExtensionConfig(config=config, logger=logger)
@@ -57,6 +60,9 @@ class ExtensionRegistry:
     def register_crypto_utility(self, extension: CryptoUtility) -> None:
         self._crypto_tool = extension
 
+    def register_third_agent(self, extension: ThirdAgentExtension) -> None:
+        self._third_agent = extension
+
     def register_rpc_handler(self, method: str, handler: Callable) -> None:
         method_name = str(method or "").strip()
         if not method_name:
@@ -84,6 +90,14 @@ class ExtensionRegistry:
     def get_crypto_provider(self) -> CryptoProvider | None:
         ext = self._crypto_tool
         return ext.get_crypto() if ext is not None else None
+
+    def get_third_agent_extension(self) -> ThirdAgentExtension | None:
+        return self._third_agent
+
+    def get_third_agent(self) -> ThirdAgent | None:
+        """Return registered ThirdAgent, or None when no extension registered."""
+        ext = self._third_agent
+        return ext.get_third_agent() if ext is not None else None
 
     def register(
         self,

--- a/jiuwenswarm/extensions/sdk/__init__.py
+++ b/jiuwenswarm/extensions/sdk/__init__.py
@@ -1,9 +1,11 @@
 from jiuwenswarm.extensions.sdk.agent_server_client import AgentServerClientExtension
 from jiuwenswarm.extensions.sdk.base import BaseExtension
 from jiuwenswarm.extensions.sdk.crypto_utility import CryptoUtility
+from jiuwenswarm.extensions.sdk.third_agent import ThirdAgentExtension
 
 __all__ = [
     "BaseExtension",
     "AgentServerClientExtension",
     "CryptoUtility",
+    "ThirdAgentExtension",
 ]

--- a/jiuwenswarm/extensions/sdk/third_agent.py
+++ b/jiuwenswarm/extensions/sdk/third_agent.py
@@ -1,0 +1,19 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+
+from abc import abstractmethod
+
+from jiuwenswarm.extensions.sdk.base import BaseExtension
+from jiuwenswarm.gateway.routing.third_agent import ThirdAgent
+
+
+class ThirdAgentExtension(BaseExtension):
+    """扩展入口：持有真正的 `ThirdAgent` 实现，通过 `get_third_agent()` 暴露。"""
+
+    @abstractmethod
+    def get_third_agent(self) -> ThirdAgent:
+        """返回第三方 Agent list/switch 能力实例。"""
+        ...
+
+    async def shutdown(self) -> None:
+        """扩展关闭"""
+        pass

--- a/jiuwenswarm/gateway/app_gateway.py
+++ b/jiuwenswarm/gateway/app_gateway.py
@@ -441,6 +441,13 @@ class GatewayServer:
         return text or None
 
     @staticmethod
+    def _connection_agent_type(ws: Any) -> str:
+        """返回当前 WS 连接绑定的 agent_type（缺省 jiuwenswarm）。"""
+        raw = getattr(ws, "_gateway_agent_type", None)
+        text = str(raw or "jiuwenswarm").strip().lower()
+        return text or "jiuwenswarm"
+
+    @staticmethod
     def _invoke_local_handler(
         handler: Callable[..., Awaitable[None]],
         ctx: _LocalHandlerContext,
@@ -976,6 +983,7 @@ class GatewayServer:
 
         ws_user_id = self._extract_ws_user_id(ws)
         setattr(ws, "_gateway_user_id", ws_user_id)
+        setattr(ws, "_gateway_agent_type", "jiuwenswarm")
         uid_marker = "" if ws_user_id else " uid_empty=yes"
         logger.info(
             "[Gateway] WS handshake X-User-Id: user_id=%r%s channel=%s path=%s",
@@ -1190,6 +1198,10 @@ class GatewayServer:
             # 确保 mode 被设置到 params 中，以便后续转发到 AgentServer
             params = dict(params)
             params.setdefault("mode", mode.value)
+
+            # 连接级 agent_type 为 SSOT，注入后续转发请求
+            # （3rdagent.switch 由 TUI local_handler 写回 ws._gateway_agent_type）
+            params["agent_type"] = self._connection_agent_type(ws)
 
             # V2: agent_ref 全链路透传（阶段2）。
             # tui 客户端从不发 agent_ref（_agent_ref 恒 None）→ 按 mode/agent_id 合成 AgentRef，
@@ -1442,6 +1454,15 @@ async def _run(
         client = agent_server_ext.get_client()
     else:
         client = WebSocketAgentServerClient(ping_interval=20.0, ping_timeout=600.0)
+
+    from jiuwenswarm.gateway.routing.third_agent import get_unsupported_third_agent
+
+    third_agent_ext = extension_registry.get_third_agent_extension()
+    if third_agent_ext is not None:
+        logger.info("[App] using extension ThirdAgent: %s", third_agent_ext.metadata.name)
+        third_agent = third_agent_ext.get_third_agent()
+    else:
+        third_agent = get_unsupported_third_agent()
 
     # 如果是 WebSocket 客户端，需要连接；如果是 YuanrongFrontendAgentClient，无需连接
     if isinstance(client, WebSocketAgentServerClient):
@@ -1704,6 +1725,7 @@ async def _run(
             CliRouteBindParams(
                 agent_client=client,
                 message_handler=message_handler,
+                third_agent=third_agent,
                 on_config_saved=_on_config_saved,
                 path="/tui",
                 channel_id="tui",

--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -397,6 +397,7 @@ class CliHandlersBindParams:
     channel: Any  # GatewayServer instance
     agent_client: Any = None
     message_handler: Any = None
+    third_agent: Any = None
     on_config_saved: Any = None
     path: str = "/tui"
     cron_controller: Any = None
@@ -406,6 +407,7 @@ class CliHandlersBindParams:
 class CliRouteBindParams:
     agent_client: Any = None
     message_handler: Any = None
+    third_agent: Any = None
     on_config_saved: Any = None
     path: str = "/tui"
     channel_id: str = "tui"
@@ -679,12 +681,22 @@ def _load_env_from_file() -> dict[str, str]:
     return result
 
 
+def resolve_3rdagent_switch_session_id(params: dict | None) -> str:
+    """Explicit ``params.session_id`` for 3rdagent.switch (never gateway req_id fallback)."""
+    if not isinstance(params, dict):
+        return ""
+    return str(params.get("session_id") or "").strip()
+
+
 def register_cli_handlers(bind: CliHandlersBindParams) -> None:
     channel = bind.channel
     agent_client = bind.agent_client
     on_config_saved = bind.on_config_saved
     path = bind.path
     cron_controller_ref = bind.cron_controller
+    from jiuwenswarm.gateway.routing.third_agent import get_unsupported_third_agent
+
+    third_agent = bind.third_agent if bind.third_agent is not None else get_unsupported_third_agent()
 
     async def _config_get(ws, req_id, params, session_id):
         payload = {
@@ -2710,10 +2722,86 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             logger.warning("[models.list] %s", exc)
             await channel.send_response(ws, req_id, ok=False, error=str(exc), code="INTERNAL_ERROR")
 
+    async def _3rdagent_list(ws, req_id, params, session_id, user_id=None):
+        params = params if isinstance(params, dict) else {}
+        current = str(
+            getattr(ws, "_gateway_agent_type", None)
+            or params.get("agent_type")
+            or "jiuwenswarm"
+        ).strip() or "jiuwenswarm"
+        uid = str(user_id or getattr(ws, "_gateway_user_id", None) or "").strip()
+        try:
+            result = await third_agent.thirdagent_list(
+                user_id=uid,
+                current_agent_type=current,
+            )
+        except Exception as exc:
+            logger.warning("[3rdagent.list] %s", exc)
+            await channel.send_response(
+                ws, req_id, ok=False, error=str(exc), code="INTERNAL_ERROR"
+            )
+            return
+        if not result.get("ok"):
+            await channel.send_response(
+                ws,
+                req_id,
+                ok=False,
+                error=str(result.get("error") or "3rdagent.list unsupported"),
+                code=str(result.get("code") or "UNSUPPORTED"),
+            )
+            return
+        await channel.send_response(
+            ws, req_id, ok=True, payload=dict(result.get("payload") or {})
+        )
+
+    async def _3rdagent_switch(ws, req_id, params, session_id, user_id=None):
+        del session_id  # do not use gateway req_id fallback; require explicit params.session_id
+        params = params if isinstance(params, dict) else {}
+        uid = str(user_id or getattr(ws, "_gateway_user_id", None) or "").strip()
+        explicit_session_id = resolve_3rdagent_switch_session_id(params)
+        if not explicit_session_id:
+            await channel.send_response(
+                ws,
+                req_id,
+                ok=False,
+                error="session_id is required for 3rdagent.switch",
+                code="BAD_REQUEST",
+            )
+            return
+        try:
+            result = await third_agent.thirdagent_switch(
+                user_id=uid,
+                agent_type=str(params.get("agent_type") or ""),
+                session_id=explicit_session_id,
+                params=params,
+            )
+        except Exception as exc:
+            logger.warning("[3rdagent.switch] %s", exc)
+            await channel.send_response(
+                ws, req_id, ok=False, error=str(exc), code="INTERNAL_ERROR"
+            )
+            return
+        if not result.get("ok"):
+            await channel.send_response(
+                ws,
+                req_id,
+                ok=False,
+                error=str(result.get("error") or "3rdagent.switch unsupported"),
+                code=str(result.get("code") or "UNSUPPORTED"),
+            )
+            return
+        payload = dict(result.get("payload") or {})
+        switched = str(payload.get("agent_type") or "").strip()
+        if switched:
+            setattr(ws, "_gateway_agent_type", switched)
+        await channel.send_response(ws, req_id, ok=True, payload=payload)
+
     channel.register_local_handler(path, "config.get", _config_get)
     channel.register_local_handler(path, "config.set", _config_set)
     channel.register_local_handler(path, "config.validate_model", _config_validate_model)
     channel.register_local_handler(path, "models.list", _models_list)
+    channel.register_local_handler(path, "3rdagent.list", _3rdagent_list)
+    channel.register_local_handler(path, "3rdagent.switch", _3rdagent_switch)
     channel.register_local_handler(path, "session.list", _session_list)
     channel.register_local_handler(path, "session.create", _session_create)
     channel.register_local_handler(path, "session.delete", _session_delete)
@@ -3073,6 +3161,7 @@ def build_cli_route_binding(bind: CliRouteBindParams) -> GatewayRouteBinding:
                 channel=channel,
                 agent_client=bind.agent_client,
                 message_handler=bind.message_handler,
+                third_agent=bind.third_agent,
                 on_config_saved=bind.on_config_saved,
                 path=bind.path,
                 cron_controller=bind.cron_controller,

--- a/jiuwenswarm/gateway/routing/third_agent.py
+++ b/jiuwenswarm/gateway/routing/third_agent.py
@@ -1,0 +1,78 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+
+"""ThirdAgent - Gateway 侧第三方 Agent list/switch 能力接口."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ThirdAgent(ABC):
+    """第三方 Agent 目录 / 切换接口（Gateway 域）。"""
+
+    def normalize_agent_type(self, raw: Any) -> str:
+        """Normalize agent_type; default accepts any non-empty value."""
+        agent_type = str(raw or "jiuwenswarm").strip().lower()
+        return agent_type or "jiuwenswarm"
+
+    @abstractmethod
+    async def thirdagent_list(
+        self,
+        *,
+        user_id: str,
+        current_agent_type: str = "",
+    ) -> dict[str, Any]:
+        """Handle ``3rdagent.list`` for a user."""
+        ...
+
+    @abstractmethod
+    async def thirdagent_switch(
+        self,
+        *,
+        user_id: str,
+        agent_type: str,
+        session_id: str = "",
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Handle ``3rdagent.switch`` for (user_id, agent_type)."""
+        ...
+
+
+class UnsupportedThirdAgent(ThirdAgent):
+    """Default implementation when no ThirdAgent extension is registered."""
+
+    async def thirdagent_list(
+        self,
+        *,
+        user_id: str,
+        current_agent_type: str = "",
+    ) -> dict[str, Any]:
+        del user_id, current_agent_type
+        return {
+            "ok": False,
+            "error": "3rdagent.list requires an AgentOS Router extension",
+            "code": "UNSUPPORTED",
+        }
+
+    async def thirdagent_switch(
+        self,
+        *,
+        user_id: str,
+        agent_type: str,
+        session_id: str = "",
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del user_id, agent_type, session_id, params
+        return {
+            "ok": False,
+            "error": "3rdagent.switch requires an AgentOS Router extension",
+            "code": "UNSUPPORTED",
+        }
+
+
+_UNSUPPORTED_THIRD_AGENT = UnsupportedThirdAgent()
+
+
+def get_unsupported_third_agent() -> ThirdAgent:
+    return _UNSUPPORTED_THIRD_AGENT

--- a/tests/unit_tests/extensions/test_agentos_router.py
+++ b/tests/unit_tests/extensions/test_agentos_router.py
@@ -100,10 +100,25 @@ class FakeRegistryClient:
     def __init__(self) -> None:
         self.registered: list[AgentInfo] = []
         self.image_lookups = 0
+        self.list_user_images_calls: list[str] = []
 
     async def get_image_info(self, image_name: str) -> ImageInfo:
         self.image_lookups += 1
         return ImageInfo(image_name=image_name)
+
+    async def list_user_images(self, user_id: str) -> list[ImageInfo]:
+        self.list_user_images_calls.append(user_id)
+        return [
+            ImageInfo(
+                image_name="claude",
+                image_uri="registry://claude:latest",
+                metadata={"agent_type": "claude", "user_id": user_id},
+            ),
+            ImageInfo(
+                image_name="opencode",
+                metadata={"agent_type": "opencode", "user_id": user_id},
+            ),
+        ]
 
     async def register_agent(self, agent_info: AgentInfo) -> None:
         self.registered.append(agent_info)
@@ -183,6 +198,101 @@ async def test_third_party_type_creates_via_yuanrong() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_switch_creates_without_forwarding_chat() -> None:
+    yuanrong = FakeYuanRongClient()
+    agent_manager = AgentManager()
+    client = AgentOSRouterClient(yuanrong, FakeRegistryClient(), agent_manager)
+
+    response = await client.thirdagent_switch(
+        user_id="u1",
+        agent_type="claude",
+        session_id="sess-1",
+    )
+    await client.shutdown()
+
+    assert response["ok"] is True
+    assert yuanrong.create_calls == 1
+    assert yuanrong.send_calls == 0
+    assert response["payload"]["agent_type"] == "claude"
+    assert response["payload"]["sandbox_id"] == "sbx-1"
+    agents = await agent_manager.list_user_agents("u1")
+    assert len(agents) == 1
+    assert agents[0].info.agent_type == "claude"
+
+
+@pytest.mark.asyncio
+async def test_agent_list_returns_registry_images_without_creating() -> None:
+    yuanrong = FakeYuanRongClient()
+    registry = FakeRegistryClient()
+    agent_manager = AgentManager()
+    client = AgentOSRouterClient(yuanrong, registry, agent_manager)
+
+    response = await client.thirdagent_list(
+        user_id="u1",
+        current_agent_type="jiuwenswarm",
+    )
+    await client.shutdown()
+
+    assert response["ok"] is True
+    assert yuanrong.create_calls == 0
+    assert yuanrong.send_calls == 0
+    assert registry.list_user_images_calls == ["u1"]
+    assert response["payload"]["current_agent_type"] == "jiuwenswarm"
+    assert [item["agent_type"] for item in response["payload"]["agents"]] == [
+        "claude",
+        "opencode",
+    ]
+    assert response["payload"]["agents"][0]["image_uri"] == "registry://claude:latest"
+    assert await agent_manager.list_user_agents("u1") == []
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_reuses_existing_agent() -> None:
+    yuanrong = FakeYuanRongClient()
+    agent_manager = AgentManager()
+    client = AgentOSRouterClient(yuanrong, FakeRegistryClient(), agent_manager)
+
+    first = await client.thirdagent_switch(
+        user_id="u1",
+        agent_type="claude",
+        session_id="sess-1",
+    )
+    second = await client.thirdagent_switch(
+        user_id="u1",
+        agent_type="claude",
+        session_id="sess-1",
+    )
+    await client.shutdown()
+
+    assert first["ok"] and second["ok"]
+    assert yuanrong.create_calls == 1
+    assert yuanrong.send_calls == 0
+    assert first["payload"]["agent_id"] == second["payload"]["agent_id"]
+
+
+@pytest.mark.asyncio
+async def test_chat_after_switch_reuses_agent() -> None:
+    yuanrong = FakeYuanRongClient()
+    agent_manager = AgentManager()
+    client = AgentOSRouterClient(yuanrong, FakeRegistryClient(), agent_manager)
+
+    switch_resp = await client.thirdagent_switch(
+        user_id="u1",
+        agent_type="claude",
+        session_id="sess-1",
+    )
+    chat_envelope = _envelope(agent_type="claude")
+    chat_resp = await client.send_request(chat_envelope)
+    await client.shutdown()
+
+    assert switch_resp["ok"] and chat_resp.ok
+    assert yuanrong.create_calls == 1
+    assert yuanrong.send_calls == 1
+    assert chat_envelope.channel_context["agent_id"] == switch_resp["payload"]["agent_id"]
+    assert chat_envelope.channel_context["agent_type"] == "claude"
+
+
+@pytest.mark.asyncio
 async def test_delete_agent_releases_yuanrong_sandbox() -> None:
     yuanrong = FakeYuanRongClient()
     agent_manager = AgentManager()
@@ -196,6 +306,51 @@ async def test_delete_agent_releases_yuanrong_sandbox() -> None:
 
     assert yuanrong.delete_calls == ["sbx-1"]
     assert await agent_manager.list_user_agents("u1") == []
+
+
+@pytest.mark.asyncio
+async def test_unsupported_third_agent_returns_unsupported() -> None:
+    from jiuwenswarm.gateway.routing.third_agent import get_unsupported_third_agent
+
+    third = get_unsupported_third_agent()
+    listed = await third.thirdagent_list(user_id="u1", current_agent_type="jiuwenswarm")
+    switched = await third.thirdagent_switch(
+        user_id="u1", agent_type="claude", session_id="s1"
+    )
+
+    assert listed["ok"] is False
+    assert listed["code"] == "UNSUPPORTED"
+    assert switched["ok"] is False
+    assert switched["code"] == "UNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_agentos_third_agent_list_and_switch() -> None:
+    from jiuwenswarm.extensions.agentos.agentos_router.third_agent import (
+        AgentOSThirdAgent,
+    )
+
+    yuanrong = FakeYuanRongClient()
+    registry = FakeRegistryClient()
+    agent_manager = AgentManager()
+    client = AgentOSRouterClient(yuanrong, registry, agent_manager)
+    third = AgentOSThirdAgent(client)
+
+    listed = await third.thirdagent_list(user_id="u1", current_agent_type="jiuwenswarm")
+    switched = await third.thirdagent_switch(
+        user_id="u1", agent_type="claude", session_id="sess-1"
+    )
+    await client.shutdown()
+
+    assert listed["ok"] is True
+    assert [item["agent_type"] for item in listed["payload"]["agents"]] == [
+        "claude",
+        "opencode",
+    ]
+    assert switched["ok"] is True
+    assert switched["payload"]["agent_type"] == "claude"
+    assert yuanrong.create_calls == 1
+    assert yuanrong.send_calls == 0
 
 
 def test_agentos_selected_by_agent_client_type() -> None:
@@ -281,9 +436,13 @@ async def test_agentos_extension_is_selected_independently(
 
     class Registry:
         registered = None
+        third_agent = None
 
         def register_agent_server_client(self, extension) -> None:
             self.registered = extension
+
+        def register_third_agent(self, extension) -> None:
+            self.third_agent = extension
 
     registry = Registry()
     assert await plain_extension.register_extensions(registry) == []
@@ -292,4 +451,6 @@ async def test_agentos_extension_is_selected_independently(
     assert len(registered) == 1
     assert isinstance(registered[0], AgentOSRouter)
     assert registry.registered is registered[0]
+    assert registry.third_agent is registered[0]
+    assert registry.third_agent.get_third_agent() is registered[0].get_third_agent()
     await registered[0].shutdown()

--- a/tests/unit_tests/gateway/test_app_gateway_acp.py
+++ b/tests/unit_tests/gateway/test_app_gateway_acp.py
@@ -2053,3 +2053,384 @@ async def test_gateway_server_ignores_frame_x_user_id_without_handshake_header()
 
     assert len(seen) == 1
     assert seen[0].user_id is None
+
+
+def _build_tui_server_with_agent_switch() -> GatewayServerProbe:
+    config = GatewayServerConfig(
+        enabled=True,
+        host="127.0.0.1",
+        port=19002,
+        routes={
+            "/tui": RouteConfig(
+                path="/tui",
+                channel_id="tui",
+                forward_methods=frozenset(
+                    {
+                        ReqMethod.CHAT_SEND.value,
+                    }
+                ),
+            ),
+        },
+    )
+    return GatewayServerProbe(config, DummyBus())
+
+
+@pytest.mark.asyncio
+async def test_gateway_injects_default_agent_type_on_forward():
+    server = _build_tui_server_with_agent_switch()
+    ws = FakeWebSocket(user_id="alice")
+    setattr(ws, "_gateway_agent_type", "jiuwenswarm")
+    seen = []
+
+    async def on_message(msg):
+        seen.append(msg)
+
+    server.on_message(on_message)
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-chat",
+                "method": "chat.send",
+                "params": {
+                    "session_id": "sess-1",
+                    "content": "hello",
+                },
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert len(seen) == 1
+    assert seen[0].params.get("agent_type") == "jiuwenswarm"
+
+
+@pytest.fixture
+def _third_agent_registry():
+    from openjiuwen.core.runner.callback.framework import AsyncCallbackFramework
+
+    from jiuwenswarm.extensions.registry import ExtensionRegistry
+
+    ExtensionRegistry.reset_instance()
+    registry = ExtensionRegistry.create_instance(AsyncCallbackFramework(), {}, None)
+    yield registry
+    ExtensionRegistry.reset_instance()
+
+
+def _resolve_third_agent_for_test():
+    from jiuwenswarm.extensions.registry import ExtensionRegistry
+    from jiuwenswarm.gateway.routing.third_agent import get_unsupported_third_agent
+
+    third = ExtensionRegistry.get_instance().get_third_agent()
+    return third if third is not None else get_unsupported_third_agent()
+
+
+@pytest.mark.asyncio
+async def test_gateway_agent_list_uses_local_handler_default_unsupported(
+    _third_agent_registry,
+):
+    server = _build_tui_server_with_agent_switch()
+    seen = []
+
+    async def on_message(msg):
+        seen.append(msg)
+
+    server.on_message(on_message)
+
+    async def _list(ws, req_id, params, session_id, user_id=None):
+        third = _resolve_third_agent_for_test()
+        result = await third.thirdagent_list(
+            user_id=str(user_id or ""),
+            current_agent_type=str(getattr(ws, "_gateway_agent_type", "") or ""),
+        )
+        await server.send_response(
+            ws,
+            req_id,
+            ok=bool(result.get("ok")),
+            payload=result.get("payload"),
+            error=result.get("error"),
+            code=result.get("code"),
+        )
+
+    server.register_local_handler("/tui", "3rdagent.list", _list)
+    ws = FakeWebSocket(user_id="alice")
+    setattr(ws, "_gateway_agent_type", "claude")
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-list",
+                "method": "3rdagent.list",
+                "params": {"session_id": "sess-1"},
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert seen == []
+    assert len(ws.sent_frames) == 1
+    assert ws.sent_frames[0]["ok"] is False
+    assert ws.sent_frames[0].get("code") == "UNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_gateway_agent_switch_local_handler_updates_connection(
+    _third_agent_registry,
+):
+    from jiuwenswarm.extensions.sdk.third_agent import ThirdAgentExtension
+    from jiuwenswarm.gateway.routing.third_agent import ThirdAgent
+
+    class _FakeThirdAgent(ThirdAgent):
+        def normalize_agent_type(self, raw):
+            return str(raw or "jiuwenswarm").strip().lower() or "jiuwenswarm"
+
+        async def thirdagent_list(self, *, user_id, current_agent_type=""):
+            del user_id, current_agent_type
+            return {"ok": True, "payload": {"agents": []}}
+
+        async def thirdagent_switch(self, *, user_id, agent_type, session_id="", params=None):
+            del user_id, session_id, params
+            normalized = self.normalize_agent_type(agent_type)
+            if normalized == "unknown":
+                return {
+                    "ok": False,
+                    "error": f"unsupported agent_type: {normalized}",
+                    "code": "UNSUPPORTED_AGENT_TYPE",
+                }
+            return {
+                "ok": True,
+                "payload": {
+                    "agent_id": "a1",
+                    "agent_type": normalized,
+                    "sandbox_id": "sbx-1",
+                    "status": "ready",
+                },
+            }
+
+    class _FakeThirdAgentExt(ThirdAgentExtension):
+        def __init__(self, impl: ThirdAgent) -> None:
+            self._impl = impl
+
+        async def initialize(self, config) -> None:
+            del config
+
+        def get_third_agent(self) -> ThirdAgent:
+            return self._impl
+
+    _third_agent_registry.register_third_agent(_FakeThirdAgentExt(_FakeThirdAgent()))
+    server = _build_tui_server_with_agent_switch()
+    seen = []
+
+    async def on_message(msg):
+        seen.append(msg)
+
+    server.on_message(on_message)
+
+    async def _switch(ws, req_id, params, session_id, user_id=None):
+        params = params if isinstance(params, dict) else {}
+        third = _resolve_third_agent_for_test()
+        result = await third.thirdagent_switch(
+            user_id=str(user_id or ""),
+            agent_type=str(params.get("agent_type") or ""),
+            session_id=str(session_id or ""),
+            params=params,
+        )
+        if result.get("ok"):
+            payload = dict(result.get("payload") or {})
+            switched = str(payload.get("agent_type") or "").strip()
+            if switched:
+                setattr(ws, "_gateway_agent_type", switched)
+            await server.send_response(ws, req_id, ok=True, payload=payload)
+            return
+        await server.send_response(
+            ws,
+            req_id,
+            ok=False,
+            error=result.get("error"),
+            code=result.get("code"),
+        )
+
+    server.register_local_handler("/tui", "3rdagent.switch", _switch)
+    ws = FakeWebSocket(user_id="alice")
+    setattr(ws, "_gateway_agent_type", "jiuwenswarm")
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-switch",
+                "method": "3rdagent.switch",
+                "params": {"agent_type": "claude", "session_id": "sess-1"},
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert getattr(ws, "_gateway_agent_type") == "claude"
+    assert seen == []
+    assert ws.sent_frames[0]["ok"] is True
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-chat",
+                "method": "chat.send",
+                "params": {
+                    "session_id": "sess-1",
+                    "content": "hello",
+                    "agent_type": "opencode",
+                },
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert len(seen) == 1
+    assert seen[0].params.get("agent_type") == "claude"
+
+
+@pytest.mark.asyncio
+async def test_gateway_agent_switch_rejects_unsupported_type(_third_agent_registry):
+    from jiuwenswarm.extensions.sdk.third_agent import ThirdAgentExtension
+    from jiuwenswarm.gateway.routing.third_agent import ThirdAgent
+
+    class _FakeThirdAgent(ThirdAgent):
+        async def thirdagent_list(self, *, user_id, current_agent_type=""):
+            del user_id, current_agent_type
+            return {"ok": True, "payload": {"agents": []}}
+
+        async def thirdagent_switch(self, *, user_id, agent_type, session_id="", params=None):
+            del user_id, session_id, params
+            return {
+                "ok": False,
+                "error": f"unsupported agent_type: {agent_type}",
+                "code": "UNSUPPORTED_AGENT_TYPE",
+            }
+
+    class _FakeThirdAgentExt(ThirdAgentExtension):
+        def __init__(self, impl: ThirdAgent) -> None:
+            self._impl = impl
+
+        async def initialize(self, config) -> None:
+            del config
+
+        def get_third_agent(self) -> ThirdAgent:
+            return self._impl
+
+    _third_agent_registry.register_third_agent(_FakeThirdAgentExt(_FakeThirdAgent()))
+    server = _build_tui_server_with_agent_switch()
+    seen = []
+
+    async def on_message(msg):
+        seen.append(msg)
+
+    server.on_message(on_message)
+
+    async def _switch(ws, req_id, params, session_id, user_id=None):
+        params = params if isinstance(params, dict) else {}
+        third = _resolve_third_agent_for_test()
+        result = await third.thirdagent_switch(
+            user_id=str(user_id or ""),
+            agent_type=str(params.get("agent_type") or ""),
+            session_id=str(session_id or ""),
+            params=params,
+        )
+        await server.send_response(
+            ws,
+            req_id,
+            ok=bool(result.get("ok")),
+            payload=result.get("payload"),
+            error=result.get("error"),
+            code=result.get("code"),
+        )
+
+    server.register_local_handler("/tui", "3rdagent.switch", _switch)
+    ws = FakeWebSocket(user_id="alice")
+    setattr(ws, "_gateway_agent_type", "jiuwenswarm")
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-switch-bad",
+                "method": "3rdagent.switch",
+                "params": {"agent_type": "unknown", "session_id": "sess-1"},
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert getattr(ws, "_gateway_agent_type") == "jiuwenswarm"
+    assert seen == []
+    assert len(ws.sent_frames) == 1
+    assert ws.sent_frames[0]["ok"] is False
+    assert ws.sent_frames[0].get("code") == "UNSUPPORTED_AGENT_TYPE"
+
+
+def test_resolve_3rdagent_switch_session_id_requires_explicit_param():
+    from jiuwenswarm.gateway.channel_manager.tui.tui_connect import (
+        resolve_3rdagent_switch_session_id,
+    )
+
+    assert resolve_3rdagent_switch_session_id(None) == ""
+    assert resolve_3rdagent_switch_session_id({}) == ""
+    assert resolve_3rdagent_switch_session_id({"session_id": "  "}) == ""
+    assert resolve_3rdagent_switch_session_id({"session_id": "sess-1"}) == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_gateway_agent_switch_rejects_missing_session_id():
+    server = _build_tui_server_with_agent_switch()
+    from jiuwenswarm.gateway.channel_manager.tui.tui_connect import (
+        resolve_3rdagent_switch_session_id,
+    )
+
+    async def _switch(ws, req_id, params, session_id, user_id=None):
+        del session_id, user_id
+        params = params if isinstance(params, dict) else {}
+        if not resolve_3rdagent_switch_session_id(params):
+            await server.send_response(
+                ws,
+                req_id,
+                ok=False,
+                error="session_id is required for 3rdagent.switch",
+                code="BAD_REQUEST",
+            )
+            return
+        await server.send_response(ws, req_id, ok=True, payload={})
+
+    server.register_local_handler("/tui", "3rdagent.switch", _switch)
+    ws = FakeWebSocket(user_id="alice")
+    setattr(ws, "_gateway_agent_type", "jiuwenswarm")
+
+    await server.handle_raw_message_public(
+        ws,
+        json.dumps(
+            {
+                "type": "req",
+                "id": "req-switch-no-sid",
+                "method": "3rdagent.switch",
+                "params": {"agent_type": "claude"},
+            },
+            ensure_ascii=False,
+        ),
+        path="/tui",
+    )
+
+    assert getattr(ws, "_gateway_agent_type") == "jiuwenswarm"
+    assert len(ws.sent_frames) == 1
+    assert ws.sent_frames[0]["ok"] is False
+    assert ws.sent_frames[0].get("code") == "BAD_REQUEST"


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind feature

## Summary

为 AgentOS Router 增加第三方 Agent 切换能力，仅实现 Gateway 侧接口（不改 TUI 前端）。

### 新增 RPC

1. `3rdagent.list`
   - 根据当前连接 `user_id` 从注册中心拉取用户可用镜像
   - 返回可 switch 的 agent 列表：`agent_type` / `image_name` / `image_uri` / `metadata`
   - 同时返回当前连接的 `current_agent_type`
   - 不创建 agent，不转发业务 chat

2. `3rdagent.switch`
   - 参数：`params.agent_type`（`jiuwenswarm` / `opencode` / `claude`）
   - Gateway 将该值写入当前 WS 连接属性 `_gateway_agent_type`
   - Router 对 `(user_id, agent_type)` 执行 `get_or_create`（已存在则复用）
   - 返回 `agent_id` / `agent_type` / `sandbox_id` / `status`
   - 不转发业务 chat

### 连接级路由

- WS 握手默认 `_gateway_agent_type = jiuwenswarm`
- 该连接后续 forward 请求（如 `chat.send`）由 Gateway 自动注入 `params.agent_type`
- 连接属性为 SSOT，客户端自带值会被覆盖
- 断连后属性失效，新连接回到默认 `jiuwenswarm`

### 主要改动

- `ReqMethod` 增加 `3rdagent.switch` / `3rdagent.list`
- TUI Gateway forward 列表放行上述方法
- `RegistryClient.list_user_images(user_id)`：一期 stub 返回内置可切换类型
- 非 AgentOS Router 客户端对上述 RPC 短路返回，避免未知 method 错误


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->