### PR TITLE
fix(gateway): 修复断线取消链路中的 user_id 丢失

### DIFF
--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -2197,7 +2197,13 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
             payload["intent"] = intent
         await channel.send_response(ws, req_id, ok=True, payload=payload)
 
-    async def _tui_disconnect_request(ws, req_id, params, session_id):
+    async def _tui_disconnect_request(
+        ws,
+        req_id,
+        params,
+        session_id,
+        user_id=None,
+    ):
         payload = {"accepted": True, "session_id": session_id}
         try:
             await channel.send_response(ws, req_id, ok=True, payload=payload)
@@ -2211,7 +2217,13 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
         if callable(is_bound_to_client):
             owns_session = bool(is_bound_to_client("tui", sid, ws))
         if mh is not None and sid and owns_session:
-            cleaned = await mh.cancel_agent_sessions_on_disconnect([("tui", sid)])
+            disconnect_user_id = str(
+                user_id or getattr(ws, "_gateway_user_id", None) or ""
+            ).strip() or None
+            cleaned = await mh.cancel_agent_sessions_on_disconnect(
+                [("tui", sid)],
+                user_id=disconnect_user_id,
+            )
             if not cleaned:
                 logger.warning(
                     "[tui.disconnect] immediate cleanup failed; "
@@ -3322,13 +3334,21 @@ def build_cli_route_binding(bind: CliRouteBindParams) -> GatewayRouteBinding:
         request_keys = stale_request_keys or []
         if not stale_session_keys and not request_keys:
             return
+        disconnect_user_id = str(
+            getattr(_ws, "_gateway_user_id", None) or ""
+        ).strip() or None
         if hasattr(mh, "schedule_cancel_agent_sessions_on_disconnect"):
             await mh.schedule_cancel_agent_sessions_on_disconnect(
                 stale_session_keys,
                 stale_request_keys=request_keys,
+                user_id=disconnect_user_id,
             )
             return
-        await mh.cancel_agent_sessions_on_disconnect(stale_session_keys, stale_request_keys=request_keys)
+        await mh.cancel_agent_sessions_on_disconnect(
+            stale_session_keys,
+            stale_request_keys=request_keys,
+            user_id=disconnect_user_id,
+        )
 
     def _tui_session_bound(channel_id: str, session_id: str) -> None:
         mh = bind.message_handler

--- a/jiuwenswarm/gateway/message_handler/message_handler.py
+++ b/jiuwenswarm/gateway/message_handler/message_handler.py
@@ -1095,6 +1095,7 @@ class MessageHandler(ABC):
         session_keys: list[tuple[str, str]],
         *,
         stale_request_keys: list[tuple[str, str]] | None = None,
+        user_id: str | None = None,
     ) -> bool:
         """取消仍绑定在断开连接上的会话（与显式 chat.interrupt 对齐）。
 
@@ -1106,6 +1107,7 @@ class MessageHandler(ABC):
                 ``_request_to_client`` 中 ``client is ws`` 的反查。即使
                 ``session_keys`` 为空，这里仍能让我们通过 ``_stream_sessions``
                 找出该 WS 上 in-flight stream 对应的 session_id，避免漏取消。
+            user_id: 断开连接绑定的用户 ID；旧调用未提供时保持 ``None``。
 
         Returns:
             ``True`` 表示所有会话的 AgentServer 中断均成功（或无可取消的会话）；
@@ -1133,7 +1135,11 @@ class MessageHandler(ABC):
                 continue
             seen.add(sid)
             self.cancel_scheduled_disconnect_cancel(_channel_id, sid)
-            cleaned = await self._cancel_disconnect_session(_channel_id, sid)
+            cleaned = await self._cancel_disconnect_session(
+                _channel_id,
+                sid,
+                user_id=user_id,
+            )
             all_cleaned = cleaned and all_cleaned
         return all_cleaned
 
@@ -1143,6 +1149,7 @@ class MessageHandler(ABC):
         *,
         stale_request_keys: list[tuple[str, str]] | None = None,
         delay_seconds: float = _TUI_DISCONNECT_CANCEL_GRACE_SECONDS,
+        user_id: str | None = None,
     ) -> None:
         """Schedule a disconnect cancel unless the same session reconnects first."""
         merged, recovered_via_requests = self._merge_disconnect_session_keys(
@@ -1169,7 +1176,12 @@ class MessageHandler(ABC):
             seen.add(task_key)
             self.cancel_scheduled_disconnect_cancel(channel_id, sid)
             task = asyncio.create_task(
-                self._delayed_disconnect_cancel(channel_id, sid, delay_seconds)
+                self._delayed_disconnect_cancel(
+                    channel_id,
+                    sid,
+                    delay_seconds,
+                    user_id=user_id,
+                )
             )
             self._disconnect_cancel_tasks[task_key] = task
 
@@ -1221,7 +1233,13 @@ class MessageHandler(ABC):
 
         return merged, recovered_via_requests
 
-    def _build_disconnect_cancel_message(self, channel_id: str, session_id: str) -> "Message":
+    def _build_disconnect_cancel_message(
+        self,
+        channel_id: str,
+        session_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> "Message":
         from jiuwenswarm.common.schema.message import Message, ReqMethod
 
         disconnect_params = {
@@ -1247,10 +1265,21 @@ class MessageHandler(ABC):
             ok=True,
             req_method=ReqMethod.CHAT_CANCEL,
             is_stream=False,
+            user_id=user_id,
         )
 
-    async def _cancel_disconnect_session(self, channel_id: str, session_id: str) -> bool:
-        stub = self._build_disconnect_cancel_message(channel_id, session_id)
+    async def _cancel_disconnect_session(
+        self,
+        channel_id: str,
+        session_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> bool:
+        stub = self._build_disconnect_cancel_message(
+            channel_id,
+            session_id,
+            user_id=user_id,
+        )
         try:
             return bool(
                 await self._cancel_agent_work_for_session(
@@ -1273,11 +1302,17 @@ class MessageHandler(ABC):
         channel_id: str,
         session_id: str,
         delay_seconds: float,
+        *,
+        user_id: str | None = None,
     ) -> None:
         task_key = (channel_id, session_id)
         try:
             await asyncio.sleep(max(0.0, delay_seconds))
-            await self._cancel_disconnect_session(channel_id, session_id)
+            await self._cancel_disconnect_session(
+                channel_id,
+                session_id,
+                user_id=user_id,
+            )
         finally:
             if self._disconnect_cancel_tasks.get(task_key) is asyncio.current_task():
                 self._disconnect_cancel_tasks.pop(task_key, None)

--- a/scripts/demo_disconnect_cancel_user_id.py
+++ b/scripts/demo_disconnect_cancel_user_id.py
@@ -1,0 +1,54 @@
+"""Show that disconnect cancellation keeps the WebSocket user ID."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+from jiuwenswarm.gateway.message_handler.message_handler import MessageHandler
+
+
+class DemoAgentClient:
+    last_request: Any = None
+
+    @classmethod
+    async def send_request(cls, request: Any) -> SimpleNamespace:
+        cls.last_request = request
+        return SimpleNamespace(
+            request_id=request.request_id,
+            channel_id=request.channel,
+            ok=True,
+            payload={"event_type": "chat.interrupt_result", "success": True},
+            metadata=None,
+        )
+
+    @staticmethod
+    async def send_request_stream(request: Any):
+        if False:
+            yield request
+
+
+class DemoMessageHandler(MessageHandler):
+    pass
+
+
+async def main() -> None:
+    handler = DemoMessageHandler(DemoAgentClient())
+    cleaned = await handler.cancel_agent_sessions_on_disconnect(
+        [("tui", "demo-session")],
+        user_id="demo-user",
+    )
+
+    request = DemoAgentClient.last_request
+    assert cleaned is True
+    assert request is not None
+    assert request.user_id == "demo-user"
+    print(
+        "disconnect cancel user_id preserved:",
+        request.user_id,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/demo_disconnect_cancel_user_id.py
+++ b/scripts/demo_disconnect_cancel_user_id.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any
 
 from jiuwenswarm.gateway.message_handler.message_handler import MessageHandler
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class DemoAgentClient:
@@ -41,14 +45,18 @@ async def main() -> None:
     )
 
     request = DemoAgentClient.last_request
