### PR TITLE
fix(diff): include sub-agent file changes in parent session diff stats

### DIFF
--- a/jiuwenswarm/server/runtime/session/git_diff_status.py
+++ b/jiuwenswarm/server/runtime/session/git_diff_status.py
@@ -14,7 +14,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from jiuwenswarm.server.runtime.session.project_git import GitError, GitOperationError
 from jiuwenswarm.server.utils.diff_service import get_diff_service
@@ -291,7 +291,7 @@ def _convert_stats(raw_stats: dict[str, Any] | None) -> DiffStats:
 
 
 def get_session_extra_history_roots(session_id: str | None) -> list[str]:
-    """Return team/member/worktree roots recorded for file history monitoring."""
+    """Return team/member/worktree/sub-agent roots for file history monitoring."""
     sid = str(session_id or "").strip()
     if not sid:
         return []
@@ -343,8 +343,6 @@ def get_session_extra_history_roots(session_id: str | None) -> list[str]:
             try:
                 path = Path(raw.strip()).expanduser()
                 parts = path.parts
-                # 使用最后一次出现的位置,避免路径中 team_name 多次出现时
-                # 定位到错误的层级(深层路径更可能是实际 team 目录)。
                 idx = -1
                 for i in range(len(parts) - 1, -1, -1):
                     if parts[i] == team_name:
@@ -377,7 +375,42 @@ def get_session_extra_history_roots(session_id: str | None) -> list[str]:
                 add_root(str(independent_member_workspace(member_name)))
         except Exception:  # noqa: BLE001
             pass
+
+    _discover_sub_agent_workspaces(sid, add_root)
+
     return roots
+
+
+def _discover_sub_agent_workspaces(session_id: str, add_root: Callable[[Any], None]) -> None:
+    """Scan workspace/sub_agents for sub-agent dirs belonging to *session_id*.
+
+    In single-agent mode the parent session has no ``team_name`` and no
+    ``team_file_monitor_roots`` metadata, so the normal team-root inference
+    in ``get_session_extra_history_roots`` produces nothing.  Sub-agent
+    workspaces live under ``<agent_workspace>/sub_agents/<sub_session_id>/``
+    with ``sub_session_id = <session_id>_sub_<type>_<suffix>``.  We enumerate
+    matching directories here and add them as extra history roots so that
+    ``_read_agent_history`` can pick up the sub-agent's ``.agent_history``
+    entries.
+    """
+    from jiuwenswarm.common.utils import get_agent_workspace_dir
+
+    sub_agents_dir = get_agent_workspace_dir() / "sub_agents"
+    if not sub_agents_dir.is_dir():
+        return
+    prefix = f"{session_id}_sub_"
+    try:
+        children = list(sub_agents_dir.iterdir())
+    except OSError:
+        return
+    for child in children:
+        try:
+            if not child.is_dir():
+                continue
+        except OSError:
+            continue
+        if child.name.startswith(prefix):
+            add_root(str(child))
 
 
 def _convert_hunks(raw_hunks: list[dict[str, Any]] | None) -> list[DiffHunk]:

--- a/jiuwenswarm/server/utils/diff_service.py
+++ b/jiuwenswarm/server/utils/diff_service.py
@@ -618,6 +618,10 @@ class DiffService:
         文件名约定: ``file_ops_{agent_id}_{session_id}.json``,其中 session_id
         始终是 ``.json`` 前的最后一段。使用 ``_{session_id}.json`` 后缀匹配替代
         子串匹配,避免短 session_id 误匹配其他 agent 的 file_ops 文件。
