### PR TITLE
fix:生成多余-p文件夹

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/command_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/command_tools.py
@@ -207,6 +207,68 @@ _POSIX_COMMANDS = frozenset({
 })
 _QUOTED_WINDOWS_PATH_PATTERN = re.compile(r"(?P<quote>['\"])(?P<path>[A-Za-z]:\\[^'\"]+)(?P=quote)")
 _UNQUOTED_WINDOWS_PATH_PATTERN = re.compile(r"(?<![\w/])(?P<path>[A-Za-z]:\\[^\s|&;]+)")
+_POSIX_CMD_FLAGS_SILENT_ON_CMD = {
+    "mkdir": frozenset({"-p"}),
+}
+
+
+def _translate_mkdir_p_to_powershell(segment: str) -> str | None:
+    try:
+        tokens = shlex.split(segment, posix=False)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+    base = _strip_matching_quotes(tokens[0]).rsplit("/", maxsplit=1)[-1].rsplit("\\", maxsplit=1)[-1].lower()
+    if base.endswith(".exe"):
+        base = base[:-4]
+    if base != "mkdir":
+        return None
+    has_p = False
+    paths: list[str] = []
+    other_flags: list[str] = []
+    for tok in tokens[1:]:
+        stripped = _strip_matching_quotes(tok)
+        if stripped == "-p" or stripped == "--parents":
+            has_p = True
+        elif stripped.startswith("-"):
+            other_flags.append(stripped)
+        else:
+            paths.append(tok)
+    if not has_p:
+        return None
+    if other_flags:
+        return None
+    if not paths:
+        return None
+    items = []
+    for p in paths:
+        bare = _strip_matching_quotes(p)
+        escaped = bare.replace("'", "''")
+        items.append(f"New-Item -ItemType Directory -Path '{escaped}' -Force")
+    return "; ".join(items)
+
+
+def _translate_posix_segment_for_powershell(segment: str) -> str | None:
+    try:
+        tokens = shlex.split(segment, posix=False)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+    base = _strip_matching_quotes(tokens[0]).rsplit("/", maxsplit=1)[-1].rsplit("\\", maxsplit=1)[-1].lower()
+    if base.endswith(".exe"):
+        base = base[:-4]
+    if base == "mkdir":
+        return _translate_mkdir_p_to_powershell(segment)
+    return None
+
+
+def _translate_posix_for_powershell(command: str) -> str | None:
+    segments = _split_shell_segments(command)
+    if len(segments) != 1:
+        return None
+    return _translate_posix_segment_for_powershell(segments[0])
 
 
 def _clip_text(value: str, max_chars: int) -> str:
