### PR TITLE
fix(clawhub): pass ownerHandle to resolve ambiguous slug 409 Conflict

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
@@ -391,7 +391,9 @@ class SkillToolkit:
                 clawhub_owner = ""
                 if "/" in target:
                     clawhub_owner, _, clawhub_slug = target.partition("/")
-                payload = await self._manager.handle_skills_clawhub_download({"slug": clawhub_slug, "owner_handle": clawhub_owner, "force": False})
+                payload = await self._manager.handle_skills_clawhub_download(
+                    {"slug": clawhub_slug, "owner_handle": clawhub_owner, "force": False}
+                )
         except Exception as exc:  # noqa: BLE001
             logger.exception("install_skill failed")
             return {

--- a/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
@@ -362,27 +362,44 @@ class SkillToolkit:
 
             resolved_source = normalized_source
             wait_timeout = self._safe_int(timeout_sec, 60)
-            existing_item = self._find_installed_by_target(target, resolved_source)
-            if existing_item is not None:
-                detail = (
-                    f"Skill `{existing_item['name']}` is already installed. "
-                    "Skipping duplicate installation."
-                )
-                return {
-                    "success": True,
-                    "source": resolved_source,
-                    "installed": True,
-                    "already_installed": True,
-                    "name": existing_item["name"],
-                    "description": existing_item["description"],
-                    "identifier": existing_item["identifier"],
-                    "skill_file": existing_item["skill_file"],
-                    "detail": detail,
-                }
 
             if resolved_source == "skillnet":
+                existing_item = self._find_installed_by_target(target, resolved_source)
+                if existing_item is not None:
+                    detail = (
+                        f"Skill `{existing_item['name']}` is already installed. "
+                        "Skipping duplicate installation."
+                    )
+                    return {
+                        "success": True,
+                        "source": resolved_source,
+                        "installed": True,
+                        "already_installed": True,
+                        "name": existing_item["name"],
+                        "description": existing_item["description"],
+                        "identifier": existing_item["identifier"],
+                        "skill_file": existing_item["skill_file"],
+                        "detail": detail,
+                    }
                 payload = await self._install_skillnet_sync_wait(target, wait_timeout)
             elif resolved_source == "teamskillshub":
+                existing_item = self._find_installed_by_target(target, resolved_source)
+                if existing_item is not None:
+                    detail = (
+                        f"Skill `{existing_item['name']}` is already installed. "
+                        "Skipping duplicate installation."
+                    )
+                    return {
+                        "success": True,
+                        "source": resolved_source,
+                        "installed": True,
+                        "already_installed": True,
+                        "name": existing_item["name"],
+                        "description": existing_item["description"],
+                        "identifier": existing_item["identifier"],
+                        "skill_file": existing_item["skill_file"],
+                        "detail": detail,
+                    }
                 payload = await self._manager.handle_skills_team_skills_hub_install(
                     {"asset_id": target, "force": False}
                 )
@@ -391,6 +408,23 @@ class SkillToolkit:
                 clawhub_owner = ""
                 if "/" in target:
                     clawhub_owner, _, clawhub_slug = target.partition("/")
+                existing_item = self._find_installed_by_target(clawhub_slug, resolved_source)
+                if existing_item is not None:
+                    detail = (
+                        f"Skill `{existing_item['name']}` is already installed. "
+                        "Skipping duplicate installation."
+                    )
+                    return {
+                        "success": True,
+                        "source": resolved_source,
+                        "installed": True,
+                        "already_installed": True,
+                        "name": existing_item["name"],
+                        "description": existing_item["description"],
+                        "identifier": existing_item["identifier"],
+                        "skill_file": existing_item["skill_file"],
+                        "detail": detail,
+                    }
                 payload = await self._manager.handle_skills_clawhub_download(
                     {"slug": clawhub_slug, "owner_handle": clawhub_owner, "force": False}
                 )

--- a/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
@@ -384,11 +384,13 @@ class SkillToolkit:
             wait_timeout = self._safe_int(timeout_sec, 60)
 
             if resolved_source == "skillnet":
-                if (r := self._check_already_installed(target, resolved_source)) is not None:
+                r = self._check_already_installed(target, resolved_source)
+                if r is not None:
                     return r
                 payload = await self._install_skillnet_sync_wait(target, wait_timeout)
             elif resolved_source == "teamskillshub":
-                if (r := self._check_already_installed(target, resolved_source)) is not None:
+                r = self._check_already_installed(target, resolved_source)
+                if r is not None:
                     return r
                 payload = await self._manager.handle_skills_team_skills_hub_install(
                     {"asset_id": target, "force": False}
@@ -398,7 +400,8 @@ class SkillToolkit:
                 clawhub_owner = ""
                 if "/" in target:
                     clawhub_owner, _, clawhub_slug = target.partition("/")
-                if (r := self._check_already_installed(clawhub_slug, resolved_source)) is not None:
+                r = self._check_already_installed(clawhub_slug, resolved_source)
+                if r is not None:
                     return r
                 payload = await self._manager.handle_skills_clawhub_download(
                     {"slug": clawhub_slug, "owner_handle": clawhub_owner, "force": False}

--- a/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
@@ -387,7 +387,11 @@ class SkillToolkit:
                     {"asset_id": target, "force": False}
                 )
             else:
-                payload = await self._manager.handle_skills_clawhub_download({"slug": target, "force": False})
+                clawhub_slug = target
+                clawhub_owner = ""
+                if "/" in target:
+                    clawhub_owner, _, clawhub_slug = target.partition("/")
+                payload = await self._manager.handle_skills_clawhub_download({"slug": clawhub_slug, "owner_handle": clawhub_owner, "force": False})
         except Exception as exc:  # noqa: BLE001
             logger.exception("install_skill failed")
             return {

--- a/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
+++ b/jiuwenswarm/agents/harness/common/tools/skill_toolkits.py
@@ -103,6 +103,26 @@ class SkillToolkit:
 
         return None
 
+    def _check_already_installed(self, identifier: str, source: str) -> dict[str, Any] | None:
+        existing_item = self._find_installed_by_target(identifier, source)
+        if existing_item is None:
+            return None
+        detail = (
+            f"Skill `{existing_item['name']}` is already installed. "
+            "Skipping duplicate installation."
+        )
+        return {
+            "success": True,
+            "source": source,
+            "installed": True,
+            "already_installed": True,
+            "name": existing_item["name"],
+            "description": existing_item["description"],
+            "identifier": existing_item["identifier"],
+            "skill_file": existing_item["skill_file"],
+            "detail": detail,
+        }
+
     def _is_builtin_skill(self, skill_name: str) -> bool:
         """复用原有卸载语义：只有真正运行在 builtin 目录中的技能才视为内置。"""
         return self._manager.is_builtin_skill(skill_name)
@@ -364,42 +384,12 @@ class SkillToolkit:
             wait_timeout = self._safe_int(timeout_sec, 60)
 
             if resolved_source == "skillnet":
-                existing_item = self._find_installed_by_target(target, resolved_source)
-                if existing_item is not None:
-                    detail = (
-                        f"Skill `{existing_item['name']}` is already installed. "
-                        "Skipping duplicate installation."
-                    )
-                    return {
-                        "success": True,
-                        "source": resolved_source,
-                        "installed": True,
-                        "already_installed": True,
-                        "name": existing_item["name"],
-                        "description": existing_item["description"],
-                        "identifier": existing_item["identifier"],
-                        "skill_file": existing_item["skill_file"],
-                        "detail": detail,
-                    }
+                if (r := self._check_already_installed(target, resolved_source)) is not None:
+                    return r
                 payload = await self._install_skillnet_sync_wait(target, wait_timeout)
             elif resolved_source == "teamskillshub":
-                existing_item = self._find_installed_by_target(target, resolved_source)
-                if existing_item is not None:
-                    detail = (
-                        f"Skill `{existing_item['name']}` is already installed. "
-                        "Skipping duplicate installation."
-                    )
-                    return {
-                        "success": True,
-                        "source": resolved_source,
-                        "installed": True,
-                        "already_installed": True,
-                        "name": existing_item["name"],
-                        "description": existing_item["description"],
-                        "identifier": existing_item["identifier"],
-                        "skill_file": existing_item["skill_file"],
-                        "detail": detail,
-                    }
+                if (r := self._check_already_installed(target, resolved_source)) is not None:
+                    return r
                 payload = await self._manager.handle_skills_team_skills_hub_install(
                     {"asset_id": target, "force": False}
                 )
@@ -408,23 +398,8 @@ class SkillToolkit:
                 clawhub_owner = ""
                 if "/" in target:
                     clawhub_owner, _, clawhub_slug = target.partition("/")
-                existing_item = self._find_installed_by_target(clawhub_slug, resolved_source)
-                if existing_item is not None:
-                    detail = (
-                        f"Skill `{existing_item['name']}` is already installed. "
-                        "Skipping duplicate installation."
-                    )
-                    return {
-                        "success": True,
-                        "source": resolved_source,
-                        "installed": True,
-                        "already_installed": True,
-                        "name": existing_item["name"],
-                        "description": existing_item["description"],
-                        "identifier": existing_item["identifier"],
-                        "skill_file": existing_item["skill_file"],
-                        "detail": detail,
-                    }
+                if (r := self._check_already_installed(clawhub_slug, resolved_source)) is not None:
+                    return r
                 payload = await self._manager.handle_skills_clawhub_download(
                     {"slug": clawhub_slug, "owner_handle": clawhub_owner, "force": False}
                 )

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/skills.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/skills.ts
@@ -256,14 +256,21 @@ export function createSkillsCommand(): SlashCommand {
             return;
           }
 
-          // ClawHub install flow: "slug@clawhub" or bare slug that looks like a ClawHub identifier
+          // ClawHub install flow: "ownerHandle/slug@clawhub" or "slug@clawhub"
           // ClawHub identifiers are alphanumeric slugs like "code-review", "daily-report" etc.
           if (spec.includes("@clawhub") || (spec.includes("@") && spec.endsWith("@clawhub"))) {
-            const slug = spec.replace(/@clawhub$/i, "");
+            const clawhubPart = spec.replace(/@clawhub$/i, "");
+            let slug = clawhubPart;
+            let ownerHandle: string | undefined;
+            if (clawhubPart.includes("/")) {
+              const [owner, s] = clawhubPart.split("/");
+              ownerHandle = owner;
+              slug = s;
+            }
             ctx.addItem(makeItem(ctx.sessionId, "info", `Installing from ClawHub: ${slug}`));
             const downloadPayload = await ctx.request<{ success?: boolean; detail?: string; detail_key?: string; skill?: { name?: string; source?: string } }>(
               "skills.clawhub.download",
-              { slug, force: false },
+              { slug, owner_handle: ownerHandle || "", force: false },
               120_000,
             );
             if (downloadPayload.success) {
@@ -296,7 +303,7 @@ export function createSkillsCommand(): SlashCommand {
                   ctx.addItem(makeItem(ctx.sessionId, "info", `Force re-installing from ClawHub: ${slug}`));
                   const forcePayload = await ctx.request<{ success?: boolean; detail?: string; detail_key?: string; skill?: { name?: string; source?: string } }>(
                     "skills.clawhub.download",
-                    { slug, force: true },
+                    { slug, owner_handle: ownerHandle || "", force: true },
                     120_000,
                   );
                   if (forcePayload.success) {
@@ -324,7 +331,7 @@ export function createSkillsCommand(): SlashCommand {
                     value: s.slug,
                     description: `${s.summary || "(no description)"} | slug: ${s.slug} | v${s.version || "?"}`,
                   }));
-                  ctx.addItem(makeItem(ctx.sessionId, "info", `Found ${searchPayload.skills.length} matching skills on ClawHub. Use the slug shown below:`, "*", { view: "list", title: "ClawHub Search Results (use slug@clawhub to install)", items }));
+                  ctx.addItem(makeItem(ctx.sessionId, "info", `Found ${searchPayload.skills.length} matching skills on ClawHub. Use the slug shown below:`, "*", { view: "list", title: "ClawHub Search Results", items }));
                 } else {
                   // Search also requires token — if token error, give guidance
                   if (searchPayload.detail_key === "skills.clawhub.errors.tokenNotConfigured") {

--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/skills.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/skills.ts
@@ -263,9 +263,9 @@ export function createSkillsCommand(): SlashCommand {
             let slug = clawhubPart;
             let ownerHandle: string | undefined;
             if (clawhubPart.includes("/")) {
-              const [owner, s] = clawhubPart.split("/");
-              ownerHandle = owner;
-              slug = s;
+              const slashIdx = clawhubPart.indexOf("/");
+              ownerHandle = clawhubPart.substring(0, slashIdx);
+              slug = clawhubPart.substring(slashIdx + 1);
             }
             ctx.addItem(makeItem(ctx.sessionId, "info", `Installing from ClawHub: ${slug}`));
             const downloadPayload = await ctx.request<{ success?: boolean; detail?: string; detail_key?: string; skill?: { name?: string; source?: string } }>(

--- a/jiuwenswarm/channels/web/frontend/src/features/ClawHubSearchModal/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/features/ClawHubSearchModal/index.tsx
@@ -40,6 +40,7 @@ type ClawHubSkillItem = {
   summary: string;
   version: string;
   updated_at: number;
+  owner_handle: string;
 };
 
 interface ClawHubSearchModalProps {
@@ -256,7 +257,7 @@ export function ClawHubSearchModal({
         skill?: { name: string };
       }>(
         "skills.clawhub.download",
-        withSession({ slug, force: forceOverwrite })
+        withSession({ slug, owner_handle: item.owner_handle, force: forceOverwrite })
       );
       if (!data.success) {
         const message = data.detail_key

--- a/jiuwenswarm/channels/web/frontend/src/features/ClawHubSearchModal/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/features/ClawHubSearchModal/index.tsx
@@ -348,7 +348,7 @@ export function ClawHubSearchModal({
                   const avatar = getSkillAvatar(item.slug);
                   return (
                     <div
-                      key={item.slug}
+                      key={item.owner_handle ? `${item.owner_handle}/${item.slug}` : item.slug}
                       className={`p-4 rounded-lg border border-border bg-panel ${viewMode === "grid" ? "flex flex-col" : "flex items-start justify-between gap-4"}`}
                       style={viewMode === "grid" ? { width: "496px", height: "168px", flexShrink: 0 } : undefined}
                     >
@@ -632,7 +632,7 @@ export function ClawHubSearchModal({
                     const avatar = getSkillAvatar(item.slug);
                     return (
                       <div
-                        key={item.slug}
+                      key={item.owner_handle ? `${item.owner_handle}/${item.slug}` : item.slug}
                         className="p-4 rounded-lg border border-border bg-panel flex items-start justify-between gap-4"
                       >
                         <div className="flex items-center gap-3 min-w-0 flex-1">

--- a/jiuwenswarm/server/runtime/skill/skill_manager.py
+++ b/jiuwenswarm/server/runtime/skill/skill_manager.py
@@ -1144,6 +1144,7 @@ class SkillManager:
                             "summary": item.get("summary", ""),
                             "version": item.get("version", ""),
                             "updated_at": item.get("updatedAt", 0),
+                            "owner_handle": item.get("ownerHandle", ""),
                         }
                     )
 
@@ -1174,6 +1175,7 @@ class SkillManager:
 
         params:
             slug: skill slug (必需)
+            owner_handle: 发布者标识 (可选，slug 有多个发布者时必需)
             version: 版本号 (可选，默认 latest)
             tag: 标签 (可选，如 latest)
             force: 强制覆盖 (可选，默认 False)
@@ -1195,6 +1197,7 @@ class SkillManager:
                 "detail_key": "skills.clawhub.errors.tokenNotConfigured",
             }
 
+        owner_handle = str(params.get("owner_handle") or "").strip()
         version = params.get("version")
         tag = params.get("tag")
         force = bool(params.get("force", False))
@@ -1217,6 +1220,8 @@ class SkillManager:
                 headers["Authorization"] = f"Bearer {token}"
 
             download_params = {"slug": slug}
+            if owner_handle:
+                download_params["ownerHandle"] = owner_handle
             if version:
                 download_params["version"] = version
             if tag:

--- a/tests/unit_tests/agentserver/test_skill_manager_clawhub_owner_handle.py
+++ b/tests/unit_tests/agentserver/test_skill_manager_clawhub_owner_handle.py
@@ -1,0 +1,250 @@
+import json
+
+import pytest
+
+from jiuwenswarm.server.runtime.skill.skill_manager import SkillManager
+
+
+class _FakeSearchResponse:
+    def __init__(self, data: dict):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    @staticmethod
+    def raise_for_status():
+        return None
+
+
+class _FakeSearchClient:
+    def __init__(self, results: list[dict]):
+        self._results = results
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, *, params, headers):
+        assert url == "https://clawhub.ai/api/v1/search"
+        assert "q" in params
+        return _FakeSearchResponse({"results": self._results})
+
+
+class _FakeDownloadResponse:
+    def __init__(self, status_code: int, text: str = "", content: bytes = b""):
+        self.status_code = status_code
+        self.text = text
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+            raise httpx.HTTPStatusError(
+                message=f"Client error '{self.status_code}'",
+                request=httpx.Request("GET", "https://clawhub.ai/api/v1/download"),
+                response=self,
+            )
+
+
+class _FakeDownloadClient:
+    def __init__(self, status_code: int = 200, text: str = "", content: bytes = b""):
+        self._status_code = status_code
+        self._text = text
+        self._content = content
+        self._captured_params: dict | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, *, params, headers):
+        assert url == "https://clawhub.ai/api/v1/download"
+        self._captured_params = params
+        return _FakeDownloadResponse(
+            status_code=self._status_code,
+            text=self._text,
+            content=self._content,
+        )
+
+    def get_captured_params(self) -> dict | None:
+        return self._captured_params
+
+
+@pytest.mark.asyncio
+async def test_clawhub_search_returns_owner_handle(tmp_path, monkeypatch):
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    fake_results = [
+        {
+            "slug": "ppt-generator",
+            "displayName": "PPT Generator",
+            "summary": "Generate PPT",
+            "version": "1.0.0",
+            "updatedAt": 1000000,
+            "ownerHandle": "kirkraman",
+        },
+        {
+            "slug": "ppt-generator",
+            "displayName": "PPT Gen 2",
+            "summary": "Another PPT",
+            "version": "2.0.0",
+            "updatedAt": 2000000,
+            "ownerHandle": "wwlyzzyorg",
+        },
+    ]
+
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: _FakeSearchClient(fake_results),
+    )
+
+    result = await manager.handle_skills_clawhub_search({"q": "ppt-generator", "limit": 50})
+
+    assert result["success"] is True
+    assert len(result["skills"]) == 2
+    assert result["skills"][0]["owner_handle"] == "kirkraman"
+    assert result["skills"][1]["owner_handle"] == "wwlyzzyorg"
+
+
+@pytest.mark.asyncio
+async def test_clawhub_search_owner_handle_missing_is_empty_string(tmp_path, monkeypatch):
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    fake_results = [
+        {
+            "slug": "unique-skill",
+            "displayName": "Unique Skill",
+            "summary": "Only one publisher",
+            "version": "1.0.0",
+            "updatedAt": 1000000,
+        },
+    ]
+
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: _FakeSearchClient(fake_results),
+    )
+
+    result = await manager.handle_skills_clawhub_search({"q": "unique-skill"})
+
+    assert result["success"] is True
+    assert result["skills"][0]["owner_handle"] == ""
+
+
+@pytest.mark.asyncio
+async def test_clawhub_download_passes_owner_handle_to_api(tmp_path, monkeypatch):
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    fake_client = _FakeDownloadClient(status_code=400, text="error")
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: fake_client,
+    )
+
+    await manager.handle_skills_clawhub_download(
+        {"slug": "ppt-generator", "owner_handle": "kirkraman"}
+    )
+
+    captured = fake_client.get_captured_params()
+    assert captured is not None
+    assert captured["slug"] == "ppt-generator"
+    assert captured["ownerHandle"] == "kirkraman"
+
+
+@pytest.mark.asyncio
+async def test_clawhub_download_without_owner_handle_omits_param(tmp_path, monkeypatch):
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    fake_client = _FakeDownloadClient(status_code=400, text="error")
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: fake_client,
+    )
+
+    await manager.handle_skills_clawhub_download({"slug": "unique-skill"})
+
+    captured = fake_client.get_captured_params()
+    assert captured is not None
+    assert captured["slug"] == "unique-skill"
+    assert "ownerHandle" not in captured
+
+
+@pytest.mark.asyncio
+async def test_clawhub_download_empty_owner_handle_omits_param(tmp_path, monkeypatch):
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    fake_client = _FakeDownloadClient(status_code=400, text="error")
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: fake_client,
+    )
+
+    await manager.handle_skills_clawhub_download(
+        {"slug": "unique-skill", "owner_handle": ""}
+    )
+
+    captured = fake_client.get_captured_params()
+    assert captured is not None
+    assert "ownerHandle" not in captured
+
+
+@pytest.mark.asyncio
+async def test_install_skill_parses_owner_handle_from_identifier(tmp_path, monkeypatch):
+    from jiuwenswarm.agents.harness.common.tools.skill_toolkits import SkillToolkit
+
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    toolkit = SkillToolkit(manager=manager)
+
+    fake_client = _FakeDownloadClient(status_code=400, text="error")
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: fake_client,
+    )
+
+    result = await toolkit.install_skill(
+        identifier="kirkraman/ppt-generator",
+        source="clawhub",
+    )
+
+    captured = fake_client.get_captured_params()
+    assert captured is not None
+    assert captured["slug"] == "ppt-generator"
+    assert captured["ownerHandle"] == "kirkraman"
+
+
+@pytest.mark.asyncio
+async def test_install_skill_plain_slug_no_owner_handle(tmp_path, monkeypatch):
+    from jiuwenswarm.agents.harness.common.tools.skill_toolkits import SkillToolkit
+
+    manager = SkillManager(workspace_dir=str(tmp_path / "workspace"))
+    await manager.handle_skills_clawhub_set_token({"token": "test-token"})
+
+    toolkit = SkillToolkit(manager=manager)
+
+    fake_client = _FakeDownloadClient(status_code=400, text="error")
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.skill.skill_manager.httpx.AsyncClient",
+        lambda timeout: fake_client,
+    )
+
+    result = await toolkit.install_skill(
+        identifier="unique-skill",
+        source="clawhub",
+    )
+
+    captured = fake_client.get_captured_params()
+    assert captured is not None
+    assert captured["slug"] == "unique-skill"
+    assert "ownerHandle" not in captured


### PR DESCRIPTION
ClawHub download API returns 409 when multiple publishers share the same slug. Add owner_handle pass-through so the download request includes ownerHandle to uniquely identify the skill.

- skill_manager: search returns owner_handle; download accepts and forwards owner_handle as ownerHandle to ClawHub API
- web frontend: ClawHubSkillItem type adds owner_handle; install request passes owner_handle
- TUI frontend: support ownerHandle/slug@clawhub install format; download request passes owner_handle
- skill_toolkits: parse ownerHandle/slug from identifier

Refs:#1873

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <label>


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->


## 现象

技能源管理选择 ClawHub，搜索 "ppt-generator" 安装，提示：**请求失败，请检查token或者访问太频繁，稍后重试**。尝试了3个不同 CLI Token 均报相同错误。

## 根因

**ClawHub download API (`/api/v1/download?slug=ppt-generator`) 返回 HTTP 409 Conflict**，错误信息为：

> Ambiguous skill slug "ppt-generator". Multiple publishers use this slug. Retry with ownerHandle, for example: /api/v1/download?slug=ppt-generator&ownerHandle=<owner>.

ClawHub 上同一个 slug 可以有多个发布者（如 `ppt-generator@wwlyzzyorg`、`ppt-generator@kirkraman` 等），`slug` 本身不是唯一标识，**`ownerHandle + slug` 组合才是唯一标识**。

当前代码只传了 `slug`，未传 `ownerHandle`，导致 API 无法区分具体要下载哪个发布者的技能，返回 409。

后端对所有 HTTP 错误统一返回 `detail_key: "skills.clawhub.errors.httpError"`，前端映射为 **"请求失败，请检查token或者访问太频繁，稍后重试"**，实际是 409（slug 冲突）而非 401（token 错误）或 429（频率限制），导致提示信息误导用户。

## 修改方案

### 1. 后端 skill_manager.py

- **搜索接口** `handle_skills_clawhub_search`：从 ClawHub API 搜索结果中提取 `ownerHandle` 字段，以 `owner_handle` 为 key 透传给前端
- **下载接口** `handle_skills_clawhub_download`：新增可选参数 `owner_handle`，当值非空时将其作为 `ownerHandle` 参数传给 ClawHub download API

### 2. Web 前端 ClawHubSearchModal

- **ClawHubSkillItem 类型**：新增 `owner_handle: string` 字段，接收后端搜索结果中的 `owner_handle`
- **安装请求**：调用 `skills.clawhub.download` 时，将 `item.owner_handle` 作为 `owner_handle` 参数一并传入

### 3. TUI 前端 skills.ts

- **安装命令格式**：支持 `ownerHandle/slug@clawhub` 格式（如 `kirkraman/ppt-generator@clawhub`），从中解析出 `ownerHandle` 和 `slug`
- **安装请求**：调用 `skills.clawhub.download` 时传入 `owner_handle` 参数；原有纯 `slug@clawhub` 格式保持兼容，`owner_handle` 为空时不传

### 4. skill_toolkits.py (Agent 安装技能)

- **install_skill**：当 `identifier` 包含 `/` 时（如 `kirkraman/ppt-generator`），从中解析出 `ownerHandle` 和 `slug`，分别传给 `handle_skills_clawhub_download`

## 自验证：
配置clawhub token：
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/5cca54ac-abc5-408b-abfa-5a4f2f74959d" />
下载ppt-generator
<img width="1898" height="834" alt="image" src="https://github.com/user-attachments/assets/2dc48036-8ab9-4864-8374-1ee3fc49552e" />
我的技能可以看到已安装ppt-generator
<img width="1910" height="714" alt="image" src="https://github.com/user-attachments/assets/7971f7b6-7c0c-4407-86f2-58ef5bcb2739" />
调用ppt-generator skill
<img width="1584" height="856" alt="image" src="https://github.com/user-attachments/assets/856a2e63-fe8b-4f20-b976-1a401b4e01df" />


<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1021
<!-- /bot1-related-issues -->
