### PR TITLE
fix: 模型回复语言跟随界面语言设置，不再被用户输入语言带偏

### DIFF
--- a/jiuwenswarm/agents/harness/common/prompt/prompt_builder.py
+++ b/jiuwenswarm/agents/harness/common/prompt/prompt_builder.py
@@ -59,6 +59,8 @@ def _response_prompt(language: str) -> PromptSection:
 }
 ```
 
+- **preferred_response_language**：用户期望的回复语言。你必须使用该语言回复用户，无论用户消息本身使用的是什么语言。
+
 ## 系统消息
 
 ```json
@@ -97,6 +99,8 @@ You receive user messages and system messages; handle each by source and type.
   "source": "user"
 }
 ```
+
+- **preferred_response_language**: The user's preferred response language. You must respond in this language, regardless of the language used in the user's message.
 
 ## System Message
 

--- a/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py
+++ b/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py
@@ -29,9 +29,7 @@ from jiuwenswarm.common.utils import (
     logger,
 )
 
-_LANGUAGE_NAMES = {"cn": "Chinese", "zh": "Chinese", "en": "English"}
-
-_LANGUAGE_NAMES = {"cn": "Chinese", "zh": "Chinese", "en": "English"}
+_LANGUAGE_NAMES = {"cn": "Chinese (Simplified)", "zh": "Chinese (Simplified)", "en": "English"}
 
 
 class RuntimePromptRail(DeepAgentRail):
@@ -114,7 +112,11 @@ class RuntimePromptRail(DeepAgentRail):
         )
 
     def set_force_english(self, force: bool) -> None:
-        """Force English-only injected sections regardless of language (code mode)."""
+        """Force English for scaffolding sections (time/runtime/env) in code mode.
+
+        Does NOT affect the Language section (response language), which always
+        follows the user's preferred language set via :meth:`set_language`.
+        """
         self._force_english = force
 
     @staticmethod
@@ -224,10 +226,16 @@ class RuntimePromptRail(DeepAgentRail):
         ).strip()
         available_models_str = ", ".join(available_models) if available_models else model
         mode = (runtime_state.get("mode") or self._mode or "unknown").strip()
+        # Language section controls the model's *response* language and must
+        # follow the user's preferred language.  ``_force_english`` only
+        # affects system-prompt scaffolding (time / runtime / env sections),
+        # NOT the response language, so that code mode (which sets
+        # _force_english=True for English scaffolding) still replies in the
+        # user's chosen language.
         language_val = (
-            "en"
-            if self._force_english
-            else self._language or runtime_state.get("language") or "unknown"
+            self._language
+            or runtime_state.get("language")
+            or "unknown"
         ).strip()
         channel = (runtime_state.get("channel") or self._channel or "unknown").strip()
 
@@ -283,24 +291,9 @@ class RuntimePromptRail(DeepAgentRail):
         language_name = _LANGUAGE_NAMES.get(language_val, language_val)
         language_output_content = (
             "# Language\n\n"
-            f"Always respond in {language_name}. "
-            f"Use {language_name} for all explanations, comments, "
-            f"and communications with the user. "
-            f"Technical terms and code identifiers should remain "
-            f"in their original form."
-        )
-        self.system_prompt_builder.add_section(PromptSection(
-            name="language_output",
-            content={"cn": language_output_content, "en": language_output_content},
-            priority=93,
-        ))
-
-        # ── Language output constraint (injected near end) ──
-        self.system_prompt_builder.remove_section("language_output")
-        language_name = _LANGUAGE_NAMES.get(language_val, language_val)
-        language_output_content = (
-            "# Language\n\n"
-            f"Always respond in {language_name}. "
+            f"Always respond in {language_name}, regardless of the language "
+            f"used in the user's message. Even if the user writes in another "
+            f"language, you must still respond in {language_name}. "
             f"Use {language_name} for all explanations, comments, "
             f"and communications with the user. "
             f"Technical terms and code identifiers should remain "

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_code.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_code.py
@@ -396,21 +396,6 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
     def _resolve_output_language(self) -> str:
         """Resolve user's preferred output language for runtime_state display.
 
-        Distinct from prompt/runtime language, which defaults to "en" in code mode.
-        Returns the normalized language code ("cn"/"en") based on
-        config.yaml preferred_language, so the Language section injected
-        by RuntimePromptRail can instruct the LLM to respond in the
-        user's chosen language.
-        """
-        config_base = get_config()
-        raw = str(config_base.get("preferred_language", "zh")).strip().lower()
-        if raw == "zh":
-            raw = "cn"
-        return resolve_language(raw)
-
-    def _resolve_output_language(self) -> str:
-        """Resolve user's preferred output language for runtime_state display.
-
         Distinct from prompt/runtime language (always "en" in code mode).
         Returns the normalized language code ("cn"/"en") based on
         config.yaml preferred_language, so the Language section injected
@@ -1214,7 +1199,10 @@ class JiuwenSwarmCodeAdapter(JiuWenSwarmDeepAdapter):
         resolved_channel = str(runtime_config.channel_id or
                                self._resolve_prompt_channel(runtime_config.session_id) or "web").strip() or "web"
         if self._runtime_prompt_rail:
-            self._runtime_prompt_rail.set_language(resolved_language)
+            # Language section (response language) must follow the user's
+            # preferred language, not the code-mode "en" which only governs
+            # system-prompt scaffolding (time/runtime/env sections).
+            self._runtime_prompt_rail.set_language(self._resolve_output_language())
             self._runtime_prompt_rail.set_force_english(self._force_english_runtime_prompt)
             self._runtime_prompt_rail.set_channel(resolved_channel)
             self._runtime_prompt_rail.set_model_name(self._resolve_model_name())

--- a/tests/unit_tests/agentserver/test_system_prompt_restructure.py
+++ b/tests/unit_tests/agentserver/test_system_prompt_restructure.py
@@ -691,11 +691,11 @@ async def test_runtime_prompt_language_output_prefers_rail_language_over_runtime
     await runtime_rail.before_model_call(ctx)
 
     prompt = builder.build()
-    assert "Always respond in Chinese." in prompt
+    assert "Always respond in Chinese (Simplified)" in prompt
     rendered = agent.prompt_attachment_manager.render(
         await agent.prompt_attachment_manager.list_by_filter(session_id="sess1")
     )
-    assert "Always respond in Chinese." not in rendered
+    assert "Always respond in Chinese (Simplified)" not in rendered
     assert "Always respond in English." not in rendered
     assert "Always respond in English." not in prompt
     assert "当前语言：cn" in rendered


### PR DESCRIPTION
Paired: [GitHub #1345](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1345) ↔ [GitCode !4101](https://gitcode.com/openJiuwen/jiuwenswarm/pull/4101)

# Issue #2218 问题定位根因与修改方案总结

## 问题描述

界面语言切换到中文后，发送日语"こんにちは"，模型回复日语而非中文。预期模型回复语言应跟随界面语言设置。

---

## 根因定位

模型回复语言由 [[runtime_prompt_rail.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/[runtime_prompt_rail.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py#L288-L296)) 的 **Language section** 控制，该 section 在每次模型调用前注入系统提示。存在 **三个层面的问题**：

### 根因 1：Language 指令不够强（Deep 模式 + Code 模式均受影响）

[runtime_prompt_rail.py](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py#L288-L296) 原指令：

```
Always respond in Chinese. Use Chinese for all explanations, comments,
and communications with the user.
```

未明确指出 **"无论用户消息用什么语言"**，模型遇到日语输入时倾向于匹配用户消息语言，忽略该指令。

### 根因 2：Code 模式 `_force_english` 短路覆盖用户语言

[[interface_code.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/server/runtime/agent_adapter/interface_code.py#L383)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/server/runtime/agent_adapter/interface_code.py#L383) 设置 `_force_english_runtime_prompt = True`，导致 [[runtime_prompt_rail.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py#L227-L231)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py#L227-L231) 中 `language_val` 被硬编码为 `"en"`：

```python
# 原逻辑（已删除 _force_english 短路）
language_val = (
    "en"
    if self._force_english          # ← Code 模式恒为 True，强制英文
    else self._language or runtime_state.get("language") or "unknown"
).strip()
```

即使 `runtime_state` 中已写入正确的用户语言 `"cn"`（通过 `_resolve_output_language()`），也因短路被忽略。Code 模式下 Language section 始终输出 "Always respond in English."

### 根因 3：`preferred_response_language` 字段缺少使用说明

[[prompt_builder.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/prompt/prompt_builder.py#L45-L132)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/prompt/prompt_builder.py#L45-L132) 的 response prompt 只描述了用户消息 JSON 中 `preferred_response_language` 字段的格式，但未告诉模型该字段的用途——模型不知道需要根据该字段决定回复语言。

---

## 修改方案

### 修改 1：强化 Language section 指令 + 移除 `_force_english` 短路

**文件**：[[runtime_prompt_rail.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/rails/runtime_prompt_rail.py)

**a) `language_val` 计算（L225-235）** — 移除 `_force_english` 对回复语言的控制：

```python
# 修改前
language_val = (
    "en" if self._force_english
    else self._language or runtime_state.get("language") or "unknown"
).strip()

