### PR TITLE
test(gateway): prevent team_name regression in session list

### DIFF
--- a/tests/unit_tests/test_app_web_handlers.py
+++ b/tests/unit_tests/test_app_web_handlers.py
@@ -88,6 +88,41 @@ class FakeHeartbeatService:
 
 
 @pytest.mark.asyncio
+async def test_session_list_preserves_team_name_in_projected_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jiuwenswarm.server.runtime.session.session_metadata.get_all_sessions_metadata",
+        lambda **_kwargs: (
+            [
+                {
+                    "session_id": "sess-team-1",
+                    "mode": "team",
+                    "team_name": "dev-team-swarm_sess-team-1",
+                    "title": "team task",
+                    "delivery_context": {"channel_id": "internal"},
+                }
+            ],
+            1,
+        ),
+    )
+    channel = FakeWebChannel()
+    _register_web_handlers(WebHandlersBindParams(channel=channel))
+
+    await channel.methods["session.list"](
+        object(),
+        "req-session-list",
+        {},
+        "current-session",
+    )
+
+    payload = channel.responses[-1]["payload"]
+    assert payload["sessions"][0]["mode"] == "team"
+    assert payload["sessions"][0]["team_name"] == "dev-team-swarm_sess-team-1"
+    assert "delivery_context" not in payload["sessions"][0]
+
+
+@pytest.mark.asyncio
 async def test_path_set_reloads_config_and_resets_agent_browser_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Paired: [GitHub #1416](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1416) ↔ [GitCode !4127](https://gitcode.com/openJiuwen/jiuwenswarm/pull/4127)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

* Adds focused regression coverage for the Gateway `session.list` metadata projection used by the Web UI.
* Issue #1348 was caused by `team_name` being omitted from the projected session metadata, which made the Team panel discard otherwise valid `mode=team` sessions and display zero teams.
* The current `develop` implementation already preserves `team_name`; this test locks in that behavior so a future whitelist change cannot silently reintroduce the issue.
* The test also verifies that internal metadata such as `delivery_context` remains excluded from the Web response.

**Which issue(s) this PR fixes**:

Fixes #1348

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

**Test plan**

* Mock `get_all_sessions_metadata()` with a team session containing `mode`, `team_name`, and an internal `delivery_context`.
* Invoke the registered Gateway Web `session.list` handler.
* Verify that `mode` and `team_name` are preserved in the projected response.
* Verify that `delivery_context` is not exposed.
* Run the focused unit test and Ruff on the changed Python test file.

**Test results**

```text
$ uv run --no-cache --no-sync pytest tests/unit_tests/test_app_web_handlers.py -k session_list_preserves_team_name_in_projected_metadata
collected 72 items / 71 deselected / 1 selected
tests/unit_tests/test_app_web_handlers.py::test_session_list_preserves_team_name_in_projected_metadata PASSED [100%]
================ 1 passed, 71 deselected in 108.41s (0:01:48) =================

$ uv run --no-cache --no-sync ruff check tests/unit_tests/test_app_web_handlers.py
All checks passed!
```

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Maintainer review has not happened yet; this PR is ready for review.
+ - [x] **Test**: The regression case is included in this PR and passes locally.
+ - [x] **Verification**: The verification scenario and actual command output are included above.
+ - [x] **Interface**: N/A; this test-only change does not modify external interfaces.
+ - [x] **Document**: N/A; no public behavior or documentation is changed.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1348
<!-- /bot1-related-issues -->