### PR TITLE
fix(session): prevent metadata clobber that erases session identity

### DIFF
--- a/jiuwenswarm/server/runtime/agent_adapter/team_helpers.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/team_helpers.py
@@ -479,6 +479,16 @@ def persist_workflow_runs(runs: dict[str, WorkflowRunState], session_id: str) ->
     from jiuwenswarm.server.runtime.session.session_metadata import _read_metadata, _enqueue_write
     runs_data = {run_id: run_state.model_dump() for run_id, run_state in runs.items()}
     metadata = _read_metadata(session_id, cache_bust=True)
+    if not metadata.get("session_id"):
+        # Do not blindly write back after a failed read (e.g. a concurrent
+        # write window): the write replaces the whole file and would erase
+        # session_id/title. Skip this persist; the next delta retries.
+        logger.warning(
+            "[TeamHelpers] skipping workflow_runs persist: failed to read "
+            "session metadata (session_id=%s)",
+            session_id,
+        )
+        return
     metadata[_WORKFLOW_RUNS_STATE_KEY] = runs_data
     _enqueue_write(session_id, metadata)
 

--- a/jiuwenswarm/server/runtime/session/session_metadata.py
+++ b/jiuwenswarm/server/runtime/session/session_metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import queue
 import re
 import shutil
@@ -26,7 +27,10 @@ logger = logging.getLogger(__name__)
 _METADATA_QUEUE: queue.Queue[tuple[str, dict[str, Any], bool]] = queue.Queue(maxsize=5000)
 _WORKER_STARTED = False
 _WORKER_LOCK = threading.Lock()
-_FILE_LOCK = threading.Lock()
+# Reentrant: the read path now holds this lock too (see _read_metadata).
+# RLock guards against a same-thread nesting (read->write or write->read)
+# deadlocking in the future.
+_FILE_LOCK = threading.RLock()
 
 # 内存缓存: 解决异步写入时读取到陈旧磁盘数据的竞态条件
 _METADATA_CACHE: dict[str, dict[str, Any]] = {}
@@ -293,13 +297,42 @@ def _read_metadata(session_id: str, cache_bust: bool = False) -> dict[str, Any]:
     fpath = get_agent_sessions_dir() / session_id / "metadata.json"
     if not fpath.exists():
         return {}
+    # Reading must be mutually exclusive with _write_metadata_sync: the writer
+    # replaces the whole file, so an unlocked read can land inside the
+    # replacement window and observe empty content.
     try:
