### PR TITLE
fix: persist chat.tool_result to history so tool status restores corr…

### DIFF
--- a/jiuwenswarm/channels/web/frontend/package.json
+++ b/jiuwenswarm/channels/web/frontend/package.json
@@ -18,6 +18,7 @@
     "test:stream-delta-batcher": "tsc src/services/streamDeltaBatcher.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/stream-delta-batcher --skipLibCheck --noEmitOnError && node --test tests/streamDeltaBatcher.test.mjs",
     "test:file-download-dedup": "tsc src/utils/fileDownloadDedup.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/file-download-dedup --skipLibCheck --noEmitOnError && node --test tests/fileDownloadDedup.test.mjs",
     "test:chat-store-streaming": "esbuild src/stores/chatStore.ts --bundle --platform=node --format=esm --outfile=node_modules/.cache/chat-store-streaming/chatStore.mjs --define:import.meta.env.DEV=false && node --test tests/chatStoreStreaming.test.mjs",
+    "test:settle-historical-tool-executions": "esbuild src/stores/chatStore.ts --bundle --platform=node --format=esm --outfile=node_modules/.cache/chat-store-streaming/chatStore.mjs --define:import.meta.env.DEV=false && node --test tests/settleHistoricalToolExecutions.test.mjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
+++ b/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
@@ -2862,6 +2862,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
           useChatStore.getState().setThinking(sessionId, false);
           useChatStore.getState().clearSubtasks(sessionId);
           useChatStore.getState().stopStreaming(sessionId);
+          useChatStore.getState().settleHistoricalToolExecutions(sessionId);
 
           // 检查是否有等待的任务队列
           const currentMode = useSessionStore.getState().getRuntime(sessionId)?.mode;

--- a/jiuwenswarm/channels/web/frontend/tests/settleHistoricalToolExecutions.test.mjs
+++ b/jiuwenswarm/channels/web/frontend/tests/settleHistoricalToolExecutions.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { useChatStore } from '../node_modules/.cache/chat-store-streaming/chatStore.mjs';
+
+const SID = 'settle-historical-test';
+
+function setup() {
+  useChatStore.getState().ensureRuntime(SID);
+}
+
+function teardown() {
+  useChatStore.getState().removeRuntime(SID);
+}
+
+function addToolCall(toolCallId, toolName) {
+  useChatStore.getState().addToolCall(SID, {
+    id: toolCallId,
+    name: toolName,
+    arguments: {},
+  }, { startedAt: new Date().toISOString() });
+}
+
+function getToolStatus(toolCallId) {
+  const runtime = useChatStore.getState().getRuntime(SID);
+  if (!runtime) return undefined;
+  const execution = runtime.toolExecutions.get(toolCallId);
+  return execution?.status;
+}
+
+test('settleHistoricalToolExecutions settles pending tools when isProcessing is false', () => {
+  setup();
+  try {
+    addToolCall('call-1', 'list_files');
+    assert.equal(getToolStatus('call-1'), 'pending');
+
+    useChatStore.getState().settleHistoricalToolExecutions(SID);
+    assert.equal(getToolStatus('call-1'), 'completed');
+  } finally {
+    teardown();
+  }
+});
+
+test('settleHistoricalToolExecutions skips settling when isProcessing is true', () => {
+  setup();
+  try {
+    useChatStore.getState().setProcessing(SID, true);
+    addToolCall('call-2', 'code');
+
+    useChatStore.getState().settleHistoricalToolExecutions(SID);
+    assert.equal(getToolStatus('call-2'), 'pending');
+  } finally {
+    useChatStore.getState().setProcessing(SID, false);
+    teardown();
+  }
+});
+
+test('settleHistoricalToolExecutions settles after setProcessing false', () => {
+  setup();
+  try {
+    useChatStore.getState().setProcessing(SID, true);
+    addToolCall('call-3', 'cron');
+
+    useChatStore.getState().settleHistoricalToolExecutions(SID);
+    assert.equal(getToolStatus('call-3'), 'pending');
+
+    useChatStore.getState().setProcessing(SID, false);
+    useChatStore.getState().settleHistoricalToolExecutions(SID);
+    assert.equal(getToolStatus('call-3'), 'completed');
+  } finally {
+    teardown();
+  }
+});
+
+test('settleHistoricalToolExecutions does not downgrade completed tools', () => {
+  setup();
+  try {
+    addToolCall('call-4', 'search');
+
+    useChatStore.getState().addToolResult(SID, {
+      toolCallId: 'call-4',
+      toolName: 'search',
+      result: 'found',
+      success: true,
+    });
+    assert.equal(getToolStatus('call-4'), 'completed');
+
+    useChatStore.getState().settleHistoricalToolExecutions(SID);
+    assert.equal(getToolStatus('call-4'), 'completed');
+  } finally {
+    teardown();
+  }
+});
+
+test('settleHistoricalToolExecutions settles timeout tools', () => {
+  setup();
+  try {
+    addToolCall('call-5', 'slow_tool');
+
+    useChatStore.getState().markTimedOutExecutions(SID);
+    const status = getToolStatus('call-5');
+    assert.equal(status, 'pending');
+
+    useChatStore.getState().settleHistoricalToolExecutions(SID);
+    assert.equal(getToolStatus('call-5'), 'completed');
+  } finally {
+    teardown();
+  }
+});
+
+test('addToolCall then addToolResult yields completed status', () => {
+  setup();
+  try {
+    addToolCall('call-6', 'read_file');
+
+    useChatStore.getState().addToolResult(SID, {
+      toolCallId: 'call-6',
+      toolName: 'read_file',
+      result: 'content',
+      success: true,
+    });
+    assert.equal(getToolStatus('call-6'), 'completed');
+  } finally {
+    teardown();
+  }
+});

