### PR TITLE
fix(memory): When all the folders in the workspace path don't have a …

### DIFF
--- a/jiuwenswarm/agents/harness/common/rails/project_memory/files.py
+++ b/jiuwenswarm/agents/harness/common/rails/project_memory/files.py
@@ -238,7 +238,7 @@ def discover_and_load_memory_files(
         watch_paths=watch_paths,
     )
 
-    project_root = find_project_root(workspace_key)
+    project_root = find_project_root(workspace_key) or Path(workspace_key)
     if project_root is not None:
         try:
             cwd = Path(workspace_key)

--- a/tests/unit_tests/agentserver/rails/test_project_memory_rail.py
+++ b/tests/unit_tests/agentserver/rails/test_project_memory_rail.py
@@ -588,3 +588,94 @@ def test_resolve_workspace_path_falls_back_when_workspace_missing():
 
 def test_module_exports_project_memory_rail():
     assert hasattr(_rail_mod, "ProjectMemoryRail")
+
+
+@pytest.mark.asyncio
+async def test_pm1_defect_a_no_marker_skips_project_layer(monkeypatch):
+    """find_project_root 返回 None 时 project 层零扫描。
+
+    files.py:242 ``if project_root is not None:`` 整块跳过，workspace 自身的
+    JIUWENSWARM.md 永远不进 _scan_relative_files。修后 fallback 到
+    workspace_key，walk 退化为单层，文件能被发现。
+    """
+    monkeypatch.setattr(_files_mod, "find_project_root", lambda *_args, **_kw: None)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _touch(root, "JIUWENSWARM.md", "NO-MARKER-RULE\n")
+
+        rail = ProjectMemoryRail(workspace=str(root), language="en")
+        agent = _make_agent_with_builder()
+        rail.init(agent)
+        await rail.before_model_call(ctx=_make_ctx(agent))
+
+        body = await _project_memory_body(agent, "en")
+        assert "NO-MARKER-RULE" in body, (
+            "find_project_root 返回 None 时 workspace 自身的 JIUWENSWARM.md "
+            "仍应被加载（PM-1 缺陷 A，files.py fallback 后转绿）"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pm1_defect_a_no_marker_skips_rules_glob_and_local(monkeypatch):
+    """不只丢 JIUWENSWARM.md：.jiuwen/rules/*.md 与 JIUWENSWARM.local.md
+    同在 files.py:242 的 if 块内，project_root is None 时一并静默丢失。
+    修复后 fallback 走 _scan_relative_globs / LOCAL_MEMORY_FILES，应一并加载。
+    """
+    monkeypatch.setattr(_files_mod, "find_project_root", lambda *_args, **_kw: None)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _touch(root, ".jiuwen/rules/01_style.md", "STYLE-NO-MARKER\n")
+        _touch(root, ".jiuwen/rules/02_test.md", "TEST-NO-MARKER\n")
+        _touch(root, "JIUWENSWARM.local.md", "LOCAL-NO-MARKER\n")
+
+        rail = ProjectMemoryRail(workspace=str(root), language="en")
+        agent = _make_agent_with_builder()
+        rail.init(agent)
+        await rail.before_model_call(ctx=_make_ctx(agent))
+
+        body = await _project_memory_body(agent, "en")
+        assert "STYLE-NO-MARKER" in body, (
+            ".jiuwen/rules/*.md 在 find_project_root=None 时应仍被加载（PM-1 缺陷 A）"
+        )
+        assert "TEST-NO-MARKER" in body
+        assert "LOCAL-NO-MARKER" in body, (
+            "JIUWENSWARM.local.md 在 find_project_root=None 时应仍被加载（PM-1 缺陷 A）"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pm1_defect_a_plus_b_cache_misses_newly_added_md(monkeypatch):
+    """
+    find_project_root 强制 None：
+      - 首次空目录：project 层整块跳过 → files=[]，且 watch_paths 不含
+        workspace（files.py:267 的 watch_paths.add 在 if 块内）→ 缓存空结果
+        且 snapshot 为空。
+      - 新增 JIUWENSWARM.md 后再调用：命中缓存，snapshot 比对为空视为未变
+        → 直接返回缓存的空 files，永不重扫。
+    修后 fallback 使 workspace 进 watch_paths，新增文件触发父目录 mtime 变化，
+    缓存正常失效，下一轮读到。
+    """
+    monkeypatch.setattr(_files_mod, "find_project_root", lambda *_args, **_kw: None)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        rail = ProjectMemoryRail(workspace=str(root), language="en")
+        agent = _make_agent_with_builder()
+        rail.init(agent)
+
+        # 首次：空目录，写空缓存
+        await rail.before_model_call(ctx=_make_ctx(agent))
+        assert await _project_memory_section(agent) is None
+
+        # 用户在启动目录手动新增 JIUWENSWARM.md
+        _touch(root, "JIUWENSWARM.md", "LATE-ADDED-RULE\n")
+
+        # 下一轮：缓存应失效（或 project 层被扫到），读到新增文件
+        await rail.before_model_call(ctx=_make_ctx(agent))
+        body = await _project_memory_body(agent, "en")
+        assert "LATE-ADDED-RULE" in body, (
+            "无 marker 目录新增 JIUWENSWARM.md 后，下一轮 before_model_call 应能读到"
+            "（PM-1 缺陷 A+B，files.py fallback + watch_paths 含 workspace 后转绿）"
+        )


### PR DESCRIPTION
 **Problem**

  In jiuwenswarm/agents/harness/common/rails/project_memory/files.py, the function discover_and_load_memory_files calls
  find_project_root(workspace_key) to locate the project root. When none of the folders along the workspace path contain
  a project-root marker file (e.g., .git, .hg, pyproject.toml), find_project_root returns None.

  The code is guarded by if project_root is not None:, so when the result is None the entire project layer is silently
  skipped. This means three categories of memory files living inside the workspace itself are never scanned:

  1. The workspace's own JIUWENSWARM.md — the primary project memory the user expects to load.
  2. The .jiuwen/rules/*.md glob — rule files.
  3. JIUWENSWARM.local.md — the local override file.

  Because watch_paths.add(workspace) also lives inside that same if block (files.py:267), the workspace directory never
  enters the watch set. A second, compounding defect: on the first call against an empty directory an
  empty result is cached with an empty snapshot; after the user manually adds JIUWENSWARM.md, the next call hits the
  cache, the empty-vs-empty snapshot comparison treats the directory as unchanged, and the file is never picked up — a
  permanent blind spot.

  **Solution**

  A one-line, defensive fallback in files.py:241:

  - project_root = find_project_root(workspace_key)
  + project_root = find_project_root(workspace_key) or Path(workspace_key)

  When find_project_root returns None, the code falls back to workspace_key itself as the project root. This ensures:

  - The if project_root is not None: block always executes, so JIUWENSWARM.md, .jiuwen/rules/*.md, and
  JIUWENSWARM.local.md are always discovered via _scan_relative_files, _scan_relative_globs, and LOCAL_MEMORY_FILES.
  - The directory walk degrades gracefully to a single-layer scan rooted at the workspace (rather than walking up to a
  real project root), which is the correct behavior when the workspace has no marker.
  - The workspace enters watch_paths, so the parent-directory mtime changes when files are added — the cache invalidates
  correctly on the next before_model_call, fixing the permanent-cache-miss.

  **Testing**

  New tests in tests/unit_tests/agentserver/rails/test_project_memory_rail.py (3 async tests, +91 lines), each
  monkeypatches find_project_root to return None to reproduce the no-marker scenario:

  Validates: A workspace with JIUWENSWARM.md but no project-root marker still loads its content into the project-memory
    body (the fallback turns the previously-skipped scan green).

  Validates: Confirms the fix also recovers .jiuwen/rules/01_style.md, .jiuwen/rules/02_test.md, and
  JIUWENSWARM.local.md

  Validates: Reproduces the combined defect: first call on an empty directory writes an empty cache + empty
  snapshot;


  **Self-validation**
  Reproducible version：https://gitcode.com/openJiuwen/jiuwenswarm/tree/dev0.2.1.final

  before modification
<img width="2000" height="1117" alt="image" src="https://github.com/user-attachments/assets/f9c9c356-1481-4bdd-993c-48d3c092ca5f" />

after modification
<img width="1850" height="1125" alt="image" src="https://github.com/user-attachments/assets/66bba985-f356-4e32-9504-4b7bd9bc3897" />

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1061
<!-- /bot1-related-issues -->