@@ -560,6 +622,12 @@ def _resolve_execution_plan(command: str, shell_type: str) -> tuple[list[str] | 
                 exe = _available_bash(allow_wsl=False)
                 if exe:
                     return [exe, "-lc", _normalize_windows_paths_for_bash(command)], False, "bash"
+                translated = _translate_posix_for_powershell(command)
+                ps_exe = _available_powershell()
+                if translated is not None and ps_exe:
+                    return [ps_exe, "-NoProfile", "-NonInteractive", "-Command", translated], False, "powershell"
+                if ps_exe:
+                    return [ps_exe, "-NoProfile", "-NonInteractive", "-Command", command], False, "powershell"
             normalized = "cmd"
         if normalized == "powershell":
             exe = _available_powershell()

--- a/jiuwenswarm/agents/harness/common/tools/command_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/command_tools.py
@@ -207,9 +207,6 @@ _POSIX_COMMANDS = frozenset({
 })
 _QUOTED_WINDOWS_PATH_PATTERN = re.compile(r"(?P<quote>['\"])(?P<path>[A-Za-z]:\\[^'\"]+)(?P=quote)")
 _UNQUOTED_WINDOWS_PATH_PATTERN = re.compile(r"(?<![\w/])(?P<path>[A-Za-z]:\\[^\s|&;]+)")
-_POSIX_CMD_FLAGS_SILENT_ON_CMD = {
-    "mkdir": frozenset({"-p"}),
-}
 
 
 def _translate_mkdir_p_to_powershell(segment: str) -> str | None:

--- a/tests/unit_tests/agents/test_command_tools_posix_windows.py
+++ b/tests/unit_tests/agents/test_command_tools_posix_windows.py
@@ -1,0 +1,221 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.tools.command_tools import (
+    _looks_like_posix,
+    _resolve_execution_plan,
+    _split_shell_segments,
+    _translate_mkdir_p_to_powershell,
+    _translate_posix_for_powershell,
+    _translate_posix_segment_for_powershell,
+    _available_bash,
+    _available_powershell,
+)
+
+
+# ── _translate_mkdir_p_to_powershell ────────────────────────────────
+
+
+class TestTranslateMkdirP:
+    @pytest.mark.parametrize(
+        "command, expected",
+        [
+            ("mkdir -p dir", "New-Item -ItemType Directory -Path 'dir' -Force"),
+            ("mkdir -p a/b/c", "New-Item -ItemType Directory -Path 'a/b/c' -Force"),
+            ("mkdir -p 'path with spaces'", "New-Item -ItemType Directory -Path 'path with spaces' -Force"),
+            ("mkdir -p a b c", "New-Item -ItemType Directory -Path 'a' -Force; New-Item -ItemType Directory -Path 'b' -Force; New-Item -ItemType Directory -Path 'c' -Force"),
+            ("mkdir --parents dir", "New-Item -ItemType Directory -Path 'dir' -Force"),
+            ("mkdir -p dir/subdir", "New-Item -ItemType Directory -Path 'dir/subdir' -Force"),
+        ],
+    )
+    def test_translates_mkdir_p(self, command: str, expected: str) -> None:
+        assert _translate_mkdir_p_to_powershell(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "mkdir dir",
+            "mkdir -p",
+            "mkdir -p dir -v",
+            "mkdir -p dir -m 755",
+            "ls -la",
+            "cat file.txt",
+            "",
+        ],
+    )
+    def test_returns_none_for_untranslatable(self, command: str) -> None:
+        assert _translate_mkdir_p_to_powershell(command) is None
+
+    @pytest.mark.parametrize(
+        "command, expected",
+        [
+            ("mkdir -p 'path with \"quotes\"'", "New-Item -ItemType Directory -Path 'path with \"quotes\"' -Force"),
+            ('mkdir -p "$(Start-Process calc)"', "New-Item -ItemType Directory -Path '$(Start-Process calc)' -Force"),
+            ('mkdir -p "$env:TEMP"', "New-Item -ItemType Directory -Path '$env:TEMP' -Force"),
+            ("mkdir -p \"it's here\"", "New-Item -ItemType Directory -Path 'it''s here' -Force"),
+        ],
+    )
+    def test_injection_vectors_neutralized(self, command: str, expected: str) -> None:
+        assert _translate_mkdir_p_to_powershell(command) == expected
+
+
+# ── _translate_posix_segment_for_powershell ─────────────────────────
+
+
+class TestTranslatePosixSegment:
+    def test_translates_mkdir_p_segment(self) -> None:
+        assert _translate_posix_segment_for_powershell("mkdir -p dir") is not None
+
+    def test_returns_none_for_ls(self) -> None:
+        assert _translate_posix_segment_for_powershell("ls -la") is None
+
+    def test_returns_none_for_empty(self) -> None:
+        assert _translate_posix_segment_for_powershell("") is None
+
+    def test_returns_none_for_mkdir_without_p(self) -> None:
+        assert _translate_posix_segment_for_powershell("mkdir dir") is None
+
+
+# ── _translate_posix_for_powershell ─────────────────────────────────
+
+
+class TestTranslatePosixForPowershell:
+    def test_translates_single_mkdir_p(self) -> None:
+        result = _translate_posix_for_powershell("mkdir -p dir")
+        assert result == "New-Item -ItemType Directory -Path 'dir' -Force"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "mkdir -p dir && echo done",
+            "mkdir -p dir; ls",
+            "ls -la",
+            "echo hello",
+        ],
+    )
+    def test_returns_none_for_compound_or_untranslatable(self, command: str) -> None:
+        assert _translate_posix_for_powershell(command) is None
+
+
+# ── _looks_like_posix ───────────────────────────────────────────────
+
+
+class TestLooksLikePosix:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "mkdir -p dir",
+            "ls -la",
+            "cat file.txt",
+            "grep pattern file",
+            "find . -name '*.py'",
+            "rm -rf dir",
+            "touch file.txt",
+            "chmod 755 script.sh",
+            "ls && cat file.txt",
+            "mkdir dir; ls",
+        ],
+    )
+    def test_detects_posix_commands(self, command: str) -> None:
+        assert _looks_like_posix(command) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo hello",
+            "python script.py",
+            "git status",
+            "npm install",
+            "dir /s pattern",
+            "powershell Get-ChildItem",
+        ],
+    )
+    def test_rejects_non_posix_commands(self, command: str) -> None:
+        assert _looks_like_posix(command) is False
+
+    def test_empty_command(self) -> None:
+        assert _looks_like_posix("") is False
+
+
+# ── _resolve_execution_plan on Windows ──────────────────────────────
+
+
+class TestResolveExecutionPlanWindows:
+    @pytest.fixture(autouse=True)
+    def _require_windows(self) -> None:
+        if os.name != "nt":
+            pytest.skip("Windows-only tests")
+
+    @pytest.fixture()
+    def _no_bash(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.command_tools._available_bash",
+            lambda **kw: None,
+        )
+
+    @pytest.fixture()
+    def _with_bash(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "jiuwenswarm.agents.harness.common.tools.command_tools._available_bash",
+            lambda **kw: "C:\\Program Files\\Git\\bin\\bash.exe",
+        )
+
+    def test_mkdir_p_translated_to_powershell_when_no_bash(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir -p dir", "auto")
+        assert resolved_shell == "powershell"
+        assert use_shell is False
+        assert "New-Item" in plan[-1]
+        assert "-ItemType Directory" in plan[-1]
+
+    def test_mkdir_p_uses_bash_when_available(self, _with_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir -p dir", "auto")
+        assert resolved_shell == "bash"
+        assert use_shell is False
+
+    def test_ls_routes_to_powershell_when_no_bash(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("ls", "auto")
+        assert resolved_shell == "powershell"
+        assert use_shell is False
+
+    def test_non_posix_stays_on_cmd(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("echo hello", "auto")
+        assert resolved_shell == "cmd"
+        assert use_shell is True
+
+    def test_compound_posix_routes_to_powershell_raw_when_no_bash(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir -p dir && echo done", "auto")
+        assert resolved_shell == "powershell"
+        assert use_shell is False
+
+    def test_mkdir_without_p_routes_to_powershell_when_no_bash(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir dir", "auto")
+        assert resolved_shell == "powershell"
+        assert use_shell is False
+
+    def test_mkdir_p_nested_path_translated(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir -p output/slides", "auto")
+        assert resolved_shell == "powershell"
+        assert "New-Item" in plan[-1]
+        assert "output/slides" in plan[-1]
+
+    def test_mkdir_p_with_spaces_translated(self, _no_bash) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir -p \"path with spaces\"", "auto")
+        assert resolved_shell == "powershell"
+        assert "New-Item" in plan[-1]
+        assert "path with spaces" in plan[-1]
+
+
+class TestResolveExecutionPlanNonWindows:
+    @pytest.fixture(autouse=True)
+    def _require_non_windows(self) -> None:
+        if os.name == "nt":
+            pytest.skip("Non-Windows-only tests")
+
+    def test_auto_routes_to_bash(self) -> None:
+        plan, use_shell, resolved_shell = _resolve_execution_plan("mkdir -p dir", "auto")
+        assert resolved_shell in ("bash", "sh")


### PR DESCRIPTION
Paired: [GitHub #1085](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1085) ↔ [GitCode !3978](https://gitcode.com/openJiuwen/jiuwenswarm/pull/3978)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <label>


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
<!--  Thanks for sending a pull request!  Here are some tips for you:

## 现象

在已注入 Windows 指令的情况下，LLM 使用 bash 工具创建目录时生成错误指令，导致在 Windows 下执行 Linux 的 `mkdir -p` 命令。cmd.exe 的 `mkdir` 不支持 `-p` 参数，将其当作字面目录名，**静默创建名为 `-p` 的目录**，且命令返回 exit_code=0（无报错），Agent 无法感知并处理这种异常。

典型场景：复杂 PPT 生成任务下，Agent 由于长上下文遗忘当前操作系统，默认按 Linux 环境生成 `mkdir -p output/slides`，实际运行在 Windows 环境下，导致目录树中出现 `-p` 文件夹。

## 根因

根因在 `command_tools.py` 的 `_resolve_execution_plan()` 函数（原代码 L559-563），**POSIX 命令在无 bash 可用的 Windows 上降级到 cmd 时，缺少转换/拦截机制**。

### Bug 触发链路

```
LLM 生成 "mkdir -p some_dir"
    ↓
mcp_exec_command(shell_type="auto")
    ↓
_resolve_execution_plan()
    ↓
_looks_like_posix("mkdir -p some_dir") → True     # "mkdir" 在 _POSIX_COMMANDS 中
    ↓
_available_bash(allow_wsl=False) → None            # 无 Git Bash 可用
    ↓
normalized = "cmd"                                  # 直接降级到 cmd，无任何拦截
    ↓
return command, True, "cmd"                          # 原命令原样传给 cmd.exe
    ↓
cmd.exe mkdir -p some_dir                            # -p 被当作目录名，静默创建 "-p" 目录
```

### 根因总结

| 层面 | 缺失 | 位置 |
|------|------|------|
| **执行层（硬约束）** | POSIX 命令降级到 cmd 时无转换/拦截逻辑 | `command_tools.py` L559-563 |
| **反馈层** | cmd.exe 执行 `mkdir -p` 不报错，Agent 无法感知异常 | `command_tools.py` L568-569 |

### Bug 触发条件

| 条件 | 说明 |
|------|------|
| OS | Windows（`os.name == "nt"`） |
| Git Bash | 未安装（`_available_bash(allow_wsl=False)` 返回 None） |
| 命令 | 包含 `_POSIX_COMMANDS` 中的命令且带 Linux 参数，如 `mkdir -p` |
| shell_type | `"auto"`（默认值） |

## 修复方案

仅在 **`command_tools.py` 执行层**添加硬约束，`shell_environment.py` Shell 选择规则保持原版不变。

### 1. 新增 POSIX→PowerShell 翻译函数

将 `mkdir -p <path>` 翻译为 PowerShell 语义等价命令 `New-Item -ItemType Directory -Path <path> -Force`：

```python
# command_tools.py L215-251
def _translate_mkdir_p_to_powershell(segment: str) -> str | None:
    # 解析命令，检测 -p/--parents 标志
    # 翻译为 New-Item -ItemType Directory -Path <path> -Force
    # 支持多路径、带空格路径
    # 有其他未知 flag 时返回 None（不翻译）
```

### 2. 新增 POSIX 翻译调度函数

```python
# command_tools.py L254-266
def _translate_posix_segment_for_powershell(segment: str) -> str | None:
    # 当前仅处理 mkdir -p，可扩展其他命令

# command_tools.py L269-273
def _translate_posix_for_powershell(command: str) -> str | None:
    # 仅处理单段命令（复合命令无法可靠重建分隔符）
```

### 3. 修改路由逻辑

`_resolve_execution_plan()` POSIX 命令无 bash 可用时，**优先翻译→PowerShell，其次原命令→PowerShell，最后才降级到 cmd**：

```python
# command_tools.py L623-632（修改后）
if _looks_like_posix(command):
    exe = _available_bash(allow_wsl=False)
    if exe:
        return [exe, "-lc", ...], False, "bash"
    # 新增：翻译 → PowerShell
    translated = _translate_posix_for_powershell(command)
    ps_exe = _available_powershell()
    if translated is not None and ps_exe:
        return [ps_exe, "-NoProfile", "-NonInteractive", "-Command", translated], False, "powershell"
    # 新增：不可翻译 → PowerShell（比 cmd 错误信息更明确）
    if ps_exe:
        return [ps_exe, "-NoProfile", "-NonInteractive", "-Command", command], False, "powershell"
normalized = "cmd"
```

### 修复效果对比

| 场景 | 修复前（无 Git Bash） | 修复后（无 Git Bash） | 有 Git Bash |
|------|----------------------|----------------------|------------|
| `mkdir -p dir` | cmd 静默创建 `-p` 目录 | PowerShell 翻译为 `New-Item` → 正确创建 | bash 正确执行（不变） |
| `mkdir -p a/b/c` | cmd 静默创建 `-p` 目录 | PowerShell 翻译为 `New-Item` → 正确创建 | bash 正确执行 |
| `mkdir dir`（无 -p） | cmd 执行 | PowerShell 执行 | bash 执行 |
| `ls` | cmd 报错 "ls 不是命令" | PowerShell 执行（有 alias） | bash 执行 |
| `rm -rf dir` | cmd 报错 | PowerShell 报错 `-rf` 参数不存在 → LLM 可自纠 | bash 执行 |
| `echo hello`（非 POSIX） | cmd 执行（不变） | cmd 执行（不变） | cmd 执行 |

### 三层防护

1. **翻译层**：`mkdir -p` → `New-Item -ItemType Directory -Force`，语义等价，正确创建嵌套目录
2. **路由层**：POSIX 命令无 bash 时路由 PowerShell（不再降级到 cmd），消除静默失败路径
3. **兜底层**：即使翻译失败，PowerShell 对不兼容参数报明确错误（而非 cmd 静默产生错误结果）

### 测试覆盖

新增 48 个测试用例（`test_command_tools_posix_windows.py`），覆盖翻译函数、路由逻辑、边界条件：

- `TestTranslateMkdirP`：6 个翻译正确用例 + 7 个不可翻译用例
- `TestTranslatePosixSegment`：4 个段级翻译测试
- `TestTranslatePosixForPowershell`：5 个完整翻译测试
- `TestLooksLikePosix`：11 个检测测试 + 6 个拒绝测试
- `TestResolveExecutionPlanWindows`：8 个路由测试（含 monkeypatch 模拟无 Git Bash）
- `TestResolveExecutionPlanNonWindows`：1 个非 Windows 路由测试

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1035
<!-- /bot1-related-issues -->