--- a/jiuwenswarm/server/runtime/session/session_history.py
+++ b/jiuwenswarm/server/runtime/session/session_history.py
@@ -50,6 +50,8 @@ def _has_persistable_assistant_payload(
         return True
     if et == "chat.tool_call" and (payload.get("tool_call") or payload.get("tool_calls")):
         return True
+    if et == "chat.tool_result" and (payload.get("tool_result") or payload.get("tool_call_id")):
+        return True
     if payload.get("error") or payload.get("files"):
         return True
     if payload.get("tool_call") or payload.get("tool_calls"):

--- a/tests/unit_tests/test_session_history_empty_filter.py
+++ b/tests/unit_tests/test_session_history_empty_filter.py
@@ -66,3 +66,140 @@ def test_append_history_skips_empty_chat_final_and_heartbeat(tmp_path, monkeypat
     assert [item.get("event_type") for item in data] == ["chat.file", "chat.final"]
     assert data[1]["content"] == "hello"
     assert session_history.load_history_records("heartbeat_abc") == []
+
+
+def test_has_persistable_assistant_payload_tool_result_with_tool_call_id():
+    assert session_history._has_persistable_assistant_payload(
+        content_text="",
+        event_type="chat.tool_result",
+        extra={"tool_call_id": "call_abc", "tool_name": "list_files", "result": "ok"},
+    ) is True
+
+
+def test_has_persistable_assistant_payload_tool_result_with_nested_tool_result():
+    assert session_history._has_persistable_assistant_payload(
+        content_text="",
+        event_type="chat.tool_result",
+        extra={"tool_result": {"tool_name": "test", "tool_call_id": "call_abc", "result": "ok"}},
+    ) is True
+
+
+def test_has_persistable_assistant_payload_tool_result_empty_rejected():
+    assert session_history._has_persistable_assistant_payload(
+        content_text="",
+        event_type="chat.tool_result",
+        extra={},
+    ) is False
+
+
+def test_has_persistable_assistant_payload_tool_result_falsy_values_rejected():
+    assert session_history._has_persistable_assistant_payload(
+        content_text="",
+        event_type="chat.tool_result",
+        extra={"tool_call_id": "", "tool_result": None},
+    ) is False
+
+
+def test_has_persistable_assistant_payload_processing_status_still_rejected():
+    assert session_history._has_persistable_assistant_payload(
+        content_text="",
+        event_type="chat.processing_status",
+        extra={"is_processing": True},
+    ) is False
+
+
+def test_has_persistable_assistant_payload_tool_update_still_rejected():
+    assert session_history._has_persistable_assistant_payload(
+        content_text="",
+        event_type="chat.tool_update",
+        extra={"tool_call_id": "call_abc", "beam_search": {}},
+    ) is False
+
+
+def test_append_history_persists_tool_result(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_history, "get_agent_sessions_dir", lambda: tmp_path)
+
+    session_history.append_history_record(
+        session_id="s-tool-result",
+        request_id="r1",
+        channel_id="web",
+        role="assistant",
+        event_type="chat.tool_call",
+        content="",
+        timestamp=1.0,
+        extra={"tool_call": {"name": "list_files", "id": "call_abc", "arguments": "{}"}},
+    )
+    session_history.append_history_record(
+        session_id="s-tool-result",
+        request_id="r1",
+        channel_id="web",
+        role="assistant",
+        event_type="chat.tool_result",
+        content="",
+        timestamp=2.0,
+        extra={"tool_call_id": "call_abc", "tool_name": "list_files", "result": "file1.txt", "success": True},
+    )
+    session_history.append_history_record(
+        session_id="s-tool-result",
+        request_id="r1",
+        channel_id="web",
+        role="assistant",
+        event_type="chat.final",
+        content="Done",
+        timestamp=3.0,
+    )
+
+    data = _wait_history("s-tool-result", min_count=3)
+    event_types = [item.get("event_type") for item in data]
+    assert event_types == ["chat.tool_call", "chat.tool_result", "chat.final"]
+
+    tool_result_record = data[1]
+    assert tool_result_record["event_type"] == "chat.tool_result"
+    assert tool_result_record["tool_call_id"] == "call_abc"
+    assert tool_result_record["tool_name"] == "list_files"
+
+
+def test_append_history_persists_tool_result_with_nested_payload(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_history, "get_agent_sessions_dir", lambda: tmp_path)
+
+    session_history.append_history_record(
+        session_id="s-nested",
+        request_id="r1",
+        channel_id="web",
+        role="assistant",
+        event_type="chat.tool_result",
+        content="cancelled",
+        timestamp=1.0,
+        extra={
+            "tool_result": {
+                "tool_name": "code",
+                "tool_call_id": "call_xyz",
+                "result": "cancelled",
+                "status": "error",
+            },
+        },
+    )
+
+    data = _wait_history("s-nested", min_count=1)
+    assert len(data) == 1
+    assert data[0]["event_type"] == "chat.tool_result"
+
+
+def test_append_history_tool_result_empty_payload_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(session_history, "get_agent_sessions_dir", lambda: tmp_path)
+
+    session_history.append_history_record(
+        session_id="s-empty-tr",
+        request_id="r1",
+        channel_id="web",
+        role="assistant",
+        event_type="chat.tool_result",
+        content="",
+        timestamp=1.0,
+        extra={},
+    )
+
+    import time as _t
+    _t.sleep(0.3)
+    data = session_history.load_history_records("s-empty-tr")
+    assert data == []


### PR DESCRIPTION
Paired: [GitHub #1857](https://github.com/openJiuwen-ai/jiuwenswarm/pull/1857) ↔ [GitCode !4300](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4300)

…ectly on refresh

Root cause: _has_persistable_assistant_payload did not explicitly handle chat.tool_result, so it fell through to the et.startswith('chat.') guard and was silently dropped. After refresh, only tool_call records existed in history, leaving tool executions stuck in 'pending' (shown as 'executing' in the UI).

Changes:
- session_history.py: add explicit chat.tool_result persistence check
- useWebSocket.ts: call settleHistoricalToolExecutions when processing_status becomes false, as a safety net for stale pending tools that survive history restore
- Add backend and frontend test cases

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <label>


**What does this PR do / why do we need it**:
* Need to describe clearly


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Need to describe clearly


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [ ] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
## 现象
用户query执行完成之后刷新浏览器，web界面中的工具状态显示为执行中

## 根因
_has_persistable_assistant_payload（session_history.py:32-61）没有显式处理 chat.tool_result 事件类型，导致它被 et.startswith("chat.") 的通用规则过滤掉（返回 False），chat.tool_result 事件不会被持久化到 history.jsonl。

**逻辑流程**
1. chat.tool_result 的 content 为空（结果在 extra 字段中）
2. _has_persistable_assistant_payload 中，chat.tool_call 在 line 51 被显式处理（if et == "chat.tool_call" and ...）
3. 但 chat.tool_result 没有类似的显式处理
4. 最终命中 line 58 的 if et.startswith("chat."): return False，被过滤掉
5. 因此 chat.tool_result 不会被持久化到 history.jsonl
**刷新后的影响**
1. 历史恢复只返回 chat.tool_call 记录，没有 chat.tool_result
2. onToolReplay 只调用 addToolCall（创建 status: 'pending'），不会调用 addToolResult
3. settleHistoricalToolExecutions 应该结算这些 'pending' 的工具，但如果有 isProcessing guard 的问题，它们会保持 'pending' 状态
4. 前端将 'pending' 状态显示为"执行中"

## 修复方案
1. 后端修复（session_history.py:53）：在 _has_persistable_assistant_payload 中添加对 chat.tool_result 的显式处理
2. 前端防御（useWebSocket.ts:2865）：当 isProcessing 变为 false 时，调用 settleHistoricalToolExecutions 作为兜底，确保即使历史恢复时被 isProcessing guard 阻止，也能在 isProcessing 变为 false 后结算残留的 'pending' 工具：

## 自验证结果
query执行完成或执行中刷新浏览器都能正常显示：
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/1b0ade3b-0fc1-4089-a0dc-de4b06448ab7" />
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/2c46850d-d8c3-423e-a7c3-0f89c66d5a72" />
<img width="1912" height="914" alt="image" src="https://github.com/user-attachments/assets/e5044c1e-4bee-41fe-b489-ae137b6ad8d1" />

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1488
<!-- /bot1-related-issues -->
