### PR TITLE
feat(tui): implement /switch-cc command and supervision ports for agentos-tui launcher handoff

### DIFF
--- a/jiuwenswarm/channels/tui/frontend/package.json
+++ b/jiuwenswarm/channels/tui/frontend/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "build:bun": "npm run clean && bun build src/index.ts --target=node --outdir dist --format=esm --sourcemap && tsc --emitDeclarationOnly",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-strip-types tests/run-tests.ts",
+    "test": "node tests/run-tests.mjs && node tests/supervised-env.test.mjs && node tests/handoff-port.test.mjs && node tests/task-lifecycle-port.test.mjs && node tests/reauth-port.test.mjs && node tests/switch-command.test.mjs",
     "lint": "oxlint --deny-warnings src",
     "format": "oxfmt --write src package.json tsconfig.json",
     "format:check": "oxfmt --check src package.json tsconfig.json",

--- a/jiuwenswarm/channels/tui/frontend/src/app-state.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/app-state.ts
@@ -1,5 +1,11 @@
 import { addError, addInfo } from "./core/commands/helpers.js";
 import type { CommandContext, PreferredLanguage } from "./core/commands/types.js";
+import type {
+  HandoffPort,
+  TaskLifecyclePort,
+  UiLifecyclePort,
+} from "./core/supervision/protocol.js";
+import type { ReauthenticationPort } from "./core/supervision/protocol.js";
 import {
   computeTimeoutAt,
   isIgnorableHistoryRestoreError,
@@ -415,6 +421,24 @@ export class CliPiAppState {
   private harnessActivateInteraction: HarnessActivateInteraction | null = null;
   private deferTranscriptFrames = false;
   private deferredTranscriptFrames: EventFrame[] = [];
+
+  // ── /switch 公共契约端口（可选；由 index.ts 注入） ──
+  /** HandoffPort；未注入时 /switch 通过 CommandContext 回退到 NOT_SUPERVISED。 */
+  private handoffPort: HandoffPort | null = null;
+  /** TaskLifecyclePort；未注入时回退到 hasServerTask()/cancel()。 */
+  private taskLifecycle: TaskLifecyclePort | null = null;
+  /** ReauthenticationPort；由 ws-client 在权威认证过期时调用。 */
+  private reauthPort: ReauthenticationPort | null = null;
+  /** UiLifecyclePort；统一顶层关闭路径。 */
+  private uiLifecycle: UiLifecyclePort | null = null;
+  /** interrupt_result 事件订阅器；等待型取消按 requestId 关联。 */
+  private interruptResultListeners = new Set<
+    (requestId: string, sessionId: string, success: boolean, message?: string) => void
+  >();
+  /** WebSocket 断开订阅器；等待型取消按 CONNECTION_LOST reject。 */
+  private connectionLostListeners = new Set<() => void>();
+  /** AppState.stop 订阅器；等待型取消按 STATE_STOPPED reject。 */
+  private stopListeners = new Set<() => void>();
   private readonly eventDelegate: AppEventDelegate = {
     getConnectionStatus: () => this.connectionStatus,
     getSessionId: () => this.sessionId,
@@ -558,11 +582,20 @@ export class CliPiAppState {
         true,
       );
     },
+    notifyInterruptResult: (requestId, sessionId, success, message) => {
+      this.notifyInterruptResult(requestId, sessionId, success, message);
+    },
   };
 
   constructor(
     private readonly wsClient: WsClient,
     cliSession?: string,
+    supervision?: {
+      handoffPort?: HandoffPort | null;
+      taskLifecycle?: TaskLifecyclePort | null;
+      reauthPort?: ReauthenticationPort | null;
+      uiLifecycle?: UiLifecyclePort | null;
+    },
   ) {
     this.sessionId = cliSession || generateSessionId();
     const config = loadTuiConfig();
@@ -570,6 +603,11 @@ export class CliPiAppState {
       setCurrentThemeName(config.theme);
       this.themeName = config.theme;
     }
+    // 注入 /switch 公共契约端口（可选；未注入时回退到非托管实现）。
+    this.handoffPort = supervision?.handoffPort ?? null;
+    this.taskLifecycle = supervision?.taskLifecycle ?? null;
+    this.reauthPort = supervision?.reauthPort ?? null;
+    this.uiLifecycle = supervision?.uiLifecycle ?? null;
   }
 
   start(): void {
@@ -596,6 +634,16 @@ export class CliPiAppState {
   }
 
   stop(): void {
+    // 通知所有 stop 订阅器（等待型取消按 STATE_STOPPED reject）。
+    for (const listener of this.stopListeners) {
+      try {
+        listener();
+      } catch {
+        // ignore — 进程即将退出
+      }
+    }
+    this.stopListeners.clear();
+
     if (this.localPendingQuestion) {
       this.localPendingQuestion.reject(new Error("app stopped while awaiting input"));
       this.localPendingQuestion = null;
@@ -850,6 +898,15 @@ export class CliPiAppState {
           ? "Backend connection failed authentication. Stopped waiting for the current response."
           : "Backend closed the connection because the message was too large. Stopped waiting for the current response.",
       );
+      // 通知连接丢失订阅器（等待型取消按 CONNECTION_LOST reject）。
+      for (const listener of this.connectionLostListeners) {
+        try {
+          listener();
+        } catch {
+          // ignore
+        }
+      }
+      this.connectionLostListeners.clear();
     }
   }
 
@@ -1124,6 +1181,20 @@ export class CliPiAppState {
         return snapshot.cancellableWork;
       },
       setRunningCommand: (name: string | null) => this.setRunningCommand(name),
+      // ── /switch 公共契约端口 ──
+      checkHandoff: (target) => this.handoffPort?.checkHandoff(target)
+        ?? {
+          ok: false,
+          code: "NOT_SUPERVISED",
+          message: "Running outside agentos-tui launcher; start via `agentos-tui` to use /switch",
+        },
+      requestHandoff: (target) => this.handoffPort
+        ? this.handoffPort.requestHandoff(target)
+        : Promise.reject(new Error("Handoff port not available (not supervised)")),
+      hasServerTask: () => this.taskLifecycle?.hasServerTask() ?? this.hasServerTask(),
+      cancelAndWaitForIdle: (opts) => this.taskLifecycle
+        ? this.taskLifecycle.cancelAndWaitForIdle(opts)
+        : Promise.reject(new Error("Task lifecycle port not available")),
     };
   }
 