-        data = json.loads(fpath.read_text(encoding="utf-8") or '{}')
-        if isinstance(data, dict):
-            return data
-    except Exception as exc:
-        logger.warning("读取 metadata.json 失败: %s", exc)
-    return {}
+        with _FILE_LOCK:
+            raw = fpath.read_text(encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to read metadata.json: %s (session_id=%s)", exc, session_id,
+        )
+        return {}
+    if not raw.strip():
+        # An empty file is a FAILURE, not "empty metadata". It must never be
+        # returned as a valid {}: callers do read-modify-write and would write
+        # the empty dict back, erasing session_id/title and other identity
+        # fields, leaving the session without an ID and impossible to open.
+        logger.warning(
+            "metadata.json is empty, treating as read failure (session_id=%s)",
+            session_id,
+        )
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to parse metadata.json: %s (session_id=%s, size=%d)",
+            exc, session_id, len(raw),
+        )
+        return {}
+    if not isinstance(data, dict):
+        logger.warning(
+            "metadata.json content is not a dict: %s (session_id=%s)",
+            type(data).__name__, session_id,
+        )
+        return {}
+    return data
 
 
 def _write_metadata_sync(
@@ -316,17 +349,44 @@ def _write_metadata_sync(
     fpath = _metadata_file(session_id)
     to_write = metadata
     with _FILE_LOCK:
-        if preserve_pin_fields and fpath.exists():
+        current: dict[str, Any] | None = None
+        if fpath.exists():
             try:
-                current = json.loads(fpath.read_text(encoding="utf-8") or "{}")
-                if isinstance(current, dict):
-                    to_write = _merge_pin_fields(current, metadata)
+                raw = fpath.read_text(encoding="utf-8")
+                parsed = json.loads(raw) if raw.strip() else None
+                if isinstance(parsed, dict):
+                    current = parsed
             except Exception as exc:  # noqa: BLE001
-                logger.warning("读取 metadata.json 置顶字段失败: %s", exc)
-        fpath.write_text(
-            json.dumps(to_write, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+                logger.warning("failed to read metadata.json: %s", exc)
+
+        # Identity guard: a caller that received an empty/partial dict and
+        # writes it back would permanently erase session_id, title, created_at
+        # and friends (writes replace the whole file, they do not merge). When
+        # disk has an identity and the incoming payload does not, treat it as a
+        # race-induced dirty write and restore the missing fields.
+        if current and current.get("session_id") and not metadata.get("session_id"):
+            recovered = {k: v for k, v in current.items() if k not in metadata}
+            to_write = {**current, **metadata}
+            logger.warning(
+                "blocked overwrite of session identity (session_id=%s): payload "
+                "has no session_id, restored %d field(s) from disk: %s",
+                session_id, len(recovered), sorted(recovered),
+            )
+
+        if preserve_pin_fields and current is not None:
+            to_write = _merge_pin_fields(current, to_write)
+
+        # Atomic write: write a temp file then rename, so that truncation by
+        # write_text can never expose empty content to a concurrent reader
+        # (precisely how session identity was being lost).
+        payload = json.dumps(to_write, ensure_ascii=False, indent=2)
+        tmp = fpath.with_name(f"{fpath.name}.{os.getpid()}.tmp")
+        try:
+            tmp.write_text(payload, encoding="utf-8")
+            os.replace(tmp, fpath)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
     return to_write
 
 

--- a/tests/unit_tests/test_session_metadata.py
+++ b/tests/unit_tests/test_session_metadata.py
@@ -2100,6 +2100,143 @@ class TestSetSessionPinnedQueuedWriteRace:
         assert data["pin_order"] == 1
 
 
+# ===========================================================================
+# Session identity preservation under concurrent writes (regression tests)
+#
+# Background: _write_metadata_sync replaces the whole file; it does not merge
+# fields. The previous _read_metadata returned an empty file as a valid {}
+# (`read_text() or '{}'`) and did not hold _FILE_LOCK. Writers used write_text,
+# which truncates before writing, so a concurrent reader could land in the
+# truncation window, read "" -> get {} -> read-modify-write the empty dict back
+# -> session_id / title / created_at permanently erased. The session then loses
+# its ID in the list, cannot be opened, and session.pin fails with
+# "session_id is required".
+# ===========================================================================
+class TestIdentityPreservation:
+    @staticmethod
+    def _seed(sessions_dir: Path, sid: str = "sess_identity") -> Path:
+        d = sessions_dir / sid
+        d.mkdir(parents=True, exist_ok=True)
+        meta = {
+            "session_id": sid,
+            "channel_id": "web",
+            "created_at": 1700000000.0,
+            "title": "title must be preserved",
+            "team_name": f"jiuwen_team_{sid}",
+            "message_count": 3,
+            "mode": "team",
+        }
+        (d / "metadata.json").write_text(
+            json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        return d / "metadata.json"
+
+    @staticmethod
+    def test_empty_file_is_read_failure_not_empty_dict(sessions_dir, monkeypatch):
+        """An empty file must be treated as a read failure and logged, not silently
+        accepted as valid empty metadata.
+
+        Note: both implementations return {}, so the return value alone cannot
+        tell them apart. The real difference is whether the failed read is
+        recorded at all -- that silence is why this bug was so hard to trace.
+        """
+        import jiuwenswarm.server.runtime.session.session_metadata as sm
+
+        fpath = TestIdentityPreservation._seed(sessions_dir)
+        fpath.write_text("", encoding="utf-8")
+        sm._METADATA_CACHE.clear()
+
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            sm.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg) % a if a else str(msg))
+        )
+
+        assert sm._read_metadata("sess_identity", cache_bust=True) == {}
+        assert warnings, "empty file silently returned as a valid {} with no warning"
+
+    @staticmethod
+    def test_write_without_session_id_does_not_erase_identity(sessions_dir):
+        """When the payload lacks session_id, identity fields on disk must survive."""
+        import jiuwenswarm.server.runtime.session.session_metadata as sm
+
+        fpath = TestIdentityPreservation._seed(sessions_dir)
+        # Simulate a caller doing read-modify-write after getting an empty
+        # dict (real case: persist_workflow_runs reads empty, then writes back
+        # a payload carrying only workflow_runs).
+        sm._write_metadata_sync("sess_identity", {"workflow_runs": {"wf_1": {}}})
+
+        data = _read_json(fpath)
+        assert data["session_id"] == "sess_identity"
+        assert data["title"] == "title must be preserved"
+        assert data["created_at"] == 1700000000.0
+        assert data["team_name"] == "jiuwen_team_sess_identity"
+        # The new field is still written
+        assert data["workflow_runs"] == {"wf_1": {}}
+
+    @staticmethod
+    def test_write_is_atomic_no_empty_window(sessions_dir):
+        """A concurrent reader must never observe an empty file mid-write (atomic replace)."""
+        import jiuwenswarm.server.runtime.session.session_metadata as sm
+
+        fpath = TestIdentityPreservation._seed(sessions_dir)
+        big = {
+            "session_id": "sess_identity",
+            "title": "title must be preserved",
+            "created_at": 1700000000.0,
+            "blob": "x" * 200_000,
+        }
+        empties: list[str] = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    raw = fpath.read_text(encoding="utf-8")
+                except (FileNotFoundError, PermissionError):
+                    empties.append("missing")
+                    continue
+                if not raw.strip():
+                    empties.append("empty")
+
+        t = threading.Thread(target=reader, daemon=True)
+        t.start()
+        for i in range(60):
+            big["message_count"] = i
+            sm._write_metadata_sync("sess_identity", big)
+        stop.set()
+        t.join(timeout=3)
+
+        assert empties == [], f"observed {len(empties)} empty/missing reads: write is not atomic"
+
+    @staticmethod
+    def test_concurrent_persist_keeps_identity(sessions_dir):
+        """A normal write racing a new-field-only write must not erase identity."""
+        import jiuwenswarm.server.runtime.session.session_metadata as sm
+
+        fpath = TestIdentityPreservation._seed(sessions_dir)
+        stop = threading.Event()
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                i += 1
+                meta = sm._read_metadata("sess_identity", cache_bust=True)
+                if meta.get("session_id"):
+                    meta["message_count"] = i
+                    sm._write_metadata_sync("sess_identity", meta)
+
+        t = threading.Thread(target=writer, daemon=True)
+        t.start()
+        for i in range(200):
+            sm._write_metadata_sync("sess_identity", {"workflow_runs": {"n": i}})
+        stop.set()
+        t.join(timeout=3)
+
+        data = _read_json(fpath)
+        for key in ("session_id", "title", "created_at", "team_name"):
+            assert key in data, f"identity field {key} was lost after concurrent writes"
+
+
 def test_remove_team_mode_session_dirs_at_startup_keeps_stable_team_sessions(
     sessions_dir,
 ):


### PR DESCRIPTION
Paired: [GitHub #1081](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1081) ↔ [GitCode !3975](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/3975)

**What type of PR is this?**

/kind bug


**What does this PR do / why do we need it**:

A session whose SwarmFlow workflow ran to completion could permanently lose its
identity fields. The session then appears in the sidebar with an empty
`session_id`, cannot be opened, and `session.pin` fails with
`session_id is required`. Conversation history is untouched — only
`metadata.json` is damaged, so the data survives on disk but is unreachable
through the UI.

Root cause is a read/write race on `metadata.json`, built from four
individually harmless pieces:

1. `_write_metadata_sync` used `Path.write_text`, which **truncates** the file
   before writing. There is a window where the file exists but is empty.
2. `_read_metadata` read from disk **without holding `_FILE_LOCK`**, so it could
   land inside that window (the writer took the lock, the reader did not).
3. It then parsed the result as `json.loads(read_text() or '{}')`. The
   `or '{}'` turned an empty read into a **valid empty dict** — no exception,
   no log, no trace.
4. Callers do read-modify-write, and writes replace the whole file without
   merging. Writing that empty dict back erased `session_id`, `title`,
   `created_at`, `user_id`, `team_name` and `round_id`.

`persist_workflow_runs` is the most exposed caller because it runs on every
workflow progress delta — hundreds of times per run — which turns a roughly
1-in-120 race into a near certainty over one completed workflow. The signature
on disk is a `metadata.json` whose **first key is `workflow_runs` instead of
`session_id`**, only possible if the key was inserted into an empty dict.

Fixes, in layers, so that no single mistake is fatal:

- **`_read_metadata`**: an empty file is a read *failure*, not empty metadata.
  Every failure mode (I/O, invalid JSON, non-dict, empty) is logged with its
  `session_id` instead of failing silently.
- **`_read_metadata`**: hold `_FILE_LOCK` for disk reads so readers and writers
  are mutually exclusive. `_FILE_LOCK` becomes an `RLock` so a future
  same-thread nesting cannot deadlock.
- **`_write_metadata_sync`**: write to a temp file and `os.replace()` it,
  removing the truncation window entirely rather than only guarding against it.
- **`_write_metadata_sync`**: if the payload has no `session_id` but disk does,
  restore the missing fields and log it. Last-resort guard, independent of
  which caller misbehaves.
- **`persist_workflow_runs`**: skip persisting when the metadata read fails
  instead of writing over it; the next progress delta retries.

This generalises a defence the codebase already applies field by field — for
example the `model_selector` work guards that "an empty string must not clear an
existing value". This is the same hazard one level up: an empty *dict* clearing
the whole file.


**Which issue(s) this PR fixes**:

Fixes #

Related: #2515 ("钉钉或者飞书发起的对话，在jiuwenswarm界面会生成一个无法打开且无标识的对话").
The symptom reported there — a conversation that cannot be opened and has no
identifier — matches this failure exactly. I have **not** confirmed it is the
same root cause: that report comes from DingTalk/Feishu channels rather than a
SwarmFlow workflow. The race fixed here is not workflow-specific, so it is a
plausible but unverified match. Deliberately not using `Fixes` for that reason —
happy to link it if a maintainer confirms.


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

**Reliability — the race itself.** A harness ran `persist_workflow_runs`
concurrently with ordinary metadata writes, with no artificial file
manipulation, and inspected `metadata.json` only after both threads stopped and
the async write queue drained (so transient mid-write states are not measured).

| | before | after |
|---|---|---|
| 6 rounds x 250 concurrent persists | 6/6 permanently corrupted | **0/6** |
| 4 rounds x 800 concurrent persists | — | **0/4**, zero empty reads |
| high contention (writes every 0.3 ms) | first empty read at iteration 1–23 | **never reached, 5/5 runs** |

Every corrupted file before the fix showed the production signature: first key
`workflow_runs`, and `session_id` / `title` / `created_at` / `team_name` /
`round_id` gone.

**Function — regression tests.** Four tests added in
`tests/unit_tests/test_session_metadata.py::TestIdentityPreservation`:

| Test | Covers |
|---|---|
| `test_empty_file_is_read_failure_not_empty_dict` | an empty read is logged, not silently accepted |
| `test_write_without_session_id_does_not_erase_identity` | the identity guard restores disk fields |
| `test_write_is_atomic_no_empty_window` | a concurrent reader never observes an empty file |
| `test_concurrent_persist_keeps_identity` | identity survives concurrent writers |

All four **fail on `develop` and pass on this branch** — verified by reverting
only the product file and re-running:

```
develop:      4 failed
  - "empty file silently returned as a valid {} with no warning"
  - KeyError: 'session_id'
  - "observed 52 empty/missing reads: write is not atomic"
  - "identity field session_id was lost after concurrent writes"
this branch:  4 passed
```

**Regression scope.** `uv run pytest tests/unit_tests/` — 277 passed, no
existing test changed behaviour, including `test_team_helpers.py`,
`test_command_workflows_handler.py`, `test_session_ops_fork.py`,
`test_project_handlers.py` and `test_work_mode.py`.

**Performance.** `_write_metadata_sync` now reads the existing file on every
write rather than only when `preserve_pin_fields=True`, which is the cost of the
identity guard. The function already performed write I/O under the same lock, so
the added read is marginal. The atomic write replaces one `write_text` with a
temp write plus `os.replace`, both of which stay inside the existing
`_FILE_LOCK` critical section.

**Known limitation (pre-existing, out of scope).** `_FILE_LOCK` is per-process,
and the Gateway and AgentServer both write this file, so cross-process
read-modify-write is still not atomic and a lost update remains theoretically
possible. What this PR guarantees is that the identity fields can no longer be
erased. A complete fix would need cross-process file locking, similar to what
was done for `cronJobStore`.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [x] **Document**: Does it involve modifications to official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

> **Design** is left unchecked on purpose: this is an unsolicited bugfix and the
> approach has not been reviewed by a Maintainer yet. Happy to adjust the
> approach if the layered fix is not the direction you want.
>
> **Interface**: no external interface changes — `_read_metadata` and
> `_write_metadata_sync` are private helpers, and their signatures are unchanged.
>
> **Document**: no documentation changes required; behaviour is restored to what
> the docs already describe.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1032
<!-- /bot1-related-issues -->