### PR TITLE
fix(tui): 修复面板选择模型切换报错 - index索引与_raw_defaults不一致 (#2665)

### DIFF
--- a/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/model.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/core/commands/builtins/model.ts
@@ -2,6 +2,7 @@ import { addError, addInfo } from "../helpers.js";
 import { CommandKind, type SlashCommand } from "../types.js";
 
 export interface ModelMeta {
+  index?: number;
   name: string;
   alias?: string;
   model_name?: string;
@@ -90,14 +91,14 @@ export function createModelCommand(): SlashCommand {
         // If no arg or "list", show selectable model list
         if (value === "" || value === "list") {
           const payload = await ctx.request<ModelListPayload>("command.model", {});
-          const models = payload.available_models ?? [];
+          const modelsMeta = payload.models ?? [];
           const current = payload.current ?? "unknown";
-          if (models.length === 0) {
+          if (modelsMeta.length === 0) {
             ctx.addItem(addInfo(ctx.sessionId, "No models configured", "m"));
             return;
           }
-          const skipped = models.filter((m) => isReservedMultimodalModelKey(m));
-          const selectable = models.filter((m) => !isReservedMultimodalModelKey(m));
+          const skipped = modelsMeta.filter((m) => isReservedMultimodalModelKey(m.name));
+          const selectableMeta = modelsMeta.filter((m) => m.name && !isReservedMultimodalModelKey(m.name));
           if (skipped.length > 0) {
             ctx.addItem(
               addInfo(
@@ -107,21 +108,20 @@ export function createModelCommand(): SlashCommand {
               ),
             );
           }
-          if (selectable.length === 0) {
+          if (selectableMeta.length === 0) {
             ctx.addItem(addInfo(ctx.sessionId, "No switchable models in list", "m"));
             return;
           }
-          const modelsMeta = payload.models ?? [];
+          const selectable = selectableMeta.map((m) => m.name);
           // 优先用后端 is_current 标记判断当前模型（同名模型仅靠名字无法区分），
           // 回退到 name-matching（兼容不带 is_current 的旧后端）
-          const currentIdx = selectable.findIndex((m, i) => {
-            const meta = modelsMeta[i];
+          const currentIdx = selectableMeta.findIndex((meta) => {
             return meta?.is_current === true;
           });
           const fallbackCurrentIdx = currentIdx < 0 ? selectable.findIndex((m) => m === current) : currentIdx;
           const nameOccurrence: Record<string, number> = {};
-          const items = selectable.map((m, i) => {
-            const meta = modelsMeta[i];
+          const items = selectableMeta.map((meta, i) => {
+            const m = meta.name;
             const isCurrent = i === fallbackCurrentIdx;
             // 统计同名出现次序
             const seq = (nameOccurrence[m] ?? 0) + 1;
@@ -144,8 +144,7 @@ export function createModelCommand(): SlashCommand {
               const _mk = (mm: ModelMeta | undefined) =>
                 `${mm?.model_provider ?? ""}|${mm?.api_base ?? ""}`;
               const myFingerprint = _mk(meta);
-              const conflictCount = selectable.reduce((acc, _x, xi) => {
-                const xm = modelsMeta[xi];
+              const conflictCount = selectableMeta.reduce((acc, xm) => {
                 return xm && _mk(xm) === myFingerprint ? acc + 1 : acc;
               }, 0);
               if (conflictCount > 1) {

--- a/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
+++ b/jiuwenswarm/channels/tui/frontend/src/ui/app-screen.ts
@@ -4304,19 +4304,17 @@ export class AppScreen implements Component, Focusable {
     const snapshot = this.state.getSnapshot();
     try {
       const payload = await this.state.request<ModelListPayload>("command.model", {});
-      const models = payload.available_models ?? [];
       const current = payload.current ?? "unknown";
-      if (models.length === 0) {
+      const modelsMeta = payload.models ?? [];
+      const skipped = modelsMeta.filter((m) => isReservedMultimodalModelKey(m.name));
+      const selectableWithOrigIdx = modelsMeta
+        .filter((meta) => meta.name && !isReservedMultimodalModelKey(meta.name))
+        .map((meta) => ({ name: meta.name, origIdx: meta.index, meta }));
+      const selectable = selectableWithOrigIdx.map((entry) => entry.name);
+      if (modelsMeta.length === 0) {
         this.openEmptyModelList(current, "No models configured");
         return;
       }
-
-      const skipped = models.filter((m) => isReservedMultimodalModelKey(m));
-      // 构建 selectable 时保留在完整 models 列表中的原始索引，避免 reserved 模型过滤后索引错位
-      const selectableWithOrigIdx = models
-        .map((m, i) => ({ name: m, origIdx: i }))
-        .filter((entry) => !isReservedMultimodalModelKey(entry.name));
-      const selectable = selectableWithOrigIdx.map((entry) => entry.name);
       if (skipped.length > 0) {
         this.state.addItem(
           addInfo(
@@ -4331,18 +4329,16 @@ export class AppScreen implements Component, Focusable {
         return;
       }
 
-      const modelsMeta = payload.models ?? [];
       // 优先用后端 is_current 标记判断当前模型（同名模型仅靠名字无法区分），
       // 回退到 name-matching（兼容不带 is_current 的旧后端）
       const currentIdx = selectableWithOrigIdx.findIndex((entry) => {
-        const meta = modelsMeta[entry.origIdx];
-        return meta?.is_current === true;
+        return entry.meta?.is_current === true;
       });
       const fallbackCurrentIdx = currentIdx < 0 ? selectable.findIndex((m) => m === current) : currentIdx;
       const nameOccurrence: Record<string, number> = {};
       const items = selectableWithOrigIdx.map((entry, i) => {
         const m = entry.name;
-        const meta = modelsMeta[entry.origIdx];
+        const meta = entry.meta;
         const isCurrent = i === fallbackCurrentIdx;
         const seq = (nameOccurrence[m] ?? 0) + 1;
         nameOccurrence[m] = seq;
@@ -4364,9 +4360,8 @@ export class AppScreen implements Component, Focusable {
           const _mk = (mm: ModelMeta | undefined) =>
             `${mm?.model_provider ?? ""}|${mm?.api_base ?? ""}`;
           const myFingerprint = _mk(meta);
-          // selectableWithOrigIdx 与 selectable 同序，origIdx 索引回 modelsMeta
           const conflictCount = selectableWithOrigIdx.reduce((acc, ent) => {
-            const xm = modelsMeta[ent.origIdx];
+            const xm = ent.meta;
             return xm && _mk(xm) === myFingerprint ? acc + 1 : acc;
           }, 0);
           if (conflictCount > 1) {
@@ -4526,7 +4521,7 @@ export class AppScreen implements Component, Focusable {
   }
 
   private createModelForm(mode: "add" | "edit", target?: { index: number }): ModelFormState {
-    const meta = target ? this.modelList?.modelsMeta[target.index] : undefined;
+    const meta = target ? this.modelList?.modelsMeta.find((m) => m.index !== undefined && m.index === target.index) : undefined;
     const fields: Record<ModelFormField, string> = {
       model_name: mode === "edit" ? meta?.model_name ?? "" : "",
       alias: mode === "edit" ? meta?.alias ?? "" : "",
@@ -4814,8 +4809,8 @@ export class AppScreen implements Component, Focusable {
       return "reasoning_level must be default, off, low, medium, or high";
     }
     if (trimmed.alias) {
-      const conflict = state.modelsMeta.find((model, index) => {
-        if (state.inputMode === "edit" && index === state.target?.index) return false;
+      const conflict = state.modelsMeta.find((model) => {
+        if (state.inputMode === "edit" && model.index !== undefined && model.index === state.target?.index) return false;
         return (model.alias || "") === trimmed.alias || model.model_name === trimmed.alias;
       });
       if (conflict) {

--- a/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
+++ b/jiuwenswarm/gateway/channel_manager/tui/tui_connect.py
@@ -2750,6 +2750,7 @@ def register_cli_handlers(bind: CliHandlersBindParams) -> None:
                     _model_name = resolve_env_vars(str(mcc.get("model_name", "")))
                     _api_key = resolve_env_vars(str(mcc.get("api_key", "")))
                     return {
+                        "index": i,
                         "name": _resolved_alias or _model_name,
                         "alias": _resolved_alias,
                         "model_name": _model_name,

--- a/tests/unit_tests/gateway/test_cli_channel_handlers.py
+++ b/tests/unit_tests/gateway/test_cli_channel_handlers.py
@@ -474,3 +474,133 @@ async def test_session_list_returns_agent_timeout_before_tui_request_timeout(mon
         "error": "AgentServer request timed out",
         "code": "AGENT_SERVER_TIMEOUT",
     }
+
+
+def test_get_model_names_skips_empty_name_entries(tmp_path, monkeypatch):
+    """Bug #2665: get_model_names() should skip entries with unresolved env vars
+    (empty resolved name), so available_models indices don't match _raw_defaults indices.
+    The frontend should use models[].index instead of available_models array index.
+    """
+    import yaml
+
+    from jiuwenswarm.common.config import get_model_names
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        yaml.safe_dump(
+            {
+                "models": {
+                    "defaults": [
+                        {
+                            "model_client_config": {
+                                "api_key": "${API_KEY}",
+                                "api_base": "${API_BASE}",
+                                "model_name": "${MODEL_NAME}",
+                                "client_provider": "${MODEL_PROVIDER}",
+                            },
+                            "model_config_obj": {"temperature": 0.95},
+                            "is_default": True,
+                        },
+                        {
+                            "model_client_config": {
+                                "api_key": "sk-test-key",
+                                "api_base": "https://dashscope.aliyuncs.com/v1",
+                                "model_name": "glm-5",
+                                "client_provider": "OpenAI",
+                            },
+                            "model_config_obj": {"temperature": 0.95},
+                        },
+                    ]
+                }
+            },
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config.CONFIG_YAML_PATH", cfg, raising=False,
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.common.config._CONFIG_YAML_PATH", cfg, raising=False,
+    )
+
+    import jiuwenswarm.common.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "CONFIG_YAML_PATH", cfg)
+    monkeypatch.setattr(cfg_mod, "_CONFIG_YAML_PATH", cfg)
+
+    for var in ("API_KEY", "API_BASE", "MODEL_NAME", "MODEL_PROVIDER"):
+        monkeypatch.delenv(var, raising=False)
+
+    names = get_model_names()
+    assert names == ["glm-5"], (
+        f"get_model_names() should skip the placeholder entry with unresolved env vars, "
+        f"got {names}"
+    )
+
+
+def test_model_meta_index_field_matches_raw_defaults_position():
+    """Bug #2665: _model_meta must include the _raw_defaults index
+    so the frontend can send the correct index for model switching.
+    """
+    from jiuwenswarm.common.config import resolve_env_vars
+
+    defaults = [
+        {
+            "model_client_config": {
+                "api_key": "${API_KEY}",
+                "api_base": "${API_BASE}",
+                "model_name": "${MODEL_NAME}",
+                "client_provider": "${MODEL_PROVIDER}",
+            },
+            "model_config_obj": {"temperature": 0.95},
+            "is_default": True,
+        },
+        {
+            "model_client_config": {
+                "api_key": "sk-test-key",
+                "api_base": "https://dashscope.aliyuncs.com/v1",
+                "model_name": "glm-5",
+                "client_provider": "OpenAI",
+            },
+            "model_config_obj": {"temperature": 0.95},
+        },
+    ]
+
+    def _model_meta(i, e):
+        mcc = e.get("model_client_config") or {}
+        mco = e.get("model_config_obj") or {}
+        _alias = e.get("alias", "")
+        _resolved_alias = resolve_env_vars(str(_alias)) if _alias else ""
+        _model_name = resolve_env_vars(str(mcc.get("model_name", "")))
+        _api_key = resolve_env_vars(str(mcc.get("api_key", "")))
+        return {
+            "index": i,
+            "name": _resolved_alias or _model_name,
+            "alias": _resolved_alias,
+            "model_name": _model_name,
+            "model_provider": resolve_env_vars(str(mcc.get("client_provider", ""))),
+            "api_base": resolve_env_vars(str(mcc.get("api_base", ""))),
+            "reasoning_level": resolve_env_vars(str(mco.get("reasoning_level", ""))),
+            "api_key_suffix": _api_key[-4:] if _api_key else "",
+            "is_current": i == 0,
+        }
+
+    import os
+    for var in ("API_KEY", "API_BASE", "MODEL_NAME", "MODEL_PROVIDER"):
+        os.environ.pop(var, None)
+
+    models = [_model_meta(i, e) for i, e in enumerate(defaults) if isinstance(e, dict)]
+
+    assert models[0]["index"] == 0
+    assert models[0]["name"] == ""
+    assert models[1]["index"] == 1
+    assert models[1]["name"] == "glm-5"
+
+    selectable = [m for m in models if m["name"] and not m["name"].lower() in ("video", "audio", "vision")]
+    assert len(selectable) == 1
+    assert selectable[0]["index"] == 1, (
+        "Frontend should use selectable[0]['index']=1 as origIdx, "
+        "not the available_models array index (0)"
+    )


### PR DESCRIPTION
Paired: [GitHub #1827](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1827) ↔ [GitCode !4288](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4288)

根因: 前端 available_models 数组索引与后端 _raw_defaults 索引不一致。 当存在环境变量未解析的占位条目(空名称)时，available_models 跳过该条目，
导致前端 origIdx 比实际 _raw_defaults 位置偏小，后端用该 index 取到错误条目。

修复:
- 后端 _model_meta 输出增加 index 字段，显式传递 _raw_defaults 真实索引
- 前端 openModelList 改用 payload.models + meta.index 构建 selectableWithOrigIdx
- 前端 model.ts CLI /model list 同步改用 modelsMeta + meta.index
- ModelMeta.index 设为可选字段，兼容旧后端(缺省时退化为 name 搜索)
- createModelForm/validateModelForm 中用 modelsMeta.find + index 查找，防止 undefined 匹配

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <label>


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
## 复现场景：
环境变量API_BASE、API_KEY、MODEL_NAME、MODEL_PROVIDER置空，本地启动jiuwenswarm-tui，/model add 配置模型，/model不加参数调出面板选择配置的模型

## 根因：
存在环境变量未解析的占位条目时，available_models 跳过空名条目导致索引偏移，面板传的 index 比实际 _raw_defaults 位置小，后端取到错误条目。

## 修复方案：后端添加显式 index + 前端使用它
1. 后端改动 tui_connect.py:2741-2758：_model_meta 输出增加 "index": i 字段
2. 前端改动 app-screen.ts:4292-4373：用 payload.models（含所有条目+真实index）构建 selectable，替代 available_models
3. 同样需修复 CLI /model list 展示路径 model.ts:117-159，用 meta.index 代替数组下标 i。

自验证结果：
置空环境变量后启动TUI
<img width="2346" height="1222" alt="image" src="https://github.com/user-attachments/assets/6c160cf7-61cb-4d5c-9f27-b9fc99b00e5c" />

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1495
<!-- /bot1-related-issues -->