# 修改后 — _force_english 仅影响 time/runtime/env 脚手架，不影响回复语言
language_val = (
    self._language
    or runtime_state.get("language")
    or "unknown"
).strip()
```

**b) Language 指令强化（L288-296）**：

```python
# 修改后
language_output_content = (
    "# Language\n\n"
    f"Always respond in {language_name}, regardless of the language "
    f"used in the user's message. Even if the user writes in another "
    f"language, you must still respond in {language_name}. "
    f"Use {language_name} for all explanations, comments, "
    f"and communications with the user. "
    f"Technical terms and code identifiers should remain "
    f"in their original form."
)
```

**c) `_LANGUAGE_NAMES` 映射（L32）** — 消除简繁歧义 + 删除重复定义：

```python
# 修改前（重复定义两次）
_LANGUAGE_NAMES = {"cn": "Chinese", "zh": "Chinese", "en": "English"}
_LANGUAGE_NAMES = {"cn": "Chinese", "zh": "Chinese", "en": "English"}

# 修改后（单次定义）
_LANGUAGE_NAMES = {"cn": "Chinese (Simplified)", "zh": "Chinese (Simplified)", "en": "English"}
```

**d) 删除重复 Language section 块** — 原先 add → remove → re-add 的冗余代码已清理。

---

### 修改 2：Code 模式 `set_language` 改用用户首选语言

**文件**：[[interface_code.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/server/runtime/agent_adapter/interface_code.py#L1201-L1206)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/server/runtime/agent_adapter/interface_code.py#L1201-L1206)

```python
# 修改前 — 始终传 "en"（_resolve_runtime_language 在 code 模式返回 "en"）
self._runtime_prompt_rail.set_language(resolved_language)

