### PR TITLE
fix(LLM connectivity test): The test probe is hard-coded with temperature=0, which is incompatible with the model that locks the sampling parameters (the kimi-k3/gpt-5/o series).

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
+++ b/jiuwenswarm/gateway/channel_manager/web/app_web_handlers.py
@@ -1405,6 +1405,51 @@ def _project_info_payload(
     }
 
 
+def _resolve_model_config_obj_for_validate(model_name: str, params: dict[str, Any]) -> dict[str, Any]:
+    """从热更新后的配置中查找对应模型的 ``model_config_obj``。
+
+    按 ``model_name`` 或 ``alias`` 匹配 ``models.defaults`` 中的条目，
+    返回该条目的 ``model_config_obj``；找不到或读取失败时 fallback 到
+    空字典（让模型使用自身默认参数，避免 ``temperature=0`` 对部分
+    模型不兼容）。前端传入的 ``reasoning_level`` 可覆盖配置值。
+    """
+    model_config_obj: dict[str, Any] = {}
+    try:
+        _cfg = get_config()
+        _models = get_default_models(_cfg)
+        for entry in _models:
+            if not isinstance(entry, dict):
+                continue
+            mcc = entry.get("model_client_config") or {}
+            entry_model_name = str(mcc.get("model_name", "")).strip()
+            entry_alias = str(entry.get("alias", "")).strip()
+            if entry_model_name == model_name or entry_alias == model_name:
+                obj = entry.get("model_config_obj")
+                if isinstance(obj, dict):
+                    model_config_obj = dict(obj)
+                logger.info(
+                    "[config.validate_model] loaded model_config_obj for '%s' "
+                    "(matched_by=%s): %s",
+                    model_name,
+                    "model_name" if entry_model_name == model_name else "alias",
+                    model_config_obj,
+                )
+                break
+        else:
+            logger.info(
+                "[config.validate_model] no model_config_obj found for '%s', using empty default",
+                model_name,
+            )
+    except Exception as exc:
+        logger.warning(
+            "[config.validate_model] failed to read model_config_obj from config, using default. %s",
+            exc,
+        )
+    if "reasoning_level" in params:
+        model_config_obj["reasoning_level"] = params.get("reasoning_level")
+    return model_config_obj
+
+
 def _register_web_handlers(bind: WebHandlersBindParams) -> None:
     """注册 Web 前端需要的 method 与 on_connect。
     on_config_saved: 可选，config.set 写回后调用的回调；
@@ -1960,9 +2005,8 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
 
         verify_ssl = bool(params.get("verify_ssl", False))
 
-        model_config_obj = {"temperature": 0}
-        if "reasoning_level" in params:
-            model_config_obj["reasoning_level"] = params.get("reasoning_level")
+        model_config_obj = _resolve_model_config_obj_for_validate(model, params)
+
         reasoning_mcc = {
             "client_provider": model_provider,
             "api_base": api_base,
@@ -1973,6 +2017,11 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
                 model_config_obj=model_config_obj,
                 model_name=model,
             )
+        )
+        logger.info(
+            "[config.validate_model] final model_request_config for '%s': %s",
+            model,
+            model_request_config.model_dump(),
         )
         model_client_config = ModelClientConfig(
             client_id="config-validate",
@@ -1989,7 +2038,6 @@ def _register_web_handlers(bind: WebHandlersBindParams) -> None:
             return await llm.invoke(
                 [{"role": "user", "content": "Hi"}],
                 max_tokens=max_tokens,
-                temperature=0,
             )
 
         try:

--- a/tests/unit_tests/gateway/test_resolve_model_config_obj.py
+++ b/tests/unit_tests/gateway/test_resolve_model_config_obj.py
@@ -1,0 +1,173 @@
+import pytest
+
+from jiuwenswarm.gateway.channel_manager.web.app_web_handlers import (
+    _resolve_model_config_obj_for_validate,
+)
+
+
+class TestResolveModelConfigObjForValidate:
+    """Tests for ``_resolve_model_config_obj_for_validate``."""
+
+    @pytest.fixture
+    def mock_models(self, monkeypatch):
+        """Patch ``get_config`` and ``get_default_models`` with a list of model entries."""
+
+        def _patch(entries):
+            def fake_get_config():
+                return {"models": {"defaults": entries}}
+
+            def fake_get_default_models(_cfg):
+                return entries
+
+            monkeypatch.setattr(
+                "jiuwenswarm.gateway.channel_manager.web.app_web_handlers.get_config",
+                fake_get_config,
+            )
+            monkeypatch.setattr(
+                "jiuwenswarm.gateway.channel_manager.web.app_web_handlers.get_default_models",
+                fake_get_default_models,
+            )
+
+        return _patch
+
+    def test_match_by_model_name(self, mock_models):
+        mock_models(
+            [
+                {
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": {"temperature": 0.7, "top_p": 0.9},
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate("gpt-4", {})
+        assert result == {"temperature": 0.7, "top_p": 0.9}
+
+    def test_match_by_alias(self, mock_models):
+        mock_models(
+            [
+                {
+                    "alias": "my-gpt",
+                    "model_client_config": {"model_name": "gpt-4-turbo"},
+                    "model_config_obj": {"temperature": 0.5},
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate("my-gpt", {})
+        assert result == {"temperature": 0.5}
+
+    def test_no_match_returns_empty_dict(self, mock_models):
+        mock_models(
+            [
+                {
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": {"temperature": 0.7},
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate("unknown-model", {})
+        assert result == {}
+
+    def test_get_config_exception_returns_empty_dict(self, monkeypatch):
+        def raise_exc():
+            raise RuntimeError("config broken")
+
+        monkeypatch.setattr(
+            "jiuwenswarm.gateway.channel_manager.web.app_web_handlers.get_config",
+            raise_exc,
+        )
+        result = _resolve_model_config_obj_for_validate("any", {})
+        assert result == {}
+
+    def test_reasoning_level_override_from_params(self, mock_models):
+        mock_models(
+            [
+                {
+                    "model_client_config": {"model_name": "deepseek-v3"},
+                    "model_config_obj": {"temperature": 0.7, "reasoning_level": "low"},
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate(
+            "deepseek-v3", {"reasoning_level": "high"}
+        )
+        assert result == {"temperature": 0.7, "reasoning_level": "high"}
+
+    def test_reasoning_level_added_when_not_in_config(self, mock_models):
+        mock_models(
+            [
+                {
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": {"temperature": 0.7},
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate(
+            "gpt-4", {"reasoning_level": "medium"}
+        )
+        assert result == {"temperature": 0.7, "reasoning_level": "medium"}
+
+    def test_reasoning_level_added_when_no_match(self, mock_models):
+        mock_models([])
+        result = _resolve_model_config_obj_for_validate(
+            "unknown", {"reasoning_level": "low"}
+        )
+        assert result == {"reasoning_level": "low"}
+
+    def test_model_config_obj_not_dict_ignored(self, mock_models):
+        mock_models(
+            [
+                {
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": "not-a-dict",  # invalid type
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate("gpt-4", {})
+        assert result == {}
+
+    def test_non_dict_entry_skipped(self, mock_models):
+        mock_models(
+            [
+                "not-a-dict-entry",  # invalid entry
+                {
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": {"temperature": 0.8},
+                },
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate("gpt-4", {})
+        assert result == {"temperature": 0.8}
+
+    def test_model_name_takes_precedence_over_alias(self, mock_models):
+        """When model_name matches entry A but alias matches entry B,
+        entry A should win because we iterate in order."""
+        mock_models(
+            [
+                {
+                    "alias": "custom-gpt",
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": {"temperature": 0.1},
+                },
+                {
+                    "alias": "gpt-4",
+                    "model_client_config": {"model_name": "gpt-4-turbo"},
+                    "model_config_obj": {"temperature": 0.9},
+                },
+            ]
+        )
+        # model_name "gpt-4" matches first entry
+        result = _resolve_model_config_obj_for_validate("gpt-4", {})
+        assert result == {"temperature": 0.1}
+
+    def test_alias_match_used_when_model_name_misses(self, mock_models):
+        mock_models(
+            [
+                {
+                    "alias": "custom-gpt",
+                    "model_client_config": {"model_name": "gpt-4"},
+                    "model_config_obj": {"temperature": 0.2},
+                }
+            ]
+        )
+        result = _resolve_model_config_obj_for_validate("custom-gpt", {})
+        assert result == {"temperature": 0.2}


### PR DESCRIPTION
### **problem**

The "model debugging" function (`config.validate_model`) has the following issues when verifying the model's connectivity: 
1. **Model parameters do not match actual operation**: Previously, `model_config_obj` was hardcoded as `{"temperature": 0}`, and it did not read the actual configuration from `config.yaml` under `models.defaults`. After the user configured parameters such as `temperature: 0.95`, the debug mode still used `0`, resulting in inconsistent behaviors between the debug environment and the actual running environment. 

2. **Some models do not support `temperature=0`**: Models such as Kimi 2.6/2.7 are incompatible with `temperature=0`. They will directly report an error, resulting in false negative results for model debugging (the model is actually usable but the debugging fails).

### **solution**

Move `_resolve_model_config_obj_for_validate` to the module level 

1. Extract the model configuration lookup logic from the `_config_validate_model` function and move it to a separate module-level function `_resolve_model_config_obj_for_validate`, which is single-minded and easy to test. 

   **a). Matching Strategy:**
- Traverse the decrypted model list returned by `get_default_models()`
- Match first by `model_name`, and if not found, then by `alias`
- Once a match is successful, return the `model_config_obj` of that entry (deep copy) 

   **b). Fallback:**
- When no model is matched → Return `{}` (an empty dictionary, allowing the model to use its default parameters)
- Exception occurred while reading configuration → Log a `warning` message and return `{}` 
- The type of the `model_config_obj` field is not `dict` → Ignore and return `{}` 

2. `model_config_obj` fallback is changed from `{"temperature": 0}` to `{}` 
An empty dictionary means that the `build_reasoning_model_request_kwargs` will not generate the `temperature` field.

3. Remove the forced override of `llm.invoke(..., temperature=0)` 
The detection request no longer hard-codes `temperature=0`. Instead, it is entirely determined by the default values of `model_config_obj` and `ModelRequestConfig`, ensuring consistency between the debugging environment and the actual running environment.

4. (Suggested implementation on the agent-core side): The default parameters of `ModelRequestConfig` follow the vendor configuration. 
The default values of relevant fields in `ModelRequestConfig` (temperature and top_p) are set to `None`, no explicit parameters need to be provided, and users do not need to configure `config.yaml`. This allows the supplier API to handle the request according to its own default behavior.

### Test
<img width="2372" height="651" alt="image" src="https://github.com/user-attachments/assets/40518ec4-6d2a-4be7-8690-bed254369ab2" />

<img width="1404" height="450" alt="image" src="https://github.com/user-attachments/assets/f1e86f56-c6ed-4b07-aeea-f3ec0796f0af" />

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #329
<!-- /bot1-related-issues -->