@@ -1192,6 +1263,78 @@ export class CliPiAppState {
   /** AppScreen 在初始化时注入 getInputValue 回调，使 app-state 可以读取输入框内容。 */
   getInputValueRef(ref: () => string): void {
     this._getInputValueRef = ref;
+  }
+
+  // ── TaskLifecyclePort 订阅接口 ──
+
+  /**
+   * 订阅 interrupt_result 事件；按 requestId + sessionId 关联。
+   * 返回取消订阅函数。迟到事件（waiter 已清除）由 listener 自行过滤。
+   */
+  onInterruptResult(
+    handler: (requestId: string, sessionId: string, success: boolean, message?: string) => void,
+  ): () => void {
+    this.interruptResultListeners.add(handler);
+    return () => {
+      this.interruptResultListeners.delete(handler);
+    };
+  }
+
+  /** 订阅 WebSocket 断开或认证失败。 */
+  onConnectionLost(handler: () => void): () => void {
+    this.connectionLostListeners.add(handler);
+    return () => {
+      this.connectionLostListeners.delete(handler);
+    };
+  }
+
+  /** 订阅 AppState.stop（进程退出前清理）。 */
+  onStop(handler: () => void): () => void {
+    this.stopListeners.add(handler);
+    return () => {
+      this.stopListeners.delete(handler);
+    };
+  }
+
+  /**
+   * 由 event-handlers 在收到 chat.interrupt_result 时调用；
+   * 通知所有订阅器，按 requestId + sessionId 关联。
+   */
+  notifyInterruptResult(
+    requestId: string,
+    sessionId: string,
+    success: boolean,
+    message?: string,
+  ): void {
+    for (const listener of this.interruptResultListeners) {
+      try {
+        listener(requestId, sessionId, success, message);
+      } catch {
+        // ignore — listener 错误不应影响其他订阅器或 UI 处理
+      }
+    }
+  }
+
+  /**
+   * 由 index.ts 在 AppState 构造后回填监督端口。
+   * TaskLifecyclePort、HandoffPort、ReauthenticationPort 依赖 AppState 方法，
+   * 无法在构造函数中直接创建。
+   */
+  setSupervisionPorts(ports: {
+    handoffPort: HandoffPort | null;
+    taskLifecycle: TaskLifecyclePort | null;
+    reauthPort: ReauthenticationPort | null;
+    uiLifecycle: UiLifecyclePort | null;
+  }): void {
+    this.handoffPort = ports.handoffPort;
+    this.taskLifecycle = ports.taskLifecycle;
+    this.reauthPort = ports.reauthPort;
+    this.uiLifecycle = ports.uiLifecycle;
+  }
+
+  /** 测试/外部用：获取 ReauthenticationPort（由 ws-client 在权威认证过期时调用）。 */
+  getReauthPort(): ReauthenticationPort | null {
+    return this.reauthPort;
   }
 
   readonly sendEventOnly = (

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/switch.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/switch.ts
@@ -1,87 +1,247 @@
-import type { ClientMode } from "../../modes.js";
-import { isTeamMode } from "../../modes.js";
+/**
+ * /switch 命令：在托管模式下安全切换到第三方 agent TUI。
+ *
+ * 子命令：
+ *   - /switch claude：切换到 claude TUI（当前唯一适配的目标）
+ *   - /switch list：列出当前支持的第三方 agent
+ *
+ * 固定执行顺序（/switch <target> 必须严格遵守）：
+ *   1. 解析并确认无额外参数
+ *   2. checkHandoff 预检 — 失败时显示错误并返回（不询问、不取消任务）
+ *   3. hasServerTask() — 有任务时询问用户；取消则直接返回（不发送 interrupt）
+ *   4. 确认后 cancelAndWaitForIdle({ timeoutMs: 5000 }) — 失败则显示错误并返回
+ *   5. requestHandoff — 二次校验 + 统一关闭路径
+ */
 import { makeItem } from "../helpers.js";
-import { CommandKind, type SlashCommand } from "../types.js";
+import { HANDOFF_TARGET_CC_TUI } from "../../supervision/protocol.js";
+import { CommandKind, type CommandContext, type SlashCommand } from "../types.js";
 
-type SwitchArg = "plan" | "fast" | "normal" | "team";
+/** /switch 等待型取消的默认超时时间。 */
+const SWITCH_CANCEL_TIMEOUT_MS = 5000;
 
-const AGENT_MODES = new Set<ClientMode>(["agent.plan", "agent.fast"]);
-const CODE_MODES = new Set<ClientMode>(["code.normal", "code.team", "code.plan"]);
+/**
+ * 当前支持的第三方 agent 列表。
+ * 每个条目包含命令参数名、展示名和对应的 handoff 目标。
+ * 未来扩展时只需在此数组新增条目（例如 codex）。
+ */
+interface SwitchTarget {
+  /** /switch <name> 中的参数名 */
+  name: string;
+  /** 展示名 */
+  label: string;
+  /** 描述 */
+  description: string;
+  /** 对应的 handoff 目标 */
+  handoffTarget: typeof HANDOFF_TARGET_CC_TUI;
+}
 
-function resolveRequestedMode(currentMode: ClientMode, switchArg: SwitchArg): ClientMode | null {
-  if (switchArg === "plan") {
-    if (AGENT_MODES.has(currentMode)) return "agent.plan";
-    if (CODE_MODES.has(currentMode)) return "code.plan";
-    return null;
+const SUPPORTED_TARGETS: readonly SwitchTarget[] = [
+  {
+    name: "claude",
+    label: "claude",
+    description: "Anthropic Claude TUI",
+    handoffTarget: HANDOFF_TARGET_CC_TUI,
+  },
+];
+
+/**
+ * 执行切换到指定目标的完整流程。
+ * 被 /switch <target> 子命令调用。
+ */
+async function performSwitch(
+  ctx: CommandContext,
+  target: SwitchTarget,
+): Promise<void> {
+  // 2. 预检 handoff（必须在询问和取消任务之前失败）
+  if (!ctx.checkHandoff || !ctx.requestHandoff) {
+    ctx.addItem(
+      makeItem(
+        ctx.sessionId,
+        "error",
+        `Switch to ${target.label} unavailable: running outside agentos-tui launcher`,
+      ),
+    );
+    return;
   }
-  if (switchArg === "fast") {
-    return AGENT_MODES.has(currentMode) ? "agent.fast" : null;
+  const check = ctx.checkHandoff(target.handoffTarget);
+  if (!check.ok) {
+    ctx.addItem(
+      makeItem(
+        ctx.sessionId,
+        "info",
+        check.message ?? (check.code ?? "unknown"),
+        "i",
+      ),
+    );
+    return;
   }
-  if (switchArg === "normal") {
-    return CODE_MODES.has(currentMode) ? "code.normal" : null;
+
+  // 3. 检查服务端任务
+  if (ctx.hasServerTask?.()) {
+    const answers = await ctx.askQuestions(
+      [
+        {
+          header: "切换 TUI",
+          question: `当前有正在运行的任务，切换到 ${target.label} 会中断这些任务。`,
+          options: [
+            {
+              label: "中断任务并切换",
+              description: `停止当前任务，切换到 ${target.label}`,
+            },
+            {
+              label: "取消切换",
+              description: "保留当前 TUI 和任务",
+            },
+          ],
+        },
+      ],
+      "switch_confirm",
+    );
+    const selected = answers[0]?.selected_options?.[0];
+    if (selected !== "中断任务并切换") {
+      // 用户取消：不发送 interrupt、不创建 waiter、不清理 UI、不产生动作退出码
+      ctx.addItem(makeItem(ctx.sessionId, "info", "切换已取消", "s"));
+      return;
+    }
+
+    // 4. 确认：等待型取消
+    if (ctx.cancelAndWaitForIdle) {
+      try {
+        await ctx.cancelAndWaitForIdle({
+          timeoutMs: SWITCH_CANCEL_TIMEOUT_MS,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        ctx.addItem(
+          makeItem(
+            ctx.sessionId,
+            "error",
+            `Cannot switch: task cancellation failed (${msg})`,
+          ),
+        );
+        return; // 取消失败、超时、断线：保留当前 TUI
+      }
+    }
   }
-  if (switchArg === "team") {
-    return CODE_MODES.has(currentMode) ? "code.team" : null;
+
+  // 5. 请求 handoff（二次校验 + 统一关闭路径）
+  try {
+    await ctx.requestHandoff(target.handoffTarget);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.addItem(makeItem(ctx.sessionId, "error", `Handoff failed: ${msg}`));
   }
-  return null;
+  // requestHandoff 成功路径不会返回（process.exit）
+}
+
+/** 渲染支持的目标列表为多行字符串。 */
+function renderTargetList(): string {
+  const lines = [
+    "Supported third-party agents:",
+    ...SUPPORTED_TARGETS.map(
+      (t, i) => `${i + 1}. ${t.label} — ${t.description}  (/switch ${t.name})`,
+    ),
+  ];
+  return lines.join("\n");
+}
+
+/** 渲染 /switch 顶层用法帮助为多行字符串。 */
+function renderSwitchHelp(): string {
+  const lines = [
+    "usage: /switch <target>",
+    "",
+    "Switch to a third-party agent TUI. Requires running under agentos-tui launcher.",
+    "",
+    "Available targets:",
+    ...SUPPORTED_TARGETS.map((t) => `  ${t.name.padEnd(10)} ${t.description}`),
+    "",
+    "Other subcommands:",
+    "  list       List all supported third-party agents",
+  ];
+  return lines.join("\n");
 }
 
 export function createSwitchCommand(): SlashCommand {
+  // 目标切换子命令：每个支持的目标一个
+  const targetSubCommands: SlashCommand[] = SUPPORTED_TARGETS.map((target) => ({
+    name: target.name,
+    description: `Switch to ${target.label} TUI`,
+    usage: `/switch ${target.name}`,
+    example: `/switch ${target.name}`,
+    kind: CommandKind.BUILT_IN,
+    takesArgs: false,
+    action: async (ctx, args) => {
+      // 1. 解析并确认无额外参数；出现额外参数时显示用法错误且无副作用。
+      if (args.trim()) {
+        ctx.addItem(
+          makeItem(ctx.sessionId, "error", `usage: /switch ${target.name} (no arguments)`),
+        );
+        return;
+      }
+      await performSwitch(ctx, target);
+    },
+  }));
+
+  // list 子命令：列出当前支持的所有第三方 agent
+  const listSubCommand: SlashCommand = {
+    name: "list",
+    description: "List supported third-party agents",
+    usage: "/switch list",
+    example: "/switch list",
+    kind: CommandKind.BUILT_IN,
+    takesArgs: false,
+    action: (ctx, args) => {
+      if (args.trim()) {
+        ctx.addItem(
+          makeItem(ctx.sessionId, "error", "usage: /switch list (no arguments)"),
+        );
+        return;
+      }
+      ctx.addItem(makeItem(ctx.sessionId, "info", renderTargetList(), "i"));
+    },
+  };
+
   return {
     name: "switch",
-    description: "Switch sub-mode in current mode family",
-    usage: "/switch <plan|fast|normal|team>",
-    example: "/switch fast",
+    description: "Switch to a third-party agent TUI (requires agentos-tui launcher)",
+    usage: "/switch <claude | list>",
+    example: "/switch claude",
     kind: CommandKind.BUILT_IN,
     takesArgs: true,
-    completion: async () => ["plan", "fast", "normal", "team"],
+    // Tab 补全：返回所有子命令名（目标 + list）
+    completion: async () => [...SUPPORTED_TARGETS.map((t) => t.name), "list"],
+    subCommands: [...targetSubCommands, listSubCommand],
     action: async (ctx, args) => {
-      const switchArg = args.trim() as SwitchArg;
-      if (switchArg !== "plan" && switchArg !== "fast" && switchArg !== "normal" && switchArg !== "team") {
-        ctx.addItem(makeItem(ctx.sessionId, "error", "usage: /switch <plan|fast|normal|team>"));
+      // 无参数或直接调用 /switch：显示用法帮助
+      const trimmed = args.trim();
+      if (!trimmed) {
+        ctx.addItem(makeItem(ctx.sessionId, "info", renderSwitchHelp(), "i"));
         return;
       }
 
-      const requestedMode = resolveRequestedMode(ctx.mode, switchArg);
-      if (!requestedMode) {
-        ctx.addItem(makeItem(ctx.sessionId, "error", "illegal command"));
-        return;
-      }
-
-      // Check if switching mode with running team tasks
-      const currentMode = ctx.mode;
-      if (currentMode !== requestedMode && isTeamMode(currentMode) && ctx.hasRunningTeamTasks?.()) {
-        const answers = await ctx.askQuestions(
-          [
-            {
-              header: "模式切换",
-              question: `当前有 team 任务正在运行，切换到 ${requestedMode} 模式会中断这些任务。`,
-              options: [
-                { label: "中断任务并切换", description: "停止当前任务，切换到新模式" },
-                { label: "取消切换", description: "继续执行当前任务" },
-              ],
-            },
-          ],
-          "mode_switch_confirm",
+      // 未知目标
+      const firstWord = trimmed.split(/\s+/)[0] ?? "";
+      const knownNames = [...SUPPORTED_TARGETS.map((t) => t.name), "list"];
+      if (!knownNames.includes(firstWord)) {
+        ctx.addItem(
+          makeItem(
+            ctx.sessionId,
+            "error",
+            `Unknown switch target: ${firstWord}. Supported: ${knownNames.join(", ")}`,
+          ),
         );
-
-        const selected = answers[0]?.selected_options?.[0];
-        if (selected !== "中断任务并切换") {
-          ctx.addItem(makeItem(ctx.sessionId, "info", "模式切换已取消", "s"));
-          return;
-        }
-        // User confirmed interrupt, send cancel request
-        ctx.sendEventOnly("chat.interrupt", { intent: "cancel", mode: currentMode });
+        return;
       }
 
-      try {
-        await ctx.request("mode.set", { mode: requestedMode });
-      } catch {
-        // Some backends still accept mode only on chat.send.
-      }
-
-      ctx.setMode(requestedMode);
-      ctx.addItem(makeItem(ctx.sessionId, "info", `Mode switched to ${requestedMode}`, "s"));
+      // 已知的子命令（claude, list）由 parseSlashCommand 路由到 subCommands.action，
+      // 走到这里的都是参数过多等边界情况。
+      ctx.addItem(
+        makeItem(
+          ctx.sessionId,
+          "error",
+          `usage: /switch <${knownNames.join(" | ")}>`,
+        ),
+      );
     },
   };
 }

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/registry.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/registry.ts
@@ -50,8 +50,18 @@ import { createUsageCommand } from "./builtins/usage.js";
 import { createReviewCommand } from "./builtins/review.js";
 import { createDebugCommand } from "./builtins/debug.js";
 import { createSecurityReviewCommand } from "./builtins/security-review.js";
+import { createSwitchCommand } from "./builtins/switch.js";
 
-export function createBuiltinCommands(): SlashCommand[] {
+export interface BuiltinCommandsOptions {
+  /**
+   * 是否激活 /switch 命令。
+   * 仅一体机场景（launcher 注入 AGENTOS_TUI_SUPERVISED=1）时为 true，
+   * 此时命令可见且可执行；否则不注册，命令在 help、补全、执行中均不可见。
+   */
+  switchEnabled?: boolean;
+}
+
+export function createBuiltinCommands(options: BuiltinCommandsOptions = {}): SlashCommand[] {
   const commands: SlashCommand[] = [
     createAgentsCommand(),
     createHelpCommand(() => commands),
@@ -98,6 +108,8 @@ export function createBuiltinCommands(): SlashCommand[] {
     createReviewCommand(),
     createDebugCommand(),
     createSecurityReviewCommand(),
+    // /switch 仅在一体机场景（托管模式）激活；否则不注册，命令完全不可见。
+    ...(options.switchEnabled ? [createSwitchCommand()] : []),
     createMemoryCommand(),
     createPluginCommand(),
     createReloadPluginsCommand(),

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/types.ts
@@ -5,6 +5,11 @@ import type { FileAttachment } from "../protocol.js";
 import type { ConfigItemSchema } from "./builtins/config.js";
 import type { ClientMode } from "../modes.js";
 import type { SessionUsageSummary } from "../../app-state.js";
+import type {
+  CancelAndWaitOptions,
+  HandoffCheckResult,
+  HandoffTarget,
+} from "../supervision/protocol.js";
 
 export type ConnectionStatus = "idle" | "connecting" | "connected" | "reconnecting" | "auth_failed" | "message_too_big";
 
@@ -120,6 +125,17 @@ export interface CommandContext {
   getStatusLineJsonInput?: () => Record<string, unknown>;
   /** Check if there are running team-related tasks that would be interrupted by mode switch */
   hasRunningTeamTasks?: () => boolean;
+
+  // ── /switch 公共契约端口（可选；JiuwenSwarm 独立运行时注入非托管实现） ──
+
+  /** HandoffPort 预检：校验托管标记、动作退出码和目标能力。 */
+  checkHandoff?: (target: HandoffTarget) => HandoffCheckResult;
+  /** HandoffPort 请求：二次校验后调用统一顶层关闭路径。 */
+  requestHandoff?: (target: HandoffTarget) => Promise<void>;
+  /** TaskLifecyclePort：统一任务快照；/switch 用于判断是否需要询问中断。 */
+  hasServerTask?: () => boolean;
+  /** TaskLifecyclePort：等待型取消；只供 /switch 等生命周期动作使用。 */
+  cancelAndWaitForIdle?: (options?: CancelAndWaitOptions) => Promise<void>;
 }
 
 export interface SlashCommand {

--- a/jiuwenswarm/channels/tui/frontend/src/core/event-handlers.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/event-handlers.ts
@@ -167,6 +167,16 @@ export interface AppEventDelegate {
   getHarnessActivateInteraction(): HarnessActivateInteraction | null;
   /** Auto-activate extension (send activate_response with action="accept") */
   autoActivateExtension(interactionId: string): void;
+  /**
+   * 由 event-handlers 在收到 chat.interrupt_result 时调用；
+   * 通知所有订阅器（等待型取消按 requestId + sessionId 关联）。
+   */
+  notifyInterruptResult(
+    requestId: string,
+    sessionId: string,
+    success: boolean,
+    message?: string,
+  ): void;
 }
 
 function _handleAgentModeToolResult(
@@ -1153,14 +1163,24 @@ export function handleIncomingFrame(delegate: AppEventDelegate, frame: EventFram
 
     case "chat.interrupt_result": {
       const intent = typeof payload.intent === "string" ? payload.intent : "cancel";
+      const requestId = typeof payload.request_id === "string" ? payload.request_id : "";
+      const eventSessionId =
+        typeof payload.session_id === "string" ? payload.session_id : activeSessionId;
       if (intent === "cancel") {
+        // 先通知等待型 waiter，让其 resolve/reject。
+        // 服务端可能不回显 TUI 的 requestId（使用自己的 interrupt_xxx 格式），
+        // 因此即使 requestId 为空也要通知，由 waiter 按 sessionId 关联。
+        // 迟到事件（waiter 已清除）由 listener 自行过滤。
+        const success = payload.success !== false;
+        const message =
+          typeof payload.message === "string" ? payload.message : undefined;
+        delegate.notifyInterruptResult(requestId, eventSessionId, success, message);
         const suppressed = delegate.getSuppressInterruptResult();
         if (suppressed) {
           delegate.clearSuppressInterruptResult();
           return true;
         }
-        const success = payload.success !== false;
-        const message = formatInterruptResultMessage(delegate.getPreferredLanguage(), intent, success, payload.message);
+        const uiMessage = formatInterruptResultMessage(delegate.getPreferredLanguage(), intent, success, payload.message);
         if (success) {
           delegate.setStreamingState(StreamingState.Interrupted);
           delegate.getActiveSubtasks().clear();
@@ -1171,7 +1191,7 @@ export function handleIncomingFrame(delegate: AppEventDelegate, frame: EventFram
             kind: "info",
             id: createId("info"),
             sessionId: activeSessionId,
-            content: message,
+            content: uiMessage,
             icon: "i",
             at: new Date().toISOString(),
           });
@@ -1184,10 +1204,10 @@ export function handleIncomingFrame(delegate: AppEventDelegate, frame: EventFram
             kind: "error",
             id: createId("error"),
             sessionId: activeSessionId,
-            content: message,
+            content: uiMessage,
             at: new Date().toISOString(),
           });
-          delegate.setLastError(message);
+          delegate.setLastError(uiMessage);
           // 失败也视为本次 interrupt 请求已结束，清本地标志 + 解除 esc 去抖窗口，
           // 否则去抖窗口内后续 esc 会被一直抑制，无法重新发起取消。
           delegate.clearInterruptRequested();

--- a/jiuwenswarm/channels/tui/frontend/src/core/supervision/handoff-port.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/supervision/handoff-port.ts
@@ -1,0 +1,106 @@
+/**
+ * HandoffPort 实现：/switch 预检 + 请求退出。
+ *
+ * 关键约束：
+ * - checkHandoff 是无副作用预检；不发送 interrupt、不改变任务状态、不清理 UI、不退出进程。
+ * - requestHandoff 在真正清理前再次执行相同校验。
+ * - 调用统一的 UiLifecyclePort.closeUi，而不是在命令中直接 process.exit()。
+ * - 拒绝并发 handoff，也拒绝在重新认证生命周期动作已经开始后执行。
+ * - 不 import、解析或启动 cc-tui。
+ * - 任一必需清理步骤失败时，继续尽力恢复终端并以非动作错误码（70）退出。
+ */
+import type {
+  HandoffCheckResult,
+  HandoffPort,
+  HandoffTarget,
+  UiLifecyclePort,
+} from "./protocol.js";
+import { HANDOFF_TARGET_CC_TUI } from "./protocol.js";
+import type { SupervisionEnv } from "./supervised-env.js";
+
+/** launcher 自身退出码：未分类内部错误。 */
+const LAUNCHER_EXIT_INTERNAL_ERROR = 70;
+
+export class HandoffPortImpl implements HandoffPort {
+  /** handoff 生命周期动作已开始；拒绝第二次调用，避免并发。 */
+  private handoffInProgress = false;
+  /** 重新认证生命周期动作已开始；与 handoff 互斥。 */
+  private reauthInProgress = false;
+
+  constructor(
+    private readonly env: SupervisionEnv,
+    private readonly lifecycle: UiLifecyclePort,
+  ) {}
+
+  checkHandoff(target: HandoffTarget): HandoffCheckResult {
+    if (!this.env.supervised) {
+      return {
+        ok: false,
+        code: "NOT_SUPERVISED",
+        message: "Running outside agentos-tui launcher; start via `agentos-tui` to use /switch",
+      };
+    }
+    if (this.env.switchCcExitCode === null) {
+      return {
+        ok: false,
+        code: "INVALID_EXIT_CODE",
+        message: "Switch exit code not provided by launcher",
+      };
+    }
+    if (target === HANDOFF_TARGET_CC_TUI && !this.env.ccTuiExecutable) {
+      return {
+        ok: false,
+        code: "TARGET_UNAVAILABLE",
+        message: "cc-tui executable not available",
+      };
+    }
+    if (this.handoffInProgress || this.reauthInProgress) {
+      return {
+        ok: false,
+        code: "HANDOFF_IN_PROGRESS",
+        message: "Another handoff or reauthentication already in progress",
+      };
+    }
+    return { ok: true };
+  }
+
+  async requestHandoff(target: HandoffTarget): Promise<void> {
+    // requestHandoff 在询问/取消任务之后才被调用；必须二次校验。
+    const check = this.checkHandoff(target);
+    if (!check.ok) {
+      throw new Error(check.message ?? check.code);
+    }
+
+    this.handoffInProgress = true;
+    try {
+      // checkHandoff 已校验 switchCcExitCode 非 null；显式断言以通过类型检查
+      const exitCode = this.env.switchCcExitCode;
+      if (exitCode === null) {
+        throw new Error("Switch exit code unexpectedly null after checkHandoff");
+      }
+      await this.lifecycle.closeUi({
+        reason: "switch",
+        exitCode,
+      });
+    } catch (err) {
+      // 清理失败：尽力恢复终端，以非动作错误码退出；不得使用切换动作码。
+      this.handoffInProgress = false;
+      await this.lifecycle.closeUi({
+        reason: "fatal",
+        exitCode: LAUNCHER_EXIT_INTERNAL_ERROR,
+      });
+      throw err;
+    }
+    // closeUi 成功路径不返回（process.exit）
+  }
+
+  /** 供 ReauthenticationPort 共享的并发互斥标记。 */
+  markReauthInProgress(): void {
+    this.reauthInProgress = true;
+  }
+
+  /** 测试用：handoff 是否已开始。 */
+  isHandoffInProgress(): boolean {
+    return this.handoffInProgress;
+  }
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/supervision/protocol.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/supervision/protocol.ts
@@ -1,0 +1,102 @@
+/**
+ * /switch 公共契约类型与常量。
+ *
+ * 这些类型是 JiuwenSwarm TUI 与 agentos-tui launcher 之间的稳定公共边界，
+ * 不得通过私有约定改变。
+ */
+
+/** launcher 当前唯一支持的 handoff 目标。 */
+export const HANDOFF_TARGET_CC_TUI = "cc-tui" as const;
+export type HandoffTarget = typeof HANDOFF_TARGET_CC_TUI;
+
+/** HandoffPort 预检失败原因。 */
+export type HandoffErrorCode =
+  | "NOT_SUPERVISED"
+  | "INVALID_EXIT_CODE"
+  | "TARGET_UNAVAILABLE"
+  | "HANDOFF_IN_PROGRESS";
+
+export interface HandoffCheckResult {
+  ok: boolean;
+  code?: HandoffErrorCode;
+  /** 已脱敏的可展示消息，不含路径细节、token 或完整 argv。 */
+  message?: string;
+}
+
+/** 等待型取消失败原因。 */
+export type CancelErrorCode =
+  | "CANCEL_REJECTED"
+  | "CANCEL_TIMEOUT"
+  | "CANCEL_CONNECTION_LOST"
+  | "CANCEL_STATE_STOPPED"
+  | "CANCEL_ALREADY_PENDING";
+
+export class CancelError extends Error {
+  constructor(
+    public readonly code: CancelErrorCode,
+    message?: string,
+  ) {
+    super(message ?? code);
+    this.name = "CancelError";
+  }
+}
+
+export interface CancelAndWaitOptions {
+  /** 是否显示普通的“任务已中断”提示；不影响 Promise 完成语义。 */
+  showNotice?: boolean;
+  /** 等待服务端权威停止的超时时间，默认 5000ms。 */
+  timeoutMs?: number;
+}
+
+/** 统一任务快照与等待型取消端口。 */
+export interface TaskLifecyclePort {
+  /** 读取统一、同步的任务快照；存在任一活动工作时返回 true。 */
+  hasServerTask(): boolean;
+  /** 同步发送取消请求，立即返回；Ctrl+C、Esc 和普通取消路径共用。 */
+  cancel(options?: { showNotice?: boolean }): boolean;
+  /**
+   * 等待型取消；只有“确认停止后才能继续”的生命周期动作（/switch）使用。
+   * 默认 timeoutMs=5000。没有可取消任务时立即成功且不发送 interrupt。
+   * 同一时刻只允许一个等待型取消。
+   */
+  cancelAndWaitForIdle(options?: CancelAndWaitOptions): Promise<void>;
+}
+
+/** Handoff 预检与请求端口。 */
+export interface HandoffPort {
+  /** 无副作用预检：读取并校验托管标记、动作退出码和目标能力。 */
+  checkHandoff(target: HandoffTarget): HandoffCheckResult;
+  /**
+   * 请求 handoff：二次校验后调用统一顶层关闭路径，以 launcher 注入的动作退出码退出。
+   * 成功路径不会返回（process.exit）。
+   */
+  requestHandoff(target: HandoffTarget): Promise<void>;
+}
+
+/** 重新认证触发原因。 */
+export type ReauthenticationReason = "access-token-expired";
+
+/**
+ * 重新认证端口；不由 /switch 调用，而由连接认证适配层在权威认证过期时调用。
+ * 不发送 interrupt、不取消任务；以 launcher 注入的重新认证动作退出码退出。
+ */
+export interface ReauthenticationPort {
+  requestReauthentication(reason: ReauthenticationReason): Promise<void>;
+}
+
+/** 顶层关闭原因；决定退出通知的 reason 字段与最终退出码。 */
+export type UiExitReason =
+  | "normal"
+  | "switch"
+  | "reauth-required"
+  | "signal"
+  | "fatal";
+
+/**
+ * 统一顶层关闭路径：串行完成退出通知 → screen.dispose → appState.stop →
+ * wsClient.disconnect → tui.stop → process.exit。
+ * 任一时刻只允许一次关闭调用；重复调用直接返回已存在的 Promise。
+ */
+export interface UiLifecyclePort {
+  closeUi(options: { reason: UiExitReason; exitCode: number }): Promise<void>;
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/supervision/reauth-port.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/supervision/reauth-port.ts
@@ -1,0 +1,71 @@
+/**
+ * ReauthenticationPort 实现：权威认证过期 → 以重新认证动作退出码退出。
+ *
+ * 关键约束：
+ * - 不由 /switch 调用；只由连接认证适配层在权威认证过期时调用。
+ * - 校验托管标记和重新认证动作码；缺少或非法时拒绝执行，不自行使用固定 89。
+ * - 拒绝与 handoff 或另一重新认证请求并发。
+ * - 不发送 interrupt，不取消、删除或本地标记完成当前服务端任务。
+ * - 调用统一顶层关闭路径；清理失败时以非动作错误码退出。
+ */
+import type { ReauthenticationPort, ReauthenticationReason, UiLifecyclePort } from "./protocol.js";
+import type { SupervisionEnv } from "./supervised-env.js";
+import type { HandoffPortImpl } from "./handoff-port.js";
+
+/** launcher 自身退出码：未分类内部错误。 */
+const LAUNCHER_EXIT_INTERNAL_ERROR = 70;
+
+export class ReauthenticationPortImpl implements ReauthenticationPort {
+  /** 重新认证生命周期动作已开始；拒绝并发调用。 */
+  private reauthInProgress = false;
+
+  constructor(
+    private readonly env: SupervisionEnv,
+    private readonly handoff: HandoffPortImpl,
+    private readonly lifecycle: UiLifecyclePort,
+  ) {}
+
+  async requestReauthentication(_reason: ReauthenticationReason): Promise<void> {
+    // 校验托管标记和重新认证动作码；缺少或非法时拒绝执行，不得自行使用固定 89。
+    if (!this.env.supervised || this.env.reauthExitCode === null) {
+      throw new Error(
+        "Reauthentication unavailable: not running under agentos-tui launcher or reauth exit code not injected",
+      );
+    }
+    // 拒绝与 handoff 或另一重新认证请求并发。
+    if (this.handoff.isHandoffInProgress() || this.reauthInProgress) {
+      throw new Error("Handoff or reauthentication already in progress");
+    }
+
+    this.reauthInProgress = true;
+    // 通知 handoff 端口，使其拒绝后续 handoff 请求。
+    this.handoff.markReauthInProgress();
+
+    try {
+      const exitCode = this.env.reauthExitCode;
+      if (exitCode === null) {
+        // 上面已校验，类型收窄失败时显式抛出
+        throw new Error("Reauth exit code unexpectedly null after validation");
+      }
+      // 不发送 interrupt、不取消任务；直接走统一关闭路径。
+      await this.lifecycle.closeUi({
+        reason: "reauth-required",
+        exitCode,
+      });
+    } catch (err) {
+      // 清理失败：尽力恢复终端，以非动作错误码退出；不得让 launcher 在清理不完整时刷新并重启。
+      this.reauthInProgress = false;
+      await this.lifecycle.closeUi({
+        reason: "fatal",
+        exitCode: LAUNCHER_EXIT_INTERNAL_ERROR,
+      });
+      throw err;
+    }
+    // closeUi 成功路径不返回（process.exit）
+  }
+
+  /** 测试用：reauth 是否已开始。 */
+  isReauthInProgress(): boolean {
+    return this.reauthInProgress;
+  }
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/supervision/supervised-env.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/supervision/supervised-env.ts
@@ -1,0 +1,43 @@
+/**
+ * 读取并校验 launcher 通过环境变量注入的监督协议快照。
+ *
+ * 协议变量是能力声明，不是认证凭据；其值可以被本地用户伪造，因此
+ * 不能替代 launcher 的退出码判断、目标重校验或服务端授权。
+ */
+
+/** 规范化后的监督协议环境快照；字段为 null 表示 launcher 未注入或值非法。 */
+export interface SupervisionEnv {
+  /** AGENTOS_TUI_SUPERVISED === "1" 时为 true；其他值或缺失均为非托管。 */
+  supervised: boolean;
+  /** /switch 动作退出码，通常为 88；未注入或非法时为 null。 */
+  switchCcExitCode: number | null;
+  /** 重新认证动作退出码，通常为 89；仅托管登录模式注入，未注入或非法时为 null。 */
+  reauthExitCode: number | null;
+  /** cc-tui 可执行文件的规范化绝对路径；未解析到可用目标时为 null。 */
+  ccTuiExecutable: string | null;
+}
+
+/**
+ * 从环境变量读取监督协议快照。launcher 不注入时返回非托管默认值。
+ */
+export function readSupervisionEnv(raw: NodeJS.ProcessEnv = process.env): SupervisionEnv {
+  const supervised = raw.AGENTOS_TUI_SUPERVISED === "1";
+  const switchCcExitCode = parseExitCode(raw.AGENTOS_TUI_SWITCH_CC_EXIT_CODE, 88);
+  // reauthExitCode 仅当 launcher 显式注入时才可用；显式兼容模式不注入。
+  const reauthExitCode = parseExitCode(raw.AGENTOS_TUI_REAUTH_EXIT_CODE, null);
+  const ccTuiExecutable = typeof raw.AGENTOS_CC_TUI_EXECUTABLE === "string"
+    ? raw.AGENTOS_CC_TUI_EXECUTABLE.trim() || null
+    : null;
+  return { supervised, switchCcExitCode, reauthExitCode, ccTuiExecutable };
+}
+
+/**
+ * 解析平台可移植范围内的十进制非零退出码。
+ * 合法范围：1..255；缺失时返回 fallback，非法时返回 null。
+ */
+function parseExitCode(raw: string | undefined, fallback: number | null): number | null {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1 || n > 255) return null;
+  return n;
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/supervision/task-lifecycle-port.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/supervision/task-lifecycle-port.ts
@@ -1,0 +1,175 @@
+/**
+ * TaskLifecyclePort 实现：统一任务快照 + 等待型取消。
+ *
+ * 关键约束：
+ * - hasServerTask() 读取统一、同步的任务快照（不依赖单一布尔）。
+ * - cancel() 保持现有同步 boolean 契约，供 Ctrl+C、Esc 和普通取消路径使用。
+ * - cancelAndWaitForIdle() 只供“确认停止后才能继续”的生命周期操作使用；默认 timeoutMs=5000。
+ * - 同一时刻只允许一个等待型取消；第二次调用以 CANCEL_ALREADY_PENDING 拒绝。
+ * - 迟到事件不得完成已结束的 waiter。
+ */
+import { CancelError, type CancelAndWaitOptions, type TaskLifecyclePort } from "./protocol.js";
+
+/** 等待型取消的内部 waiter 状态。 */
+interface Waiter {
+  /** 本次等待型取消发送 chat.interrupt 时的 requestId，由 sendEventOnly 返回。 */
+  requestId: string;
+  /** 发送时的 session_id；用于匹配 interrupt_result 事件。 */
+  sessionId: string;
+  /** 超时定时器；超时触发 CANCEL_TIMEOUT。 */
+  timer: ReturnType<typeof setTimeout>;
+  resolve: () => void;
+  reject: (e: CancelError) => void;
+  /** waiter 建立时间戳，用于过滤迟到事件。 */
+  createdAt: number;
+}
+
+export interface TaskLifecycleDeps {
+  /** 读取统一同步任务快照。 */
+  getSnapshot: () => { cancellableWork: boolean; sessionId: string };
+  /** 同步发送取消请求；立即返回，不等待服务端确认。 */
+  cancel: (options?: { showNotice?: boolean }) => boolean;
+  /** 发送事件帧并返回 requestId。 */
+  sendEventOnly: (method: string, params: Record<string, unknown>) => string;
+  /** 订阅 interrupt_result 事件；按 requestId + sessionId 关联。 */
+  onInterruptResult: (handler: InterruptResultHandler) => () => void;
+  /** 订阅 WebSocket 断开或认证失败。 */
+  onConnectionLost: (handler: () => void) => () => void;
+  /** 订阅 AppState stop（进程退出前清理）。 */
+  onStop: (handler: () => void) => () => void;
+  /** 当前连接是否存活。 */
+  isConnectionAlive: () => boolean;
+}
+
+export type InterruptResultHandler = (
+  requestId: string,
+  sessionId: string,
+  success: boolean,
+  message?: string,
+) => void;
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export class TaskLifecyclePortImpl implements TaskLifecyclePort {
+  private waiter: Waiter | null = null;
+  /** 事件订阅的取消函数；waiter 清除时一并释放。 */
+  private unlisteners: Array<() => void> = [];
+
+  constructor(private readonly deps: TaskLifecycleDeps) {}
+
+  hasServerTask(): boolean {
+    return this.deps.getSnapshot().cancellableWork;
+  }
+
+  cancel(options?: { showNotice?: boolean }): boolean {
+    return this.deps.cancel(options);
+  }
+
+  async cancelAndWaitForIdle(options?: CancelAndWaitOptions): Promise<void> {
+    // 同一时刻只允许一个等待型取消。
+    if (this.waiter !== null) {
+      throw new CancelError("CANCEL_ALREADY_PENDING");
+    }
+    // 没有可取消任务时，立即成功且不发送 interrupt。
+    if (!this.hasServerTask()) {
+      return;
+    }
+    if (!this.deps.isConnectionAlive()) {
+      throw new CancelError("CANCEL_CONNECTION_LOST");
+    }
+
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const showNotice = options?.showNotice ?? true;
+    const snapshot = this.deps.getSnapshot();
+    const sessionId = snapshot.sessionId;
+
+    // 发送 chat.interrupt；sendEventOnly 返回的 requestId 用于关联 interrupt_result。
+    // showNotice=false 时由 cancel 内部抑制 UI 通知；这里直接 sendEventOnly 避免
+    // 走同步 cancel 路径（cancel 会在 UI 层 addItem 显示提示）。
+    const requestId = this.deps.sendEventOnly("chat.interrupt", { intent: "cancel" });
+
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.waiter?.requestId === requestId) {
+          this.clearWaiter();
+          reject(new CancelError("CANCEL_TIMEOUT"));
+        }
+      }, timeoutMs);
+
+      this.waiter = {
+        requestId,
+        sessionId,
+        timer,
+        resolve,
+        reject,
+        createdAt: Date.now(),
+      };
+
+      // 注册事件回调；按 sessionId 关联。
+      // 服务端的 interrupt_result 可能不回显 TUI 发送的 requestId
+      //（服务端使用自己的 interrupt_xxx 格式），因此只要 sessionId 匹配
+      // 且当前有 waiter，就视为本次等待的结果。
+      const unlistenInterrupt = this.deps.onInterruptResult(
+        (reqId, sessId, success, message) => {
+          if (!this.waiter) return;
+          // 如果 requestId 双方都有且不匹配，则不是本次的结果
+          if (reqId && this.waiter.requestId && this.waiter.requestId !== reqId) return;
+          // sessionId 必须匹配（空 sessionId 兼容服务端不回显的情况）
+          if (sessId && sessId !== this.waiter.sessionId) return;
+          this.clearWaiter();
+          if (success) {
+            resolve();
+          } else {
+            reject(new CancelError("CANCEL_REJECTED", message));
+          }
+        },
+      );
+      const unlistenConnectionLost = this.deps.onConnectionLost(() => {
+        if (!this.waiter) return;
+        this.clearWaiter();
+        reject(new CancelError("CANCEL_CONNECTION_LOST"));
+      });
+      const unlistenStop = this.deps.onStop(() => {
+        if (!this.waiter) return;
+        this.clearWaiter();
+        reject(new CancelError("CANCEL_STATE_STOPPED"));
+      });
+
+      this.unlisteners = [unlistenInterrupt, unlistenConnectionLost, unlistenStop];
+
+      // suppress 通知：showNotice=false 时由 event-handlers 内部抑制；
+      // 这里不直接调用 cancel(showNotice:false)，因为 cancel 会立即发送 interrupt
+      // 而上面已经发送过了。
+      if (!showNotice) {
+        // 依赖 AppState 在 chat.interrupt_result 事件中检查 suppress 标志；
+        // 等待型 waiter 已经通过 listener 接管结果，不会触发普通 UI 通知路径。
+      }
+    });
+  }
+
+  /** 清除 waiter 并释放所有事件订阅。 */
+  private clearWaiter(): void {
+    if (this.waiter) {
+      clearTimeout(this.waiter.timer);
+      this.waiter = null;
+    }
+    for (const unlisten of this.unlisteners) {
+      try {
+        unlisten();
+      } catch {
+        // ignore — 进程即将退出或 waiter 已清除
+      }
+    }
+    this.unlisteners = [];
+  }
+
+  /** 测试用：当前是否有等待型取消。 */
+  hasWaiter(): boolean {
+    return this.waiter !== null;
+  }
+
+  /** 测试用：当前 waiter 的 requestId；无 waiter 时返回 null。 */
+  currentWaiterRequestId(): string | null {
+    return this.waiter?.requestId ?? null;
+  }
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/supervision/ui-lifecycle.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/supervision/ui-lifecycle.ts
@@ -1,0 +1,72 @@
+/**
+ * 统一顶层关闭路径。
+ *
+ * 串行完成：退出通知 → screen.dispose → appState.stop → wsClient.disconnect →
+ * tui.stop → process.exit。任一时刻只允许一次关闭调用。
+ */
+import type { UiExitReason, UiLifecyclePort } from "./protocol.js";
+
+export interface UiLifecycleDeps {
+  /** 退出前显式通知服务端；携带 reason 字段。best-effort，失败不阻塞退出。 */
+  notifyDisconnect: (reason: UiExitReason) => Promise<void>;
+  /** 释放 screen：关闭 alternate screen / mouse tracking 等。 */
+  disposeScreen: () => void;
+  /** 停止 AppState：清理 timer、关闭 WebSocket。 */
+  stopAppState: () => void;
+  /** 释放 TUI：恢复 raw mode。 */
+  stopTui: () => void;
+}
+
+export class UiLifecyclePortImpl implements UiLifecyclePort {
+  private closed = false;
+  private closingPromise: Promise<void> | null = null;
+
+  constructor(private readonly deps: UiLifecycleDeps) {}
+
+  async closeUi(options: { reason: UiExitReason; exitCode: number }): Promise<void> {
+    // 并发保护：正在关闭时第二次调用直接返回已存在的 Promise。
+    if (this.closed) {
+      return this.closingPromise ?? Promise.resolve();
+    }
+    this.closed = true;
+
+    if (this.closingPromise) {
+      return this.closingPromise;
+    }
+
+    this.closingPromise = (async () => {
+      // 1. 退出通知（携带 reason，由 AppState 转换为 tui.disconnect 参数）
+      try {
+        await this.deps.notifyDisconnect(options.reason);
+      } catch {
+        // best effort only; 进程即将退出
+      }
+      // 2. screen.dispose — 释放 alternate screen / mouse tracking
+      try {
+        this.deps.disposeScreen();
+      } catch {
+        // ignore — 进程即将退出
+      }
+      // 3. appState.stop — 清理 timer、关闭 WebSocket
+      try {
+        this.deps.stopAppState();
+      } catch {
+        // ignore — 进程即将退出
+      }
+      // 4. tui.stop — 释放 raw mode
+      try {
+        this.deps.stopTui();
+      } catch {
+        // ignore — 进程即将退出
+      }
+      // 5. process.exit — 使用 launcher 注入的动作退出码
+      process.exit(options.exitCode);
+    })();
+    return this.closingPromise;
+  }
+
+  /** 用于测试：是否已触发关闭。 */
+  isClosed(): boolean {
+    return this.closed;
+  }
+}

--- a/jiuwenswarm/channels/tui/frontend/src/core/ws-client.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/ws-client.ts
@@ -27,6 +27,12 @@ export class WsClient {
   private retryCount = 0;
   private readonly maxBackoffRetries = 5;
   private readonly baseDelay = 1000;
+  /**
+   * 权威认证过期回调；由 index.ts 注入 ReauthenticationPort。
+   * 仅在收到 close code 1008（auth_failed）时调用，表示服务端权威拒绝当前 token。
+   * 非 1008 的断线、1006、5xx、普通超时不触发该回调。
+   */
+  onAuthExpired?: () => void;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _status: ConnectionStatus = "idle";
   private statusListeners: Array<(status: ConnectionStatus) => void> = [];
@@ -159,6 +165,9 @@ export class WsClient {
       if (code === 1008) {
         this.setStatus("auth_failed");
         this.rejectAllPending(new Error(`auth failed: ${this.closeReason}`));
+        // 权威认证过期：通知 ReauthenticationPort 以 89 动作码退出（仅托管模式）。
+        // 非托管模式下该回调为 undefined，状态变更为 auth_failed 后由 UI 显示错误。
+        this.onAuthExpired?.();
         return;
       }
 

--- a/jiuwenswarm/channels/tui/frontend/src/index.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/index.ts
@@ -7,6 +7,12 @@ import { CommandService } from "./core/commands/CommandService.js";
 import { createBuiltinCommands } from "./core/commands/registry.js";
 import { WsClient } from "./core/ws-client.js";
 import { AppScreen } from "./ui/app-screen.js";
+import { HandoffPortImpl } from "./core/supervision/handoff-port.js";
+import { ReauthenticationPortImpl } from "./core/supervision/reauth-port.js";
+import { TaskLifecyclePortImpl } from "./core/supervision/task-lifecycle-port.js";
+import { UiLifecyclePortImpl } from "./core/supervision/ui-lifecycle.js";
+import { readSupervisionEnv } from "./core/supervision/supervised-env.js";
+import type { UiExitReason } from "./core/supervision/protocol.js";
 
 const { values } = parseArgs({
   options: {
@@ -39,15 +45,86 @@ if (!process.env.JIUWENSWARM_TUI_HEADLESS && (!process.stdin.isTTY || !process.s
 }
 
 const wsClient = new WsClient(values.url ?? "ws://127.0.0.1:19001/tui", values.token ?? "", values["user-id"] ?? "");
-const appState = new CliPiAppState(wsClient, values.session);
-const commandService = new CommandService();
-commandService.register(createBuiltinCommands());
+
+// 读取 launcher 注入的监督协议快照（非托管启动时 supervised=false）。
+const supervisionEnv = readSupervisionEnv();
 
 const terminal = new ProcessTerminal();
 const tui = new TUI(terminal);
 
 let closed = false;
 let screen: AppScreen | null = null;
+
+/**
+ * 统一顶层关闭路径：串行完成退出通知 → screen.dispose → appState.stop →
+ * tui.stop → process.exit。由 UiLifecyclePort 封装，handoff/reauth 走该路径。
+ * index.ts 启动时即构造，避免依赖 AppState 实例。
+ */
+function buildUiLifecycle(): UiLifecyclePortImpl {
+  return new UiLifecyclePortImpl({
+    notifyDisconnect: async (reason: UiExitReason) => {
+      await appState.notifyDisconnectBeforeExit(reason);
+    },
+    disposeScreen: () => {
+      screen?.dispose();
+    },
+    stopAppState: () => {
+      appState.stop();
+    },
+    stopTui: () => {
+      try {
+        tui.stop();
+      } catch {
+        // Ignore repeated stop failures.
+      }
+    },
+  });
+}
+
+// 先建 UiLifecyclePort 和 TaskLifecyclePort（后两者不依赖 AppState 实例的方法）。
+// AppState 构造函数会接收已构造的端口；这里先用占位引用，构造后回填。
+let uiLifecycle = buildUiLifecycle();
+
+const appState = new CliPiAppState(wsClient, values.session, {
+  // 在构造 AppState 之前无法直接构造 TaskLifecyclePort/HandoffPort/ReauthPort
+  // （它们依赖 AppState 的方法）；这里先传 null，构造后回填。
+  handoffPort: null,
+  taskLifecycle: null,
+  reauthPort: null,
+  uiLifecycle,
+});
+
+// AppState 已构造完成，现在构造依赖 AppState 的端口并回填。
+const taskLifecycle = new TaskLifecyclePortImpl({
+  getSnapshot: () => {
+    const snapshot = appState.getSnapshot();
+    return {
+      cancellableWork: snapshot.cancellableWork,
+      sessionId: snapshot.sessionId,
+    };
+  },
+  cancel: (opts) => appState.cancel(opts),
+  sendEventOnly: (method, params) => appState.sendEventOnly(method, params),
+  onInterruptResult: (h) => appState.onInterruptResult(h),
+  onConnectionLost: (h) => appState.onConnectionLost(h),
+  onStop: (h) => appState.onStop(h),
+  isConnectionAlive: () => appState.getSnapshot().connectionStatus === "connected",
+});
+const handoffPort = new HandoffPortImpl(supervisionEnv, uiLifecycle);
+const reauthPort = new ReauthenticationPortImpl(supervisionEnv, handoffPort, uiLifecycle);
+appState.setSupervisionPorts({ handoffPort, taskLifecycle, reauthPort, uiLifecycle });
+
+// 配置 ws-client 在权威认证过期（close code 1008）时触发重新认证。
+// 仅托管模式注入了 reauth exit code 时，reauthPort 才会以 89 退出；
+// 非托管模式下 reauthPort.requestReauthentication 会抛错，UI 保持 auth_failed 状态。
+wsClient.onAuthExpired = () => {
+  void reauthPort.requestReauthentication("access-token-expired").catch(() => {
+    // 非托管模式或 handoff 已在进行：保持原有 auth_failed UI，不强制退出。
+  });
+};
+
+const commandService = new CommandService();
+commandService.register(createBuiltinCommands({ switchEnabled: supervisionEnv.supervised }));
 
 /** 正常退出 CLI 前显式通知服务端；异常崩溃不走该路径。 */
 async function notifyDisconnectBeforeExit(): Promise<void> {

--- a/jiuwenswarm/channels/tui/frontend/tests/handoff-port.test.mjs
+++ b/jiuwenswarm/channels/tui/frontend/tests/handoff-port.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+
+import { HandoffPortImpl } from "../dist/core/supervision/handoff-port.js";
+import { HANDOFF_TARGET_CC_TUI } from "../dist/core/supervision/protocol.js";
+import { readSupervisionEnv } from "../dist/core/supervision/supervised-env.js";
+
+// 测试用 UiLifecyclePort mock：记录调用，不实际 process.exit
+class MockUiLifecycle {
+  constructor() {
+    this.calls = [];
+  }
+  async closeUi(options) {
+    this.calls.push(options);
+    // 不调用 process.exit，让测试继续运行
+  }
+  get lastCall() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+// 1. 非托管：checkHandoff 返回 NOT_SUPERVISED
+{
+  const env = readSupervisionEnv({});
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const result = handoff.checkHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "NOT_SUPERVISED");
+  assert.ok(result.message?.includes("agentos-tui"));
+}
+
+// 2. 托管但无动作退出码：checkHandoff 返回 INVALID_EXIT_CODE
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "0",  // 非法
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const result = handoff.checkHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "INVALID_EXIT_CODE");
+}
+
+// 3. 托管但无 cc-tui 可执行文件：checkHandoff 返回 TARGET_UNAVAILABLE
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const result = handoff.checkHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "TARGET_UNAVAILABLE");
+}
+
+// 4. 完整托管：checkHandoff 返回 ok
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const result = handoff.checkHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(result.ok, true);
+  assert.equal(result.code, undefined);
+}
+
+// 5. handoff 进行中：返回 HANDOFF_IN_PROGRESS
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  // 第一次 requestHandoff 触发 handoffInProgress=true（但 mock closeUi 不退出）
+  await handoff.requestHandoff(HANDOFF_TARGET_CC_TUI).catch(() => {});
+  const result = handoff.checkHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "HANDOFF_IN_PROGRESS");
+}
+
+// 6. reauth 进行中：返回 HANDOFF_IN_PROGRESS
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  handoff.markReauthInProgress();
+  const result = handoff.checkHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "HANDOFF_IN_PROGRESS");
+}
+
+// 7. requestHandoff 成功：调用 closeUi with reason=switch and correct exit code
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  await handoff.requestHandoff(HANDOFF_TARGET_CC_TUI);
+  assert.equal(lifecycle.lastCall.reason, "switch");
+  assert.equal(lifecycle.lastCall.exitCode, 88);
+}
+
+// 8. requestHandoff 在预检失败时抛错
+{
+  const env = readSupervisionEnv({});  // 非托管
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  await assert.rejects(
+    () => handoff.requestHandoff(HANDOFF_TARGET_CC_TUI),
+    /Running outside agentos-tui launcher/,
+  );
+  assert.equal(lifecycle.calls.length, 0);  // closeUi 未被调用
+}
+
+console.log("handoff-port tests passed");

--- a/jiuwenswarm/channels/tui/frontend/tests/reauth-port.test.mjs
+++ b/jiuwenswarm/channels/tui/frontend/tests/reauth-port.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+
+import { ReauthenticationPortImpl } from "../dist/core/supervision/reauth-port.js";
+import { HandoffPortImpl } from "../dist/core/supervision/handoff-port.js";
+import { readSupervisionEnv } from "../dist/core/supervision/supervised-env.js";
+
+// 测试用 UiLifecyclePort mock
+class MockUiLifecycle {
+  constructor() {
+    this.calls = [];
+  }
+  async closeUi(options) {
+    this.calls.push(options);
+  }
+  get lastCall() {
+    return this.calls[this.calls.length - 1];
+  }
+}
+
+// 1. 非托管：requestReauthentication 抛错
+{
+  const env = readSupervisionEnv({});
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const reauth = new ReauthenticationPortImpl(env, handoff, lifecycle);
+  await assert.rejects(
+    reauth.requestReauthentication("access-token-expired"),
+    /Reauthentication unavailable/,
+  );
+  assert.equal(lifecycle.calls.length, 0);
+}
+
+// 2. 托管但无 reauth exit code：抛错
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const reauth = new ReauthenticationPortImpl(env, handoff, lifecycle);
+  await assert.rejects(
+    reauth.requestReauthentication("access-token-expired"),
+    /Reauthentication unavailable/,
+  );
+}
+
+// 3. 托管 + reauth exit code：调用 closeUi with reason=reauth-required
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_TUI_REAUTH_EXIT_CODE: "89",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const reauth = new ReauthenticationPortImpl(env, handoff, lifecycle);
+  await reauth.requestReauthentication("access-token-expired");
+  assert.equal(lifecycle.lastCall.reason, "reauth-required");
+  assert.equal(lifecycle.lastCall.exitCode, 89);
+}
+
+// 4. reauth 与 handoff 互斥：handoff 进行中时 reauth 抛错
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_TUI_REAUTH_EXIT_CODE: "89",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const reauth = new ReauthenticationPortImpl(env, handoff, lifecycle);
+  // 触发 handoff（mock closeUi 不退出，但 handoffInProgress=true）
+  await handoff.requestHandoff("cc-tui").catch(() => {});
+  await assert.rejects(
+    reauth.requestReauthentication("access-token-expired"),
+    /Handoff or reauthentication already in progress/,
+  );
+}
+
+// 5. reauth 进行中时 handoff checkHandoff 返回 HANDOFF_IN_PROGRESS
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_TUI_REAUTH_EXIT_CODE: "89",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const reauth = new ReauthenticationPortImpl(env, handoff, lifecycle);
+  await reauth.requestReauthentication("access-token-expired");
+  const check = handoff.checkHandoff("cc-tui");
+  assert.equal(check.ok, false);
+  assert.equal(check.code, "HANDOFF_IN_PROGRESS");
+}
+
+// 6. reauth 不发送 interrupt（通过检查 lifecycle 调用顺序验证）
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_TUI_REAUTH_EXIT_CODE: "89",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  const lifecycle = new MockUiLifecycle();
+  const handoff = new HandoffPortImpl(env, lifecycle);
+  const reauth = new ReauthenticationPortImpl(env, handoff, lifecycle);
+  // 记录 closeUi 调用前的状态
+  const sentInterruptsBefore = 0;  // reauth 不应调用任何 sendEventOnly
+  await reauth.requestReauthentication("access-token-expired");
+  // 验证 closeUi 被调用一次，且只调用一次
+  assert.equal(lifecycle.calls.length, 1);
+  assert.equal(lifecycle.lastCall.reason, "reauth-required");
+  assert.equal(lifecycle.lastCall.exitCode, 89);
+}
+
+console.log("reauth-port tests passed");

--- a/jiuwenswarm/channels/tui/frontend/tests/supervised-env.test.mjs
+++ b/jiuwenswarm/channels/tui/frontend/tests/supervised-env.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import { readSupervisionEnv } from "../dist/core/supervision/supervised-env.js";
+
+// 1. 非托管：所有字段为默认值
+{
+  const env = readSupervisionEnv({});
+  assert.equal(env.supervised, false);
+  assert.equal(env.switchCcExitCode, 88);
+  assert.equal(env.reauthExitCode, null);
+  assert.equal(env.ccTuiExecutable, null);
+}
+
+// 2. 非托管：AGENTOS_TUI_SUPERVISED 非 "1" 时仍为 false
+{
+  const env = readSupervisionEnv({ AGENTOS_TUI_SUPERVISED: "0" });
+  assert.equal(env.supervised, false);
+  assert.equal(env.switchCcExitCode, 88);  // 默认值
+}
+
+// 3. 托管：所有字段正常注入
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "88",
+    AGENTOS_TUI_REAUTH_EXIT_CODE: "89",
+    AGENTOS_CC_TUI_EXECUTABLE: "/usr/local/bin/cc-tui",
+  });
+  assert.equal(env.supervised, true);
+  assert.equal(env.switchCcExitCode, 88);
+  assert.equal(env.reauthExitCode, 89);
+  assert.equal(env.ccTuiExecutable, "/usr/local/bin/cc-tui");
+}
+
+// 4. 托管：仅注入 SUPERVISED，switchCcExitCode 仍默认为 88
+{
+  const env = readSupervisionEnv({ AGENTOS_TUI_SUPERVISED: "1" });
+  assert.equal(env.supervised, true);
+  assert.equal(env.switchCcExitCode, 88);  // 默认值
+  assert.equal(env.reauthExitCode, null);  // 默认值（非托管登录模式不注入）
+  assert.equal(env.ccTuiExecutable, null);
+}
+
+// 5. 非法动作退出码：范围 1..255 之外返回 null
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "0",  // 0 非法
+  });
+  assert.equal(env.switchCcExitCode, null);
+}
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "256",  // 256 非法
+  });
+  assert.equal(env.switchCcExitCode, null);
+}
+
+// 6. 非数字动作退出码返回 null
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "abc",
+  });
+  assert.equal(env.switchCcExitCode, null);
+}
+
+// 7. 空字符串动作退出码：使用 fallback（switchCc 为 88，reauth 为 null）
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_TUI_SWITCH_CC_EXIT_CODE: "",
+    AGENTOS_TUI_REAUTH_EXIT_CODE: "",
+  });
+  assert.equal(env.switchCcExitCode, 88);  // 空字符串使用 fallback
+  assert.equal(env.reauthExitCode, null);  // 空字符串使用 fallback（null）
+}
+
+// 8. cc-tui 可执行文件路径：trim 空白
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_CC_TUI_EXECUTABLE: "  /path/to/cc-tui  ",
+  });
+  assert.equal(env.ccTuiExecutable, "/path/to/cc-tui");
+}
+
+// 9. cc-tui 可执行文件路径：空字符串 trim 后为空返回 null
+{
+  const env = readSupervisionEnv({
+    AGENTOS_TUI_SUPERVISED: "1",
+    AGENTOS_CC_TUI_EXECUTABLE: "   ",
+  });
+  assert.equal(env.ccTuiExecutable, null);
+}
+
+console.log("supervised-env tests passed");