# 修改后 — 传用户首选语言（读取 config.yaml 的 preferred_language）
self._runtime_prompt_rail.set_language(self._resolve_output_language())
```

同时删除重复定义的 `_resolve_output_language` 方法（原有两个完全相同的定义）。

---

### 修改 3：response prompt 增加语言字段使用说明

**文件**：[[prompt_builder.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/prompt/prompt_builder.py)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/jiuwenswarm/agents/harness/common/prompt/prompt_builder.py)

中文版（L62）：

```
- **preferred_response_language**：用户期望的回复语言。你必须使用该语言回复用户，无论用户消息本身使用的是什么语言。
```

英文版（L103）：

```
- **preferred_response_language**: The user's preferred response language. You must respond in this language, regardless of the language used in the user's message.
```

---

### 修改 4：测试断言更新

**文件**：[[test_system_prompt_restructure.py](file:///E:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/tests/unit_tests/agentserver/test_system_prompt_restructure.py#L694-L698)](file:///e:/code/multi_jiuwenclaw_dev/issue_tackling/jiuwenclaw/tests/unit_tests/agentserver/test_system_prompt_restructure.py#L694-L698)

```python
# 修改前
assert "Always respond in Chinese." in prompt

# 修改后
assert "Always respond in Chinese (Simplified)" in prompt
```

---

## 修复后的语言流程

```mermaid
flowchart TD
    A["用户界面语言 = 中文 zh<br/>用户发送 こんにちは 日语"] --> B{模式判断}
    B -->|Deep 模式| C["_resolve_runtime_language → cn<br/>set_language cn<br/>_force_english = False<br/>language_val = cn"]
    B -->|Code 模式| D["_resolve_output_language → cn 读取 preferred_language<br/>set_language cn<br/>_force_english = True 仅脚手架<br/>language_val = cn 不受 force_english"]
    C --> E["Language section 双层强化"]
    D --> E
    E --> F["System Prompt:<br/>Always respond in Chinese Simplified,<br/>regardless of the language used in the user's message.<br/>Even if the user writes in another language,<br/>you must still respond in Chinese Simplified."]
    E --> G["User Message JSON:<br/>preferred_response_language: zh<br/>→ 必须使用该语言回复,<br/>无论消息用什么语言"]
    F --> H["模型回复中文 ✓"]
    G --> H
```

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #364
<!-- /bot1-related-issues -->