### PR TITLE
fix(hooks): 修复 Agent Hook 的 session_id 丢失

### DIFF
--- a/jiuwenswarm/server/hooks/user_hook_rail.py
+++ b/jiuwenswarm/server/hooks/user_hook_rail.py
@@ -29,6 +29,19 @@ class UserHookRail(DeepAgentRail):
         self._config = hooks_config
         self._executor = HookExecutor()
 
+    @staticmethod
+    def _resolve_session_id(ctx: AgentCallbackContext) -> str:
+        """Resolve the session ID from the callback context."""
+        for source in (getattr(ctx, "session", None), ctx):
+            if source is None:
+                continue
+            for attr_name in ("get_session_id", "session_id"):
+                attr = getattr(source, attr_name, None)
+                value = attr() if callable(attr) else attr
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return ""
+
     # ---- PreToolUse: BEFORE_TOOL_CALL ----
 
     async def before_tool_call(self, ctx: AgentCallbackContext) -> None:
@@ -47,7 +60,7 @@ class UserHookRail(DeepAgentRail):
                 "event": "PreToolUse",
                 "tool_name": tool_name,
                 "tool_input": tool_args,
-                "session_id": getattr(ctx, "session_id", ""),
+                "session_id": self._resolve_session_id(ctx),
             },
         )
 
@@ -90,7 +103,7 @@ class UserHookRail(DeepAgentRail):
                 "tool_name": tool_name,
                 "tool_input": ctx.inputs.tool_args,
                 "tool_result": ctx.inputs.tool_result,
-                "session_id": getattr(ctx, "session_id", ""),
+                "session_id": self._resolve_session_id(ctx),
             },
         )
 
@@ -123,7 +136,7 @@ class UserHookRail(DeepAgentRail):
                 "tool_name": tool_name,
                 "tool_input": ctx.inputs.tool_args,
                 "error": str(getattr(ctx, "exception", "")),
-                "session_id": getattr(ctx, "session_id", ""),
+                "session_id": self._resolve_session_id(ctx),
             },
         )
 
@@ -139,7 +152,7 @@ class UserHookRail(DeepAgentRail):
             hook_input={
                 "event": "Stop",
                 "final_response": getattr(ctx.inputs, "result", None),
-                "session_id": getattr(ctx, "session_id", ""),
+                "session_id": self._resolve_session_id(ctx),
             },
         )
 

--- a/tests/unit_tests/server/hooks/test_user_hook_rail.py
+++ b/tests/unit_tests/server/hooks/test_user_hook_rail.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import AsyncMock
+
 import pytest
 
 from jiuwenswarm.common.hooks_config import HooksConfig, HookMatcher
@@ -28,6 +30,15 @@ class MockToolInputs:
 class MockCallbackContext:
     inputs: MockToolInputs = field(default_factory=MockToolInputs)
     extra: dict = field(default_factory=dict)
+    session: Any = None
+
+
+@dataclass
+class MockSession:
+    session_id: str
+
+    def get_session_id(self) -> str:
+        return self.session_id
 
 
 # ============================================================
@@ -331,6 +342,55 @@ class TestAfterInvoke:
         await rail.after_invoke(ctx)
         # 即使第二个 hook 是 blocking，也应记录 feedback
         assert "_stop_hook_feedback" in ctx.extra
+
+
+# ============================================================
+# UserHookRail: session identity
+# ============================================================
+
+
+class TestSessionIdentity:
+    @staticmethod
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("event_name", "callback_name"),
+        [
+            ("PreToolUse", "before_tool_call"),
+            ("PostToolUse", "after_tool_call"),
+            ("PostToolUseFailure", "on_tool_exception"),
+            ("Stop", "after_invoke"),
+        ],
+    )
+    async def test_hook_receives_session_id(event_name, callback_name):
+        config = HooksConfig(
+            events={
+                event_name: [
+                    HookMatcher(matcher="*", hooks=[{"command": "unused"}]),
+                ],
+            }
+        )
+        rail = UserHookRail(config)
+        rail._executor.run_all = AsyncMock(return_value=[])
+        ctx = MockCallbackContext(
+            inputs=MockToolInputs(tool_name="Read"),
+            session=MockSession("  sess_123  "),
+        )
+
+        await getattr(rail, callback_name)(ctx)
+
+        hook_input = rail._executor.run_all.await_args.kwargs["hook_input"]
+        assert hook_input["session_id"] == "sess_123"
+
+    @staticmethod
+    def test_resolve_session_id_falls_back_to_context_attribute():
+        ctx = MockCallbackContext()
+        ctx.session_id = "sess_legacy"
+
+        assert UserHookRail._resolve_session_id(ctx) == "sess_legacy"
+
+    @staticmethod
+    def test_resolve_session_id_returns_empty_without_session():
+        assert UserHookRail._resolve_session_id(MockCallbackContext()) == ""
 
 
 # ============================================================


### PR DESCRIPTION
Paired: [GitHub #1719](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1719) ↔ [GitCode !4238](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4238)

## Problem

Gateway 层的 `UserPromptSubmit` Hook 能收到正确的 `session_id`，但 Agent Rail 层的 `PreToolUse`、`PostToolUse`、`PostToolUseFailure` 和 `Stop` Hook 直接读取 `ctx.session_id`。当前 `AgentCallbackContext` 的会话标识位于 `ctx.session`，因此这些 Hook 的输入中 `session_id` 会变成空字符串。

Fixes #1671

## Solution

在 `UserHookRail` 内新增私有的会话标识解析方法，优先从 `ctx.session.get_session_id()` 或 `ctx.session.session_id` 读取，并保留对旧式 `ctx.session_id` 的兼容回退。解析结果统一去除首尾空白；不存在有效会话标识时仍返回空字符串，保持原有无会话场景行为。

该方案复用现有回调上下文，不修改公共接口，也不引入额外状态或依赖。

## Changes

- 修复四类 Agent Hook 的 `session_id` 取值路径。
- 支持方法式和属性式 session 标识，并保留旧上下文属性兼容性。
- 增加四类 Hook 的参数化回归测试。
- 增加旧调用方式和无 session 上下文的边界测试。

## Testing

- `uv run --frozen ruff check jiuwenswarm/server/hooks/user_hook_rail.py tests/unit_tests/server/hooks/test_user_hook_rail.py`
- `uv run --frozen pylint --errors-only jiuwenswarm/server/hooks/user_hook_rail.py tests/unit_tests/server/hooks/test_user_hook_rail.py`
- `uv run --frozen python -m compileall -q jiuwenswarm/server/hooks/user_hook_rail.py tests/unit_tests/server/hooks/test_user_hook_rail.py`
- 针对新增回归与不依赖 shell 的兼容性用例：`13 passed`
- 手动构造 `ctx.session.get_session_id() == "sess_probe"` 的最小探针，确认 `PreToolUse` Hook 输入得到 `session_id == "sess_probe"`。

## Notes for Reviewer

- 解析顺序有意优先使用 `ctx.session`，因为这是当前 Agent callback 的真实会话对象；直接的 `ctx.session_id` 仅作为向后兼容回退。
- 四类 Agent Hook 使用同一解析方法，避免后续事件间出现身份不一致。
- 测试使用 mock executor，只验证 Hook 输入契约，不依赖外部 shell 或模型服务。

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1671
<!-- /bot1-related-issues -->