-    assert cleaned is True
-    assert request is not None
-    assert request.user_id == "demo-user"
-    print(
-        "disconnect cancel user_id preserved:",
+    if not cleaned:
+        raise RuntimeError("Disconnect cancellation did not complete")
+    if request is None:
+        raise RuntimeError("Disconnect cancellation request was not sent")
+    if request.user_id != "demo-user":
+        raise RuntimeError(f"Unexpected disconnect user_id: {request.user_id!r}")
+    LOGGER.info(
+        "disconnect cancel user_id preserved: %s",
         request.user_id,
     )
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     asyncio.run(main())

--- a/tests/unit_tests/gateway/test_cli_channel_handlers.py
+++ b/tests/unit_tests/gateway/test_cli_channel_handlers.py
@@ -47,13 +47,29 @@ class FakeMessageHandler:
         self.cancelled = []
         self.scheduled = []
         self.reconnected = []
+        self.cancel_user_ids = []
+        self.scheduled_user_ids = []
 
-    async def cancel_agent_sessions_on_disconnect(self, session_keys, *, stale_request_keys=None):
+    async def cancel_agent_sessions_on_disconnect(
+        self,
+        session_keys,
+        *,
+        stale_request_keys=None,
+        user_id=None,
+    ):
         self.cancelled.append((session_keys, stale_request_keys or []))
+        self.cancel_user_ids.append(user_id)
         return True
 
-    async def schedule_cancel_agent_sessions_on_disconnect(self, session_keys, *, stale_request_keys=None):
+    async def schedule_cancel_agent_sessions_on_disconnect(
+        self,
+        session_keys,
+        *,
+        stale_request_keys=None,
+        user_id=None,
+    ):
         self.scheduled.append((session_keys, stale_request_keys or []))
+        self.scheduled_user_ids.append(user_id)
 
     def cancel_scheduled_disconnect_cancel(self, channel_id, session_id):
         self.reconnected.append((channel_id, session_id))
@@ -65,14 +81,28 @@ class BlockingDisconnectMessageHandler(FakeMessageHandler):
         super().__init__()
         self.cancel_started = asyncio.Event()
 
-    async def cancel_agent_sessions_on_disconnect(self, session_keys, *, stale_request_keys=None):
+    async def cancel_agent_sessions_on_disconnect(
+        self,
+        session_keys,
+        *,
+        stale_request_keys=None,
+        user_id=None,
+    ):
+        self.cancel_user_ids.append(user_id)
         self.cancel_started.set()
         await asyncio.Future()
 
 
 class FailedDisconnectMessageHandler(FakeMessageHandler):
-    async def cancel_agent_sessions_on_disconnect(self, session_keys, *, stale_request_keys=None):
+    async def cancel_agent_sessions_on_disconnect(
+        self,
+        session_keys,
+        *,
+        stale_request_keys=None,
+        user_id=None,
+    ):
         self.cancelled.append((session_keys, stale_request_keys or []))
+        self.cancel_user_ids.append(user_id)
         return False
 
 
@@ -147,6 +177,34 @@ async def test_tui_disconnect_handler_cancels_session_immediately():
 
 
 @pytest.mark.asyncio
+async def test_tui_disconnect_handler_forwards_user_id():
+    server = FakeGatewayServer()
+    handler = FakeMessageHandler()
+
+    register_cli_handlers(
+        CliHandlersBindParams(
+            channel=server,
+            agent_client=None,
+            message_handler=handler,
+            on_config_saved=None,
+            path="/tui",
+        )
+    )
+
+    ws = object()
+    server.bind_session_owner("tui", "sess-user-exit", ws)
+    await server.local_handlers["/tui"]["tui.disconnect"](
+        ws,
+        "req-user-exit",
+        {"reason": "user_exit"},
+        "sess-user-exit",
+        user_id="user-123",
+    )
+
+    assert handler.cancel_user_ids == ["user-123"]
+
+
+@pytest.mark.asyncio
 async def test_tui_disconnect_handler_does_not_cancel_session_owned_by_another_ws():
     server = FakeGatewayServer()
     handler = FakeMessageHandler()
@@ -213,6 +271,42 @@ async def test_tui_route_disconnect_schedules_cancel_for_transport_close():
 
     assert handler.scheduled == [([("tui", "sess-drop")], [("tui", "req-drop")])]
     assert handler.cancelled == []
+
+
+@pytest.mark.asyncio
+async def test_tui_route_disconnect_forwards_connection_user_id():
+    handler = FakeMessageHandler()
+    binding = build_cli_route_binding(
+        CliRouteBindParams(path="/tui", message_handler=handler)
+    )
+    ws = type("FakeWs", (), {})()
+    ws._gateway_user_id = "user-transport"  # pylint: disable=protected-access
+
+    await binding.disconnect_handler(
+        ws,
+        [("tui", "sess-transport-user")],
+        [],
+    )
+
+    assert handler.scheduled_user_ids == ["user-transport"]
+
+
+@pytest.mark.asyncio
+async def test_tui_route_disconnect_normalizes_blank_user_id():
+    handler = FakeMessageHandler()
+    binding = build_cli_route_binding(
+        CliRouteBindParams(path="/tui", message_handler=handler)
+    )
+    ws = type("FakeWs", (), {})()
+    ws._gateway_user_id = "   "  # pylint: disable=protected-access
+
+    await binding.disconnect_handler(
+        ws,
+        [("tui", "sess-blank-user")],
+        [],
+    )
+
+    assert handler.scheduled_user_ids == [None]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/gateway/test_message_handler_stream_cancel.py
+++ b/tests/unit_tests/gateway/test_message_handler_stream_cancel.py
@@ -671,6 +671,19 @@ async def test_disconnect_cancel_marks_request_as_client_disconnect() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_cancel_forwards_user_id() -> None:
+    handler = _TestMessageHandler.create()
+
+    await handler.cancel_agent_sessions_on_disconnect(
+        [("tui", "sess-user")],
+        user_id="user-123",
+    )
+
+    assert len(_FakeAgentClient.sent_requests) == 1
+    assert _FakeAgentClient.sent_requests[0].user_id == "user-123"
+
+
+@pytest.mark.asyncio
 async def test_disconnect_cancel_reports_agent_cleanup_failure() -> None:
     handler = _TestMessageHandler.create_with_client(_FailedCancelAgentClient())
 
@@ -729,6 +742,21 @@ async def test_disconnect_cancel_can_be_delayed_until_grace_expires() -> None:
 
 
 @pytest.mark.asyncio
+async def test_delayed_disconnect_cancel_forwards_user_id() -> None:
+    handler = _TestMessageHandler.create()
+
+    await handler.schedule_cancel_agent_sessions_on_disconnect(
+        [("tui", "sess-delayed-user")],
+        delay_seconds=0.01,
+        user_id="user-delayed",
+    )
+
+    await _wait_for_sent_request_count(1)
+    assert len(_FakeAgentClient.sent_requests) == 1
+    assert _FakeAgentClient.sent_requests[0].user_id == "user-delayed"
+
+
+@pytest.mark.asyncio
 async def test_reconnect_cancels_scheduled_disconnect_cancel() -> None:
     handler = _TestMessageHandler.create()
     _seed_stream_task(
@@ -784,6 +812,7 @@ async def test_disconnect_backward_compatible_without_request_keys_kwarg() -> No
 
     await asyncio.sleep(0)
     assert len(_FakeAgentClient.sent_requests) == 1
+    assert _FakeAgentClient.sent_requests[0].user_id is None
 
 
 # ---------- ChannelMode.is_team_mode ----------


### PR DESCRIPTION
Paired: [GitHub #1662](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1662) ↔ [GitCode !4196](https://gitcode.com/openJiuwen/jiuwenswarm/pull/4196)

## 问题

TUI WebSocket 断开时，网关会将 `X-User-Id` 保存在连接对象上，但断线取消链路只传递 `(channel_id, session_id)`。因此，合成的 `chat.interrupt` 请求到达 AgentServer 时会缺少 `user_id`。

## 解决方案

为现有断线取消接口增加可选的 `user_id` 参数，并使用 WebSocket 中已缓存的用户身份沿调用链透传。该参数默认值为 `None`，因此现有调用方式仍保持兼容。本方案复用已有的 `Message` 和 E2A 标准化链路，不引入新的状态或协议字段。

## 改动内容

- 从显式 `tui.disconnect` 和传输层连接关闭处理器中转发连接对应的用户 ID。
- 在立即取消和延迟取消链路中保留 `user_id`。
- 将空白用户 ID 统一转换为 `None`。
- 增加立即取消、延迟取消、空白 ID 和向后兼容场景的回归测试。
- 增加一个最小可运行演示脚本。

## 测试

- `uv run --frozen python scripts/demo_disconnect_cancel_user_id.py`
- `uv run --frozen ruff check jiuwenswarm/gateway/channel_manager/tui/tui_connect.py jiuwenswarm/gateway/message_handler/message_handler.py tests/unit_tests/gateway/test_cli_channel_handlers.py tests/unit_tests/gateway/test_message_handler_stream_cancel.py scripts/demo_disconnect_cancel_user_id.py`
- `uv run --frozen pytest tests/unit_tests/gateway/test_message_handler_stream_cancel.py tests/unit_tests/gateway/test_cli_channel_handlers.py tests/unit_tests/gateway/test_app_gateway_acp.py --no-cov -q -W ignore::SyntaxWarning`
- 测试结果：`107 passed`

测试覆盖显式断线、传输层断线、延迟取消、空白用户 ID，以及未传入 `user_id` 的旧调用方式。

## 评审注意事项

- 断线取消接口通过可选关键字参数扩展，保证现有调用在源码层面保持兼容。
- 重连宽限期仍使用 `(channel_id, session_id)` 作为键；`user_id` 仅作为请求上下文，不属于取消任务的身份标识。
- `-W ignore::SyntaxWarning` 仅用于忽略第三方包 `pysbd` 在 Python 3.12 下已有的警告，因为该仓库会将警告视为错误。