--- a/jiuwenswarm/channels/tui/frontend/tests/switch-command.test.mjs
+++ b/jiuwenswarm/channels/tui/frontend/tests/switch-command.test.mjs
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+
+import { createSwitchCommand } from "../dist/core/commands/builtins/switch.js";
+import { HANDOFF_TARGET_CC_TUI } from "../dist/core/supervision/protocol.js";
+
+// 测试用 CommandContext mock
+function makeMockContext(overrides = {}) {
+  const addedItems = [];
+  const askedQuestions = [];
+  const defaults = {
+    sessionId: "test-session",
+    addItem: (item) => addedItems.push(item),
+    askQuestions: async (questions, id) => {
+      askedQuestions.push({ questions, id });
+      // 默认返回"取消切换"
+      return [{ selected_options: ["取消切换"] }];
+    },
+    // 默认：未注入端口（模拟 JiuwenSwarm 独立运行）
+    checkHandoff: undefined,
+    requestHandoff: undefined,
+    hasServerTask: undefined,
+    cancelAndWaitForIdle: undefined,
+  };
+  return { ctx: { ...defaults, ...overrides }, addedItems, askedQuestions };
+}
+
+const switchCmd = createSwitchCommand();
+const claudeSub = switchCmd.subCommands.find((s) => s.name === "claude");
+const listSub = switchCmd.subCommands.find((s) => s.name === "list");
+
+// 1. /switch claude 额外参数：显示用法错误，不执行任何动作
+{
+  const { ctx, addedItems } = makeMockContext();
+  await claudeSub.action(ctx, "extra args");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "error");
+  assert.match(addedItems[0].content, /usage: \/switch claude/);
+}
+
+// 2. /switch claude 端口未注入（JiuwenSwarm 独立运行）：显示错误
+{
+  const { ctx, addedItems } = makeMockContext();
+  await claudeSub.action(ctx, "");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "error");
+  assert.match(addedItems[0].content, /outside agentos-tui launcher/);
+}
+
+// 3. /switch claude checkHandoff 返回 NOT_SUPERVISED：显示错误，不询问、不取消
+{
+  const { ctx, addedItems, askedQuestions } = makeMockContext({
+    checkHandoff: () => ({
+      ok: false,
+      code: "NOT_SUPERVISED",
+      message: "Running outside agentos-tui launcher",
+    }),
+    requestHandoff: () => Promise.resolve(),
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "info");
+  assert.match(addedItems[0].content, /outside agentos-tui/);
+  assert.equal(askedQuestions.length, 0);  // 未询问用户
+}
+
+// 4. /switch claude checkHandoff 返回 TARGET_UNAVAILABLE：显示错误，不询问
+{
+  const { ctx, addedItems, askedQuestions } = makeMockContext({
+    checkHandoff: () => ({
+      ok: false,
+      code: "TARGET_UNAVAILABLE",
+      message: "cc-tui executable not available",
+    }),
+    requestHandoff: () => Promise.resolve(),
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(addedItems.length, 1);
+  assert.equal(askedQuestions.length, 0);
+}
+
+// 5. /switch claude 无任务 + handoff 成功：直接调用 requestHandoff，不询问、不取消
+{
+  const handoffCalls = [];
+  const cancelCalls = [];
+  const { ctx, addedItems, askedQuestions } = makeMockContext({
+    checkHandoff: () => ({ ok: true }),
+    requestHandoff: async (target) => handoffCalls.push(target),
+    hasServerTask: () => false,
+    cancelAndWaitForIdle: async () => cancelCalls.push(true),
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(askedQuestions.length, 0);  // 无任务不询问
+  assert.equal(cancelCalls.length, 0);  // 无任务不取消
+  assert.equal(handoffCalls.length, 1);
+  assert.equal(handoffCalls[0], HANDOFF_TARGET_CC_TUI);
+}
+
+// 6. /switch claude 有任务 + 用户取消：不发送 interrupt、不调用 requestHandoff
+{
+  const handoffCalls = [];
+  const cancelCalls = [];
+  let askedCount = 0;
+  const { ctx, addedItems } = makeMockContext({
+    checkHandoff: () => ({ ok: true }),
+    requestHandoff: async (target) => handoffCalls.push(target),
+    hasServerTask: () => true,
+    cancelAndWaitForIdle: async () => cancelCalls.push(true),
+    askQuestions: async (questions, id) => {
+      askedCount += 1;
+      return [{ selected_options: ["取消切换"] }];
+    },
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(askedCount, 1);  // 有任务时询问
+  assert.equal(cancelCalls.length, 0);  // 用户取消，不取消任务
+  assert.equal(handoffCalls.length, 0);  // 不调用 handoff
+  // 应显示"切换已取消"
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "info");
+  assert.match(addedItems[0].content, /切换已取消/);
+}
+
+// 7. /switch claude 有任务 + 用户确认 + 取消成功 + handoff 成功
+{
+  const handoffCalls = [];
+  const cancelCalls = [];
+  let askedCount = 0;
+  const { ctx, addedItems } = makeMockContext({
+    checkHandoff: () => ({ ok: true }),
+    requestHandoff: async (target) => handoffCalls.push(target),
+    hasServerTask: () => true,
+    cancelAndWaitForIdle: async (opts) => cancelCalls.push(opts),
+    askQuestions: async () => {
+      askedCount += 1;
+      return [{ selected_options: ["中断任务并切换"] }];
+    },
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(askedCount, 1);
+  assert.equal(cancelCalls.length, 1);
+  assert.equal(handoffCalls.length, 1);
+  assert.equal(handoffCalls[0], HANDOFF_TARGET_CC_TUI);
+}
+
+// 8. /switch claude 有任务 + 用户确认 + 取消失败：保留 TUI，不调用 handoff
+{
+  const handoffCalls = [];
+  let askedCount = 0;
+  const { ctx, addedItems } = makeMockContext({
+    checkHandoff: () => ({ ok: true }),
+    requestHandoff: async (target) => handoffCalls.push(target),
+    hasServerTask: () => true,
+    cancelAndWaitForIdle: async () => {
+      const err = new Error("CANCEL_TIMEOUT");
+      err.code = "CANCEL_TIMEOUT";
+      throw err;
+    },
+    askQuestions: async () => {
+      askedCount += 1;
+      return [{ selected_options: ["中断任务并切换"] }];
+    },
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(askedCount, 1);
+  assert.equal(handoffCalls.length, 0);  // 取消失败，不调用 handoff
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "error");
+  assert.match(addedItems[0].content, /task cancellation failed/);
+}
+
+// 9. /switch claude requestHandoff 抛错：显示错误
+{
+  const { ctx, addedItems } = makeMockContext({
+    checkHandoff: () => ({ ok: true }),
+    requestHandoff: async () => {
+      throw new Error("handoff failed");
+    },
+    hasServerTask: () => false,
+  });
+  await claudeSub.action(ctx, "");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "error");
+  assert.match(addedItems[0].content, /Handoff failed/);
+}
+
+// 10. /switch（无参数）：显示用法帮助
+{
+  const { ctx, addedItems } = makeMockContext();
+  await switchCmd.action(ctx, "");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "info");
+  assert.match(addedItems[0].content, /usage: \/switch <target>/);
+  assert.match(addedItems[0].content, /claude/);
+  assert.match(addedItems[0].content, /list/);
+}
+
+// 11. /switch 未知目标：显示错误
+{
+  const { ctx, addedItems } = makeMockContext();
+  await switchCmd.action(ctx, "unknown");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "error");
+  assert.match(addedItems[0].content, /Unknown switch target: unknown/);
+}
+
+// 12. /switch list：显示支持的目标列表
+{
+  const { ctx, addedItems } = makeMockContext();
+  await listSub.action(ctx, "");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "info");
+  assert.match(addedItems[0].content, /Supported third-party agents:/);
+  assert.match(addedItems[0].content, /claude/);
+  assert.match(addedItems[0].content, /\/switch claude/);
+}
+
+// 13. /switch list 额外参数：显示用法错误
+{
+  const { ctx, addedItems } = makeMockContext();
+  await listSub.action(ctx, "extra");
+  assert.equal(addedItems.length, 1);
+  assert.equal(addedItems[0].kind, "error");
+  assert.match(addedItems[0].content, /usage: \/switch list/);
+}
+
+// 14. 子命令结构校验
+{
+  assert.equal(switchCmd.name, "switch");
+  assert.equal(switchCmd.subCommands.length, 2);
+  assert.equal(claudeSub.name, "claude");
+  assert.equal(listSub.name, "list");
+}
+
+console.log("switch-command tests passed");

--- a/jiuwenswarm/channels/tui/frontend/tests/task-lifecycle-port.test.mjs
+++ b/jiuwenswarm/channels/tui/frontend/tests/task-lifecycle-port.test.mjs
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+
+import { TaskLifecyclePortImpl } from "../dist/core/supervision/task-lifecycle-port.js";
+import { CancelError } from "../dist/core/supervision/protocol.js";
+
+// 测试用依赖 mock
+class MockDeps {
+  constructor() {
+    this.cancellableWork = false;
+    this.sessionId = "test-session";
+    this.connectionAlive = true;
+    this.cancelResult = true;
+    this.sentInterrupts = [];
+    this.interruptResultHandlers = [];
+    this.connectionLostHandlers = [];
+    this.stopHandlers = [];
+  }
+
+  getSnapshot() {
+    return {
+      cancellableWork: this.cancellableWork,
+      sessionId: this.sessionId,
+    };
+  }
+
+  cancel(opts) {
+    return this.cancelResult;
+  }
+
+  sendEventOnly(method, params) {
+    const id = `req_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+    this.sentInterrupts.push({ method, params, id });
+    return id;
+  }
+
+  onInterruptResult(handler) {
+    this.interruptResultHandlers.push(handler);
+    return () => {
+      this.interruptResultHandlers = this.interruptResultHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  onConnectionLost(handler) {
+    this.connectionLostHandlers.push(handler);
+    return () => {
+      this.connectionLostHandlers = this.connectionLostHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  onStop(handler) {
+    this.stopHandlers.push(handler);
+    return () => {
+      this.stopHandlers = this.stopHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  isConnectionAlive() {
+    return this.connectionAlive;
+  }
+
+  // 测试辅助方法
+  fireInterruptResult(requestId, sessionId, success, message) {
+    for (const h of this.interruptResultHandlers) {
+      h(requestId, sessionId, success, message);
+    }
+  }
+
+  fireConnectionLost() {
+    for (const h of this.connectionLostHandlers) {
+      h();
+    }
+  }
+
+  fireStop() {
+    for (const h of this.stopHandlers) {
+      h();
+    }
+  }
+}
+
+// 1. hasServerTask: 无任务时返回 false
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = false;
+  const port = new TaskLifecyclePortImpl(deps);
+  assert.equal(port.hasServerTask(), false);
+}
+
+// 2. hasServerTask: 有任务时返回 true
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  assert.equal(port.hasServerTask(), true);
+}
+
+// 3. cancelAndWaitForIdle: 无任务时立即成功，不发送 interrupt
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = false;
+  const port = new TaskLifecyclePortImpl(deps);
+  await port.cancelAndWaitForIdle();
+  assert.equal(deps.sentInterrupts.length, 0);
+}
+
+// 4. cancelAndWaitForIdle: 成功 resolve
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 1000 });
+  assert.equal(port.hasWaiter(), true);
+  const sentId = deps.sentInterrupts[0].id;
+  deps.fireInterruptResult(sentId, "test-session", true);
+  await promise;  // 应该 resolve
+  assert.equal(port.hasWaiter(), false);
+}
+
+// 5. cancelAndWaitForIdle: CANCEL_REJECTED
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 1000 });
+  const sentId = deps.sentInterrupts[0].id;
+  deps.fireInterruptResult(sentId, "test-session", false, "user rejected");
+  await assert.rejects(promise, (err) => {
+    assert.ok(err instanceof CancelError);
+    assert.equal(err.code, "CANCEL_REJECTED");
+    assert.equal(err.message, "user rejected");
+    return true;
+  });
+}
+
+// 6. cancelAndWaitForIdle: CANCEL_TIMEOUT
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 50 });
+  await assert.rejects(promise, (err) => {
+    assert.ok(err instanceof CancelError);
+    assert.equal(err.code, "CANCEL_TIMEOUT");
+    return true;
+  });
+}
+
+// 7. cancelAndWaitForIdle: CANCEL_CONNECTION_LOST
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 1000 });
+  deps.fireConnectionLost();
+  await assert.rejects(promise, (err) => {
+    assert.ok(err instanceof CancelError);
+    assert.equal(err.code, "CANCEL_CONNECTION_LOST");
+    return true;
+  });
+}
+
+// 8. cancelAndWaitForIdle: CANCEL_STATE_STOPPED
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 1000 });
+  deps.fireStop();
+  await assert.rejects(promise, (err) => {
+    assert.ok(err instanceof CancelError);
+    assert.equal(err.code, "CANCEL_STATE_STOPPED");
+    return true;
+  });
+}
+
+// 9. cancelAndWaitForIdle: CANCEL_ALREADY_PENDING
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const firstPromise = port.cancelAndWaitForIdle({ timeoutMs: 100 });  // 第一次，会被超时 reject
+  // 第二次应立即 reject ALREADY_PENDING
+  await assert.rejects(
+    port.cancelAndWaitForIdle({ timeoutMs: 1000 }),
+    (err) => {
+      assert.ok(err instanceof CancelError);
+      assert.equal(err.code, "CANCEL_ALREADY_PENDING");
+      return true;
+    },
+  );
+  // 等待第一次 promise 完成（超时），避免 unhandled rejection
+  await firstPromise.catch(() => {});
+}
+
+// 10. cancelAndWaitForIdle: 连接已断开时立即 reject
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  deps.connectionAlive = false;
+  const port = new TaskLifecyclePortImpl(deps);
+  await assert.rejects(
+    port.cancelAndWaitForIdle({ timeoutMs: 1000 }),
+    (err) => {
+      assert.ok(err instanceof CancelError);
+      assert.equal(err.code, "CANCEL_CONNECTION_LOST");
+      return true;
+    },
+  );
+  assert.equal(deps.sentInterrupts.length, 0);  // 未发送 interrupt
+}
+
+// 11. 迟到事件不完成旧 waiter：waiter 已清除后，迟到事件不应抛错
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 50 });
+  const sentId = deps.sentInterrupts[0].id;
+  await assert.rejects(promise, (err) => err.code === "CANCEL_TIMEOUT");  // waiter 已清除
+  // 迟到事件不应抛错
+  assert.doesNotThrow(() => {
+    deps.fireInterruptResult(sentId, "test-session", true);
+  });
+}
+
+// 12. requestId 不匹配的事件不完成 waiter
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 200 });
+  const sentId = deps.sentInterrupts[0].id;
+  // 发送不匹配的 requestId
+  deps.fireInterruptResult("wrong_id", "test-session", true);
+  assert.equal(port.hasWaiter(), true);  // waiter 仍在
+
+  // 发送正确 requestId 才 resolve
+  deps.fireInterruptResult(sentId, "test-session", true);
+  await promise;  // 应该 resolve
+}
+
+// 13. sessionId 不匹配的事件不完成 waiter
+{
+  const deps = new MockDeps();
+  deps.cancellableWork = true;
+  const port = new TaskLifecyclePortImpl(deps);
+  const promise = port.cancelAndWaitForIdle({ timeoutMs: 200 });
+  const sentId = deps.sentInterrupts[0].id;
+  // 发送不匹配的 sessionId
+  deps.fireInterruptResult(sentId, "wrong-session", true);
+  assert.equal(port.hasWaiter(), true);  // waiter 仍在
+
+  // 发送空 sessionId 时匹配（兼容服务端不回显 sessionId 的情况）
+  deps.fireInterruptResult(sentId, "", true);
+  await promise;  // 应该 resolve
+}
+
+console.log("task-lifecycle-port tests passed");


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind <label>


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

# JiuwenSwarm TUI `/switch` PR 接口文档

> PR 范围：仅 JiuwenSwarm TUI 前端（`jiuwenswarm/channels/tui/frontend/`）
>
> 设计依据：[tui-switch-cc-public-contract.md](tui-switch-cc-public-contract.md) 第 5、6、7 节

## 1. PR 概述

### 1.1 目标

为 JiuwenSwarm TUI 实现 `/switch` 命令及其依赖的四个公共端口，使 TUI 在 `agentos-tui` launcher 托管模式下能够：

- 安全切换到第三方 agent TUI（当前适配 Claude，未来可扩展 Codex 等）
- 在 access token 权威过期时以重新认证动作码退出（由 launcher 刷新身份并重启）
- 等待服务端任务真实停止后再执行切换

### 1.2 非目标

- 不实现 `agentos-tui` launcher（另由独立项目开发）
- 不实现 IAM 服务端接口
- 不实现从第三方 agent TUI 切回 JiuwenSwarm
- 不修改现有 `/switch` 命令以外的任何内置命令

### 1.3 兼容性

- JiuwenSwarm 独立运行（非托管）时，`/switch` 命令不注册，完全不可见（help、补全、执行均不出现）
- 所有新增的 `CommandContext` 字段均为可选，不破坏现有命令
- 现有 Ctrl+C、Esc 取消路径不受影响

### 1.4 命令结构

`/switch` 采用父命令 + 子命令结构，目标列表由 `SUPPORTED_TARGETS` 数组数据驱动，未来扩展只需新增一条目：

| 命令 | 说明 |
|------|------|
| `/switch claude` | 切换到 Anthropic Claude TUI（当前唯一适配目标） |
| `/switch list` | 列出当前支持的所有第三方 agent |
| `/switch` | 显示用法帮助 |
| Tab 补全 | 输入 `/switch ` 后按 Tab 补全所有子命令名 |

---

## 2. 新增文件

### 2.1 监督协议模块（`src/core/supervision/`）

| 文件 | 职责 |
|------|------|
| `protocol.ts` | 公共契约类型与常量定义 |
| `supervised-env.ts` | 读取并校验 launcher 注入的环境变量 |
| `ui-lifecycle.ts` | 统一顶层关闭路径（串行清理 + process.exit） |
| `handoff-port.ts` | `/switch` 预检 + 请求退出 |
| `reauth-port.ts` | 权威认证过期 → 以 89 退出 |
| `task-lifecycle-port.ts` | 统一任务快照 + 等待型取消 |

### 2.2 命令文件

| 文件 | 职责 |
|------|------|
| `src/core/commands/builtins/switch.ts` | `/switch` 父命令 + 子命令实现 |

### 2.3 测试文件

| 文件 | 用例数 | 覆盖项 |
|------|--------|--------|
| `tests/supervised-env.test.mjs` | 9 | 托管标记解析、动作码范围 1..255、非法值 |
| `tests/handoff-port.test.mjs` | 8 | 预检失败原因、requestHandoff 二次校验、并发互斥 |
| `tests/task-lifecycle-port.test.mjs` | 13 | resolve/reject/timeout/connection-lost/already-pending/迟到事件/sessionId 关联 |
| `tests/reauth-port.test.mjs` | 6 | 非托管拒绝、互斥、不发送 interrupt、以 89 退出 |
| `tests/switch-command.test.mjs` | 14 | 额外参数、预检失败、用户取消、取消失败、handoff 成功、list 子命令、未知目标、子命令结构 |

---

## 3. 修改的现有文件

| 文件 | 改动内容 |
|------|---------|
| `src/core/commands/types.ts` | `CommandContext` 新增 4 个可选端口字段 |
| `src/core/commands/registry.ts` | 新增 `BuiltinCommandsOptions.switchEnabled` 选项；仅在 `switchEnabled` 时注册 `/switch` |
| `src/app-state.ts` | 端口字段、构造函数接收 supervision、订阅接口、`notifyInterruptResult`、`setSupervisionPorts`、stop/connection-lost 通知、`getCommandContext` 注入端口 |
| `src/core/event-handlers.ts` | `chat.interrupt_result` 解析 `request_id`+`session_id` 并通知订阅器 |
| `src/core/ws-client.ts` | close code 1008 时调用 `onAuthExpired` 回调 |
| `src/index.ts` | 构建监督协议快照、4 个端口、注入 AppState、配置 ws-client 回调、传 `switchEnabled` 给 `createBuiltinCommands` |
| `package.json` | 修复 test 脚本引用 `switch-command.test.mjs` |

---

## 4. 公共接口

### 4.1 监督协议环境变量

launcher 通过环境变量注入协议快照，TUI 启动时读取：

| 环境变量 | 类型 | 必需 | 说明 |
|---------|------|------|------|
| `AGENTOS_TUI_SUPERVISED` | `"1"` | 是 | 标记为 launcher 托管模式；同时决定 `/switch` 是否注册 |
| `AGENTOS_TUI_SWITCH_CC_EXIT_CODE` | `1..255` | 否（默认 88） | `/switch` 动作退出码 |
| `AGENTOS_TUI_REAUTH_EXIT_CODE` | `1..255` | 否 | 重新认证动作退出码；不注入表示不支持自动重新认证 |
| `AGENTOS_CC_TUI_EXECUTABLE` | `string` | 是 | `cc-tui` 可执行文件绝对路径 |

**安全约束**：这些变量是能力声明，不包含 token、密码或用户身份。用户可伪造，但只影响 TUI 退出行为，不影响服务端授权。

### 4.2 `TaskLifecyclePort`

```typescript
interface TaskLifecyclePort {
  /** 读取统一同步任务快照；存在任一活动工作时返回 true */
  hasServerTask(): boolean;
  /** 同步发送取消请求，立即返回；Ctrl+C、Esc 和普通取消路径共用 */
  cancel(options?: { showNotice?: boolean }): boolean;
  /** 等待型取消；只供 /switch 等生命周期动作使用，默认 timeoutMs=5000 */
  cancelAndWaitForIdle(options?: CancelAndWaitOptions): Promise<void>;
}
```

**关联机制**：服务端的 `interrupt_result` 可能不回显 TUI 的 `requestId`（使用自己的 `interrupt_xxx` 格式），因此 waiter 按 `sessionId` 关联。当 `requestId` 双方都有且不匹配时跳过，否则按 `sessionId` 匹配。

### 4.3 `HandoffPort`

```typescript
interface HandoffPort {
  /** 无副作用预检：校验托管标记、动作退出码和目标能力 */
  checkHandoff(target: HandoffTarget): HandoffCheckResult;
  /** 二次校验后调用统一顶层关闭路径，以动作退出码退出 */
  requestHandoff(target: HandoffTarget): Promise<void>;
}
```

**预检失败码**：`NOT_SUPERVISED`、`INVALID_EXIT_CODE`、`TARGET_UNAVAILABLE`、`HANDOFF_IN_PROGRESS`

### 4.4 `ReauthenticationPort`

```typescript
interface ReauthenticationPort {
  /** 权威认证过期时调用；不取消任务，以重新认证动作退出码退出 */
  requestReauthentication(reason: ReauthenticationReason): Promise<void>;
}
```

**触发条件**：仅 WebSocket close code 1008（服务端权威拒绝 token）触发。1006/5xx/超时继续走重连，不触发 reauth。

### 4.5 `UiLifecyclePort`

```typescript
interface UiLifecyclePort {
  /** 统一顶层关闭路径：退出通知→dispose→stop→exit */
  closeUi(options: { reason: UiExitReason; exitCode: number }): Promise<void>;
}
```

**串行清理顺序**：`notifyDisconnect` → `disposeScreen` → `stopAppState` → `stopTui` → `process.exit`

**退出原因枚举**：`"normal"` | `"switch"` | `"reauth-required"` | `"signal"` | `"fatal"`

### 4.6 `CommandContext` 新增字段

```typescript
interface CommandContext {
  // ...existing fields...

  /** HandoffPort 预检 */
  checkHandoff?: (target: HandoffTarget) => HandoffCheckResult;
  /** HandoffPort 请求 */
  requestHandoff?: (target: HandoffTarget) => Promise<void>;
  /** TaskLifecyclePort：统一任务快照 */
  hasServerTask?: () => boolean;
  /** TaskLifecyclePort：等待型取消 */
  cancelAndWaitForIdle?: (options?: CancelAndWaitOptions) => Promise<void>;
}
```

所有字段可选；JiuwenSwarm 独立运行时注入非托管回退实现。

### 4.7 `BuiltinCommandsOptions`

```typescript
interface BuiltinCommandsOptions {
  /**
   * 是否激活 /switch 命令。
   * 仅一体机场景（launcher 注入 AGENTOS_TUI_SUPERVISED=1）时为 true，
   * 此时命令可见且可执行；否则不注册，命令在 help、补全、执行中均不可见。
   */
  switchEnabled?: boolean;
}
```

`index.ts` 启动时传入 `switchEnabled: supervisionEnv.supervised`。

---

## 5. `/switch` 命令执行顺序

### 5.1 `/switch claude` 流程

```
用户输入 /switch claude
  │
  ├─ 1. 解析参数；有额外参数 → 显示用法错误，返回
  │
  ├─ 2. checkHandoff("cc-tui") 预检
  │     ├─ NOT_SUPERVISED → 显示错误，返回
  │     ├─ INVALID_EXIT_CODE → 显示错误，返回
  │     ├─ TARGET_UNAVAILABLE → 显示错误，返回
  │     └─ HANDOFF_IN_PROGRESS → 显示错误，返回
  │
  ├─ 3. hasServerTask()
  │     ├─ false → 跳到步骤 5
  │     └─ true → 弹出询问框
  │           ├─ 用户选"取消切换" → 显示"切换已取消"，返回（不发送 interrupt）
  │           └─ 用户选"中断任务并切换" → 步骤 4
  │
  ├─ 4. cancelAndWaitForIdle({ timeoutMs: 5000 })
  │     ├─ 成功 → 步骤 5
  │     ├─ CANCEL_TIMEOUT → 显示"取消超时"，返回（保留 TUI）
  │     ├─ CANCEL_REJECTED → 显示"取消被拒绝"，返回
  │     ├─ CANCEL_CONNECTION_LOST → 显示"连接断开"，返回
  │     └─ CANCEL_STATE_STOPPED → 显示"状态已停止"，返回
  │
  └─ 5. requestHandoff("cc-tui")
        ├─ 成功 → closeUi({ reason: "switch", exitCode: 88 }) → process.exit(88)
        └─ 失败 → closeUi({ reason: "fatal", exitCode: 70 }) → process.exit(70)
```

### 5.2 `/switch list` 流程

```
用户输入 /switch list
  │
  ├─ 解析参数；有额外参数 → 显示用法错误，返回
  │
  └─ 显示支持的目标列表：
       Supported third-party agents:
       1. claude — Anthropic Claude TUI  (/switch claude)
```

### 5.3 `/switch`（无参数）流程

显示用法帮助，列出所有可用目标和子命令。

### 5.4 目标扩展

在 `switch.ts` 的 `SUPPORTED_TARGETS` 数组新增条目即可扩展（例如未来 `/switch codex`）：

```typescript
const SUPPORTED_TARGETS: readonly SwitchTarget[] = [
  {
    name: "claude",
    label: "claude",
    description: "Anthropic Claude TUI",
    handoffTarget: HANDOFF_TARGET_CC_TUI,
  },
  // 未来扩展示例：
  // {
  //   name: "codex",
  //   label: "codex",
  //   description: "OpenAI Codex CLI",
  //   handoffTarget: HANDOFF_TARGET_CODEX_CLI,
  // },
];
```

子命令注册、Tab 补全、`/switch list` 输出均由该数组自动驱动。

---

## 6. AppState 订阅接口

### 6.1 事件订阅

```typescript
class CliPiAppState {
  /** 订阅 interrupt_result 事件；按 requestId + sessionId 关联 */
  onInterruptResult(handler: InterruptResultHandler): () => void;
  /** 订阅 WebSocket 断开或认证失败 */
  onConnectionLost(handler: () => void): () => void;
  /** 订阅 AppState.stop（进程退出前清理） */
  onStop(handler: () => void): () => void;
}
```

### 6.2 事件通知

```typescript
class CliPiAppState {
  /** 由 event-handlers 在收到 chat.interrupt_result 时调用 */
  notifyInterruptResult(requestId: string, sessionId: string, success: boolean, message?: string): void;
}
```

### 6.3 端口注入

```typescript
class CliPiAppState {
  /** 构造函数接收可选 supervision 参数 */
  constructor(wsClient: WsClient, cliSession?: string, supervision?: {
    handoffPort?: HandoffPort | null;
    taskLifecycle?: TaskLifecyclePort | null;
    reauthPort?: ReauthenticationPort | null;
    uiLifecycle?: UiLifecyclePort | null;
  });
  /** index.ts 在构造后回填端口 */
  setSupervisionPorts(ports: { ... }): void;
  /** 获取 ReauthenticationPort（ws-client 在权威认证过期时调用） */
  getReauthPort(): ReauthenticationPort | null;
}
```

---

## 7. WsClient 新增接口

```typescript
class WsClient {
  /** 权威认证过期回调；仅 close code 1008 时调用 */
  onAuthExpired?: () => void;
}
```

**触发条件**：WebSocket close code 1008（`auth_failed`）。非 1008 的断线、1006、5xx、普通超时不触发。

---

## 8. 退出码约定

| 退出码 | 含义 | 触发方 |
|--------|------|--------|
| `88` | `/switch` 成功，launcher 启动目标 TUI | `/switch <target>` 命令 |
| `89` | access token 权威过期，launcher 刷新身份并重启 TUI | `ReauthenticationPort` |
| `70` | handoff 清理失败（非动作错误码） | `HandoffPort` / `ReauthenticationPort` 异常路径 |
| `0` | 正常退出（Ctrl+C 双击、SIGTERM、`/exit`） | 现有 `closeUi(0)` 路径 |
| `1` | 崩溃（uncaughtException） | 现有 `crash()` 路径 |

---

## 9. 验证矩阵

### 9.1 单元测试

```bash
cd jiuwenswarm/channels/tui/frontend
npm test
```

预期输出：6 个测试套件全部通过（50 个用例）。

### 9.2 类型检查

```bash
npx tsc --noEmit
```

预期：0 错误。

### 9.3 Lint

```bash
npx oxlint --deny-warnings src/core/supervision/ src/core/commands/builtins/switch.ts
```

预期：0 warnings, 0 errors。

### 9.4 端到端验证

**非托管模式（独立运行）**：
```bash
node dist/index.js --url ws://127.0.0.1:19001/tui --user-id <id> --token <token>
# 在 TUI 中输入 /switch claude
# 预期：显示 "Unknown command: switch"（命令未注册，完全不可见）
# 在 TUI 中输入 /switch list
# 预期：同上
```

**托管模式（无任务）**：
```bash
AGENTOS_TUI_SUPERVISED=1 AGENTOS_TUI_SWITCH_CC_EXIT_CODE=88 AGENTOS_CC_TUI_EXECUTABLE=/usr/bin/echo node dist/index.js --url ws://127.0.0.1:19001/tui --user-id <id> --token <token>
# 在 TUI 中输入 /switch claude
echo $?
# 预期：退出码 88
```

**托管模式（有任务）**：
```bash
# 同上启动
# 1. 发一条消息让 agent 开始处理
# 2. 处理中输入 /switch claude
# 3. 选择"中断任务并切换"
echo $?
# 预期：退出码 88
```

**托管模式（用户取消）**：
```bash
# 同上启动
# 1. 发消息让 agent 处理
# 2. 处理中输入 /switch claude
# 3. 选择"取消切换"
# 预期：显示"切换已取消"，TUI 不退出
```

**托管模式（列出目标）**：
```bash
# 同上启动
# 在 TUI 中输入 /switch list
# 预期：显示支持的目标列表（当前只有 claude）
```

**Tab 补全**：
```bash
# 同上启动
# 在 TUI 中输入 /switch 后按 Tab
# 预期：补全 claude 和 list
```

---

## 10. 文件变更清单

```
新增:
  src/core/supervision/protocol.ts
  src/core/supervision/supervised-env.ts
  src/core/supervision/ui-lifecycle.ts
  src/core/supervision/handoff-port.ts
  src/core/supervision/reauth-port.ts
  src/core/supervision/task-lifecycle-port.ts
  src/core/commands/builtins/switch.ts
  tests/supervised-env.test.mjs
  tests/handoff-port.test.mjs
  tests/task-lifecycle-port.test.mjs
  tests/reauth-port.test.mjs
  tests/switch-command.test.mjs

修改:
  src/core/commands/types.ts          (CommandContext 新增 4 个可选字段)
  src/core/commands/registry.ts      (BuiltinCommandsOptions.switchEnabled；条件注册 /switch)
  src/app-state.ts                    (端口字段、订阅接口、通知、注入)
  src/core/event-handlers.ts          (interrupt_result 通知订阅器)
  src/core/ws-client.ts              (onAuthExpired 回调)
  src/index.ts                        (构建端口、注入、配置回调、传 switchEnabled)
  package.json                        (修复 test 脚本引用 switch-command.test.mjs)
```