### PR TITLE
fix(xiaoyi): CLI notice 下发 is_complete 终止信号

### DIFF
--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -659,16 +659,18 @@ class MessageHandler(ABC):
 
         - str: 兼容历史行为，封装为 {"content": text, "is_complete": True}
         - dict: 透传给 channel（仅确保 is_complete=True）
+
+        小艺 channel 按 payload.is_complete 判定任务结束（True → WS final=true，
+        关闭「处理中」接收周期）。CLI 控制指令等 notice 均为终态回包，必须默认 True；
+        若确需多帧未完结，调用方显式传入 is_complete=False。
         """
         from jiuwenswarm.common.schema.message import Message, EventType
 
-        # 小艺 channel 按 payload.is_complete 判定任务结束（收到 True 即关闭接收周期）。
-        _default_complete = False if channel_id == "xiaoyi" else True
         if isinstance(text_or_payload, dict):
             payload = dict(text_or_payload)
-            payload.setdefault("is_complete", _default_complete)
+            payload.setdefault("is_complete", True)
         else:
-            payload = {"content": text_or_payload, "is_complete": _default_complete}
+            payload = {"content": text_or_payload, "is_complete": True}
 
         _app_id = user_infos.get("app_id") or user_infos.get("bot_id", "")
         msg = Message(

--- a/tests/unit_tests/gateway/test_send_channel_notice_complete.py
+++ b/tests/unit_tests/gateway/test_send_channel_notice_complete.py
@@ -1,0 +1,112 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Tests for MessageHandler.send_channel_notice is_complete defaults.
+
+Issue #300: 小艺 CLI 指令（/mode agent、/new_session 等）回包若 is_complete=False，
+WS 只下发 lastChunk 而不带 final=true，界面会一直处于「处理中」直到超时。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from jiuwenswarm.common.schema.message import EventType
+from jiuwenswarm.gateway.message_handler.message_handler import MessageHandler
+
+
+class _FakeAgentClient:
+    @staticmethod
+    async def send_request(env: object) -> SimpleNamespace:
+        return SimpleNamespace(ok=True, payload={})
+
+    @staticmethod
+    async def send_request_stream(env: object):
+        if False:  # pragma: no cover
+            yield env
+
+
+class _TestMessageHandler(MessageHandler):
+    @classmethod
+    def create(cls) -> "_TestMessageHandler":
+        setattr(MessageHandler, "_instance", None)
+        setattr(cls, "_instance", None)
+        handler = cls(_FakeAgentClient())
+        handler.published = []
+        return handler
+
+    async def publish_robot_messages(self, msg: object) -> None:
+        self.published.append(msg)
+
+
+def _user_infos() -> dict:
+    return {
+        "id": "req-notice-1",
+        "meta_data": {"xiaoyi_session_id": "xy-sess", "xiaoyi_task_id": "xy-task"},
+        "app_id": "app-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_channel_notice_xiaoyi_defaults_is_complete_true() -> None:
+    """CLI notice to xiaoyi must complete so UI exits processing (Issue #300)."""
+    handler = _TestMessageHandler.create()
+
+    await handler.send_channel_notice(
+        _user_infos(),
+        "xiaoyi",
+        "sess-1",
+        "[收到 CLI 指令], mode 已变更为 agent",
+    )
+
+    assert len(handler.published) == 1
+    msg = handler.published[0]
+    assert msg.channel_id == "xiaoyi"
+    assert msg.event_type == EventType.CHAT_FINAL
+    assert msg.payload["content"] == "[收到 CLI 指令], mode 已变更为 agent"
+    assert msg.payload["is_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_channel_notice_other_channel_defaults_is_complete_true() -> None:
+    handler = _TestMessageHandler.create()
+
+    await handler.send_channel_notice(
+        _user_infos(),
+        "feishu",
+        "sess-1",
+        "ok",
+    )
+
+    assert handler.published[0].payload["is_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_channel_notice_dict_setdefault_preserves_explicit_false() -> None:
+    """Callers that need multi-frame notices can still pass is_complete=False."""
+    handler = _TestMessageHandler.create()
+
+    await handler.send_channel_notice(
+        _user_infos(),
+        "xiaoyi",
+        "sess-1",
+        {"content": "partial", "is_complete": False},
+    )
+
+    assert handler.published[0].payload["is_complete"] is False
+    assert handler.published[0].payload["content"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_send_channel_notice_dict_fills_missing_is_complete_true() -> None:
+    handler = _TestMessageHandler.create()
+
+    await handler.send_channel_notice(
+        _user_infos(),
+        "xiaoyi",
+        "sess-1",
+        {"content": "skills list"},
+    )
+
+    assert handler.published[0].payload["is_complete"] is True


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

## 元信息（派工与追溯）

| 字段 | 值 |
|------|-----|
| **module** | gateway / xiaoyi |
| **关联 Issue** | #300 |
| **head 分支** | `fix/issue-300-xiaoyi-cli-final-signal` |
| **base 分支** | `develop` |

---

## 变更类型

**What type of PR is this?**

/kind bug

---

## 变更摘要

- 修复小艺 channel 发送 `/mode agent`、`/new_session` 等 CLI 指令后，界面已显示回复但仍一直「处理中」直到超时的问题
- CLI notice 恢复默认 `is_complete=True`，使 WS 下发 `final: true` 以结束接收周期
- 补齐 `send_channel_notice` 单测，覆盖小艺默认完结与显式 `False` 保留

---

## 关联 Issue

Closes #300

---

## 实现说明

根因：`MessageHandler.send_channel_notice` 对 `channel_id == "xiaoyi"` 默认 `is_complete=False`，导致小艺 `_send_legacy` 映射出 `artifact-update` 时 `lastChunk=true` 但 `final=false`：正文可见，会话不清、UI 不退出处理中。

修复：与其它 IM 通道及 docstring 对齐，notice 默认 `is_complete=True`；多帧未完结场景可由调用方显式传 `False`。

主要文件：
- `jiuwenswarm/gateway/message_handler/message_handler.py`
- `tests/unit_tests/gateway/test_send_channel_notice_complete.py`

无对外接口变更。

修复前，输入/mode agent，会一直处于处理中状态：
![image.png](https://raw.gitcode.com/user-images/assets/9297832/0aad9ab1-05f4-48a3-a7d2-a25699c094f5/image.png 'image.png')
修复后，输入/mode agent，正常结束当前轮次，不影响连续对话：
![image.png](https://raw.gitcode.com/user-images/assets/9297832/97cee943-23c0-4947-9ac7-9cca547b9405/image.png 'image.png')

---

## 文档与计划

跳过文档链（独立 Bugfix，根因已定位）。

| 产物 | 路径 / 状态 |
|------|-------------|
| requirements.md | 不涉及 |
| design.md | 不涉及 |
| dev_plan.md | 不涉及 |
| test_plan.md | 不涉及 |
| 审查结论 | 不涉及（独立 PR） |

---

## 审查摘要（Aidlc G7b 必填）

不涉及（独立 Bugfix PR，未走 Aidlc 审查产物链）。

---

## 验证结果

### 功能 / 回归验证

对照 Issue #300：CLI notice 对小艺 payload 默认 `is_complete=True`，可映射为 WS `final: true`，从而结束「处理中」。真机小艺 UI 回归需在合入后由设备侧验证。

### 自动化测试

```text
uv run pytest tests/unit_tests/gateway/test_send_channel_notice_complete.py -q --tb=short
```

4 passed。

### 手动 / UI 验证（如适用）

不涉及本机小艺真机复测；依赖上述单测与合入后设备验证。

---

## 自检清单（Self-checklist）

**Self-checklist**：（请自检，在 `[ ]` 内打上 x）

- [ ] **设计**：PR 对应的方案是否已经过 Maintainer 评审，方案检视意见是否均已答复并完成方案修改
- [x] **测试**：PR 中的代码是否已有 UT/ST 测试用例充分覆盖，新增测试用例是否随本 PR 一并上库或已经上库
- [x] **验证**：PR 描述中已包含对该 PR 对应 Feature / Refactor / Bugfix **预期目标达成情况**的详细验证结果（见上文「验证结果」）
- [ ] **接口**：是否涉及对外接口变更；如有，变更已通过接口评审，API 注释已同步更新（不涉及则保持未勾选并在「实现说明」注明）
- [ ] **文档**：是否涉及官网文档修改；如有，已提交 Doc 仓资料（不涉及则保持未勾选）

---

## 审阅者注意事项（可选）

- 请重点确认：team 联机等多帧场景若需保持接收周期开启，调用方是否已显式传 `is_complete=False`（本次仅改 notice 默认值，不强制覆盖显式字段）