+
+        当 session_id 对应的是父会话时,也接受子 agent 会话(后缀形如
+        ``_sub_{type}_{suffix}``)的 file_ops 文件,使 diff 统计能覆盖子 agent
+        的文件变更。
         """
         if not name.startswith("file_ops_"):
             return False
@@ -625,7 +629,15 @@ class DiffService:
             return False
         if not session_id:
             return not require_session
-        return name.endswith(f"_{session_id}.json")
+        suffix = f"_{session_id}.json"
+        if name.endswith(suffix):
+            return True
+        sub_marker = f"_{session_id}_sub_"
+        marker_pos = name.find(sub_marker, len("file_ops_"))
+        if marker_pos < 0:
+            return False
+        agent_id = name[len("file_ops_"):marker_pos]
+        return bool(agent_id) and "_" not in agent_id
 
     @staticmethod
     def _agent_history_dirs_for_roots(

--- a/tests/unit_tests/server/test_turn_diff_history.py
+++ b/tests/unit_tests/server/test_turn_diff_history.py
@@ -1040,6 +1040,37 @@ def test_get_session_extra_history_roots_adds_spawned_member_workspaces(tmp_path
     assert str(tmp_path / "independent" / "poet-song_workspace") in roots
 
 
+def test_get_session_extra_history_roots_discovers_sub_agent_workspaces(tmp_path):
+    """Single-agent mode (no team_name) should still find sub-agent dirs under workspace/sub_agents."""
+    sub_agents_dir = tmp_path / "workspace" / "sub_agents"
+    sub_agents_dir.mkdir(parents=True)
+    (sub_agents_dir / "sess-1_sub_general-purpose_abc").mkdir()
+    (sub_agents_dir / "sess-1_sub_general-purpose_def").mkdir()
+    (sub_agents_dir / "sess-other_sub_general-purpose_xyz").mkdir()
+    with (
+        patch(
+            "jiuwenswarm.server.runtime.session.session_metadata.get_session_metadata",
+            return_value={
+                "team_name": "",
+                "team_file_monitor_roots": None,
+            },
+        ),
+        patch(
+            "jiuwenswarm.common.utils.get_agent_workspace_dir",
+            return_value=tmp_path / "workspace",
+        ),
+    ):
+        from jiuwenswarm.server.runtime.session.git_diff_status import (
+            get_session_extra_history_roots,
+        )
+
+        roots = get_session_extra_history_roots("sess-1")
+
+    assert str(sub_agents_dir / "sess-1_sub_general-purpose_abc") in roots
+    assert str(sub_agents_dir / "sess-1_sub_general-purpose_def") in roots
+    assert str(sub_agents_dir / "sess-other_sub_general-purpose_xyz") not in roots
+
+
 def test_is_valid_file_ops_file_uses_suffix_match():
     """session_id 后缀匹配,避免子串误匹配其他 session 的 file_ops 文件。"""
     service = DiffService()
@@ -1059,6 +1090,24 @@ def test_is_valid_file_ops_file_uses_suffix_match():
     # require_session=False 且 session_id=None: 接受所有 file_ops 文件
     assert service._is_valid_file_ops_file("file_ops_agent.json", None)
     assert service._is_valid_file_ops_file("file_ops_agent.json", None, require_session=False)
+
+
+def test_is_valid_file_ops_file_matches_sub_agent_sessions():
+    """父 session_id 也应匹配子 agent 会话的 file_ops 文件(后缀 _sub_{type}_{suffix})。"""
+    service = DiffService()
+    parent = "sess_19fa7d326c9_87aa9a3ff27a"
+    sub_name = "file_ops_93eeae01a6bb439eb7e241a9c8d8d375_sess_19fa7d326c9_87aa9a3ff27a_sub_general-purpose_17a7bada.json"
+    assert service._is_valid_file_ops_file(sub_name, parent)
+    assert service._is_valid_file_ops_file(sub_name, parent, require_session=True)
+    exact_name = "file_ops_jiuwenswarm_sess_19fa7d326c9_87aa9a3ff27a.json"
+    assert service._is_valid_file_ops_file(exact_name, parent)
+    other_parent = "sess_other"
+    assert not service._is_valid_file_ops_file(sub_name, other_parent)
+    assert not service._is_valid_file_ops_file("file_ops_agent_sess_10.json", "sess_1")
+    spoofed = "file_ops_abc_sess-1_sub_def_sess-other.json"
+    assert service._is_valid_file_ops_file(spoofed, "sess-1")
+    empty_agent = "file_ops__sess-1_sub_general-purpose_abc.json"
+    assert not service._is_valid_file_ops_file(empty_agent, "sess-1")
 
 
 def test_multi_history_root_first_wins_for_duplicate_entries(tmp_path, monkeypatch):


### PR DESCRIPTION
Paired: [GitHub #1717](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1717) ↔ [GitCode !4235](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4235)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <label>


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

## 问题现象

code 模式下，会话中使用子 agent（Agent 工具）编写代码后，Web 窗口右侧 CodeEnvironmentPanel 的"本轮变更"行数统计始终为零，未正确反映子 agent 的文件变更数量。

## 根因分析

问题涉及 diff 统计流水线的两个环节，缺任一均导致子 agent 变更丢失：

### 环节一：目录发现 — `get_session_extra_history_roots` 返回空列表

`_read_agent_history` 依赖 `extra_history_roots` 参数决定扫描哪些目录的 `.agent_history`。该参数来源于 `get_session_extra_history_roots`，其逻辑为：

- 从 session metadata 读取 `team_file_monitor_roots`（由 team 模式写入）
- 若有 `team_name`，推断 team 下的 member/workspace/worktree 路径

在**单 agent 模式**下，session metadata 中 `team_name` 为空、`team_file_monitor_roots` 为 None，上述两条路径均无产出，函数返回空列表。

子 agent 的 workspace 位于 `<agent_workspace>/sub_agents/<sub_session_id>/`（如 `workspace/sub_agents/sess_xxx_sub_general-purpose_abc/`），此路径不在项目目录下，也不在任何已有扫描范围内。`_read_agent_history` 因此**完全不会扫描子 agent 的 `.agent_history` 目录**，file_ops 文件无从进入读取范围。

### 环节二：文件名匹配 — `_is_valid_file_ops_file` 拒绝子 agent 文件名

即使子 agent 目录被纳入扫描范围，`_read_agent_history` 内部用 `_is_valid_file_ops_file` 过滤 file_ops 文件名。该函数采用精确后缀匹配：`name.endswith(f"_{session_id}.json")`。

子 agent 的 file_ops 文件名形如 `file_ops_{agent_id}_{parent_session_id}_sub_{type}_{suffix}.json`，后缀为 `_{sub_session_id}.json` 而非 `_{parent_session_id}.json`，因此被拒绝匹配。

**综上：单 agent 模式下，目录未发现 + 文件名不匹配，子 agent 的代码变更在两个环节均被排除，导致 diff stats 为零。**

## 修改方案

### 1. 新增子 agent workspace 目录发现

在 `git_diff_status.py` 中新增 `_discover_sub_agent_workspaces` 函数：

- 扫描 `<agent_workspace>/sub_agents/` 目录
- 以 `{session_id}_sub_` 为前缀匹配子 agent 目录名
- 将匹配到的目录作为 extra history roots 传入 `_read_agent_history`

在 `get_session_extra_history_roots` 末尾调用此函数，确保无论是否有 team 上下文，子 agent 的 workspace 目录均被发现。

### 2. 扩展 file_ops 文件名匹配规则

在 `diff_service.py` 的 `_is_valid_file_ops_file` 中：

- 保留原有精确后缀匹配 `name.endswith(f"_{session_id}.json")` 作为第一优先级
- 新增子 agent 匹配：当精确后缀不命中时，检查文件名是否包含 `_{session_id}_sub_` 标记
- 此标记仅在子 agent 会话 ID 中出现，不会误匹配其他 session 的 file_ops 文件


自验结果：
验证4次，均正常显示
<img width="3114" height="1702" alt="a8c043fb4ef12a7d34b653591b6fcb43" src="https://github.com/user-attachments/assets/8f5b3435-9e3b-4946-85ea-0b9f76f4b60a" />

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1470
<!-- /bot1-related-issues -->
