### PR TITLE
feat(pdf): implement PDF file input and content analysis

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/pdf_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/pdf_tools.py
@@ -1,0 +1,235 @@
+# coding: utf-8
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Page-level PDF reading tool.
+
+Extracts the text layer of a PDF with pdfplumber (bundled with openjiuwen).
+Supports page ranges so large documents can be read incrementally, as the
+wiki ingestion prompts instruct. Pages without a text layer (scanned PDFs)
+are flagged so the model can fall back to vision tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openjiuwen.core.foundation.tool import tool
+
+from jiuwenswarm.common.utils import get_agent_workspace_dir
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_CHARS = 50_000
+_MAX_CHARS_CEILING = 200_000
+_MAX_PAGES_PER_CALL = 100
+
+
+@dataclass(frozen=True)
+class ReadPdfRequest:
+    pdf_path: str
+    pages: tuple[int, ...] | None  # 1-based page numbers; None = all pages
+    max_chars: int = DEFAULT_MAX_CHARS
+
+
+def _parse_page_ranges(value: Any) -> tuple[int, ...] | None:
+    """Parse ``pages`` input into sorted unique 1-based page numbers.
+
+    Accepts an int (single page), a list of ints, or a string such as
+    ``"1-5"``, ``"1,3,8-10"``. Empty / None means all pages.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("pages must be a page number, list, or range string like '1-5,8'")
+    if isinstance(value, int):
+        if value < 1:
+            raise ValueError(f"page numbers are 1-based, got: {value}")
+        return (value,)
+    if isinstance(value, (list, tuple)):
+        pages: set[int] = set()
+        for entry in value:
+            parsed = _parse_page_ranges(entry)
+            if parsed:
+                pages.update(parsed)
+        return tuple(sorted(pages)) or None
+
+    text = str(value).strip()
+    if not text:
+        return None
+    pages = set()
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_text, _, end_text = part.partition("-")
+            try:
+                start, end = int(start_text), int(end_text)
+            except ValueError as exc:
+                raise ValueError(f"Invalid page range: {part!r}. Use forms like '1-5' or '3'.") from exc
+            if start < 1 or end < start:
+                raise ValueError(f"Invalid page range: {part!r} (pages are 1-based, start <= end)")
+            pages.update(range(start, end + 1))
+        else:
+            try:
+                page = int(part)
+            except ValueError as exc:
+                raise ValueError(f"Invalid page number: {part!r}") from exc
+            if page < 1:
+                raise ValueError(f"page numbers are 1-based, got: {page}")
+            pages.add(page)
+    return tuple(sorted(pages)) or None
+
+
+def _resolve_pdf_path(value: str) -> Path:
+    """Resolve ``pdf_path`` like other always-on tools (see wiki_ingest).
+
+    Relative paths anchor to the agent workspace, never the process CWD.
+    Absolute paths are accepted as-is — local file access is gated by the
+    permission rail, matching read_file / wiki_ingest's trust model.
+    """
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("pdf_path cannot be empty")
+    path = Path(text).expanduser()
+    if not path.is_absolute():
+        path = get_agent_workspace_dir() / path
+    path = path.resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"PDF file does not exist: {path}")
+    if not path.is_file():
+        raise ValueError(f"pdf_path is not a file: {path}")
+    if path.suffix.lower() != ".pdf":
+        raise ValueError(f"read_pdf only accepts .pdf files, got: {path.name}")
+    return path
+
+
+def _normalize_request(inputs: dict[str, Any]) -> ReadPdfRequest:
+    pdf_path = str(inputs.get("pdf_path", "") or inputs.get("path", "") or "").strip()
+    if not pdf_path:
+        raise ValueError("pdf_path cannot be empty.")
+    pages = _parse_page_ranges(inputs.get("pages"))
+    try:
+        max_chars = int(inputs.get("max_chars", DEFAULT_MAX_CHARS))
+    except (TypeError, ValueError):
+        max_chars = DEFAULT_MAX_CHARS
+    max_chars = max(1_000, min(max_chars, _MAX_CHARS_CEILING))
+    return ReadPdfRequest(pdf_path=pdf_path, pages=pages, max_chars=max_chars)
+
+
+def _read_pdf_sync(req: ReadPdfRequest) -> str:
+    # Validate the path before importing pdfplumber so path errors surface
+    # clearly even in environments where the dependency is missing.
+    path = _resolve_pdf_path(req.pdf_path)
+
+    import pdfplumber
+
+    blocks: list[str] = []
+    empty_pages: list[int] = []
+    with pdfplumber.open(str(path)) as pdf:
+        total_pages = len(pdf.pages)
+        if req.pages is not None:
+            selected = [p for p in req.pages if p <= total_pages]
+            out_of_range = [p for p in req.pages if p > total_pages]
+        else:
+            selected = list(range(1, total_pages + 1))
+            out_of_range = []
+
+        truncated_pages = selected[_MAX_PAGES_PER_CALL:]
+        selected = selected[:_MAX_PAGES_PER_CALL]
+
+        header = [f"PDF: {path.name} | total pages: {total_pages} | reading pages: "
+                  + (_format_page_list(selected) if selected else "none")]
+        if out_of_range:
+            header.append(
+                f"[Note: requested page(s) {_format_page_list(out_of_range)} exceed "
+                f"total page count {total_pages} and were skipped]"
+            )
+        if truncated_pages:
+            header.append(
+                f"[Note: at most {_MAX_PAGES_PER_CALL} pages per call; "
+                f"pages {_format_page_list(truncated_pages)} were not read — "
+                "call read_pdf again with a narrower `pages` range]"
+            )
+        blocks.append("\n".join(header))
+
+        chars_used = 0
+        for idx, page_num in enumerate(selected):
+            page = pdf.pages[page_num - 1]
+            page_text = (page.extract_text() or "").strip()
+            if not page_text:
+                empty_pages.append(page_num)
+                blocks.append(f"--- Page {page_num} ---\n[no text layer on this page]")
+                continue
+            remaining = req.max_chars - chars_used
+            if remaining <= 0:
+                unread = selected[idx:]
+            else:
+                truncated_here = len(page_text) > remaining
+                if truncated_here:
+                    page_text = page_text[:remaining] + "\n[... page truncated at max_chars ...]"
+                chars_used += len(page_text)
+                blocks.append(f"--- Page {page_num} ---\n{page_text}")
+                if not truncated_here:
+                    continue
+                unread = selected[idx + 1:]
+            note = f"[Truncated at max_chars={req.max_chars}"
+            if unread:
+                note += (
+                    f"; unread pages: {_format_page_list(unread)} — "
+                    "call read_pdf again with `pages` starting there"
+                )
+            note += "]"
+            blocks.append(note)
+            break
+
+    if empty_pages:
+        blocks.append(
+            f"[Pages without extractable text: {_format_page_list(empty_pages)}. "
+            "These are likely scanned images; use image/vision tools on rendered "
+            "pages if their content is needed.]"
+        )
+    return "\n\n".join(blocks)
+
+
+def _format_page_list(pages: list[int] | tuple[int, ...]) -> str:
+    """Compress sorted page numbers into a compact range string, e.g. 1-3,7."""
+    if not pages:
+        return ""
+    ordered = sorted(set(int(p) for p in pages))
+    parts: list[str] = []
+    start = prev = ordered[0]
+    for page in ordered[1:]:
+        if page == prev + 1:
+            prev = page
+            continue
+        parts.append(str(start) if start == prev else f"{start}-{prev}")
+        start = prev = page
+    parts.append(str(start) if start == prev else f"{start}-{prev}")
+    return ",".join(parts)
+
+
+@tool(
+    name="read_pdf",
+    description=(
+        "Read the text content of a PDF file, optionally limited to specific pages. "
+        "Use this tool when a PDF file path is available and its content is needed. "
+        "For large documents, first read page 1 to learn the structure and total "
+        "page count, then read subsequent chunks with the `pages` parameter. "
+        "Input: pdf_path (local file path), optional pages (e.g. 3, '1-5' or '1,3,8-10'), "
+        "optional max_chars (default 50000). Pages without a text layer are reported "
+        "as likely scanned images."
+    ),
+)
+async def read_pdf(inputs: dict[str, Any], **kwargs) -> str:
+    _ = kwargs
+    try:
+        req = _normalize_request(inputs or {})
+        logger.info("[read_pdf] path=%s pages=%s max_chars=%s", req.pdf_path, req.pages, req.max_chars)
+        return await asyncio.to_thread(_read_pdf_sync, req)
+    except Exception as exc:
+        return f"[ERROR]: read_pdf failed: {exc}"

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/InputArea.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/InputArea.tsx
@@ -342,8 +342,15 @@ function buildSubmitContent(text: string, attachments: AttachmentDraft[]): strin
     return text;
   }
   // Agent-facing hint only (stripped from chat bubble). List every file; no 说明 line.
+  // For binary documents that have a .txt sidecar (e.g. PDF), also expose the
+  // original file path — otherwise the model cannot see the .pdf and cannot use
+  // page-level tools such as read_pdf.
   const lines = docs.map((doc) => {
     const path = pickString(doc.persistedMediaItem?.path) || '';
+    const originalPath = pickString(doc.persistedMediaItem?.original_path) || '';
+    if (path && originalPath && originalPath !== path) {
+      return `- ${doc.filename}: ${path} (original file: ${originalPath})`;
+    }
     return path ? `- ${doc.filename}: ${path}` : `- ${doc.filename}`;
   });
   return [text, '【上传文档】', ...lines].filter(Boolean).join('\n');
@@ -983,7 +990,10 @@ export function InputArea({
     );
     const trimmed = buildSubmitContent(trimmedBase, readyDrafts);
     if ((!trimmed && readyMediaItems.length === 0) || hasUploadingAttachments || hasAttachmentErrors) return;
-    if (isInterruptible && !isTeamMode && readyMediaItems.length > 0) return;
+    // In agent mode attachments queue with the task (taskQueue carries mediaItems).
+    // Other non-team modes still go through the text-only onInterrupt channel where
+    // attachments would be lost, so keep blocking there.
+    if (isInterruptible && !isTeamMode && !isAgentMode && readyMediaItems.length > 0) return;
 
     if (isListening) {
       stopListening();
@@ -991,6 +1001,12 @@ export function InputArea({
 
     const sid = useChatStore.getState().activeSessionId;
     if (goalArmed && trimmedBase && sid && onSetGoal && sid !== NEW_CONVERSATION_ID) {
+      // command.goal carries a text objective only; silently dropping attachments
+      // would make users believe they were sent, so block explicitly with an alert.
+      if (readyMediaItems.length > 0) {
+        pushAttachmentAlert(t('chat.goalAttachmentsBlocked'));
+        return;
+      }
       // command.goal 是独立控制信令，不受聊天排队影响，跳过 team/queue/interrupt 判断；
       // 消息仍要本地落进 chatStore 才能在气泡上显示"设为目标"徽章（见 MessageItem.tsx）
       useChatStore.getState().addMessage(sid, {
@@ -1019,12 +1035,12 @@ export function InputArea({
         onSubmit(trimmed, readyMediaItems);
       } else {
         // 保持队列，新消息加入队列
-        useChatStore.getState().addToTaskQueue(sid, trimmed);
+        useChatStore.getState().addToTaskQueue(sid, trimmed, readyMediaItems);
       }
     } else if (isInterruptible) {
       if (isAgentMode) {
         if (sid) {
-          useChatStore.getState().addToTaskQueue(sid, trimmed);
+          useChatStore.getState().addToTaskQueue(sid, trimmed, readyMediaItems);
           // 目标 active 但当前没有任务在处理时，常规的自动排空触发点不会命中，主动兜底一次
           onDrainTaskQueueIfIdle?.(sid);
         }
@@ -1064,12 +1080,14 @@ export function InputArea({
     goalArmed,
     onSetGoal,
     onDrainTaskQueueIfIdle,
+    pushAttachmentAlert,
     t,
   ]);
 
   const trimmedDraft = (inputValue + pendingVoiceText).trim();
   const hasDraft = trimmedDraft.length > 0 || attachments.length > 0 || isListening;
-  const isImageInterruptBlocked = isInterruptible && !isTeamMode && readyMediaItems.length > 0;
+  const isImageInterruptBlocked =
+    isInterruptible && !isTeamMode && !isAgentMode && readyMediaItems.length > 0;
   const showStop = isProcessing && !isPaused && !hasDraft;
   const canSubmit = showStop || (
     hasDraft &&

--- a/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/ChatPanel/index.tsx
@@ -164,7 +164,7 @@ function ActiveTeamGroupEntry({ isProcessing, teamAreaExpanded }: { isProcessing
 }
 
 /** 单 Agent 模式的消息队列卡片，展示在输入框上方 */
-function AgentActivityCard({ isProcessing: _isProcessing, onSendTask }: { isProcessing: boolean; onSendTask?: (content: string) => void }) {
+function AgentActivityCard({ isProcessing: _isProcessing, onSendTask }: { isProcessing: boolean; onSendTask?: (content: string, mediaItems?: MediaItem[]) => void }) {
   const [expanded, setExpanded] = useState(true);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
@@ -201,7 +201,7 @@ function AgentActivityCard({ isProcessing: _isProcessing, onSendTask }: { isProc
     const nextTask = runtime?.taskQueue[0];
     if (nextTask) {
       removeFromTaskQueue(sid, nextTask.id);
-      onSendTask?.(nextTask.content);
+      onSendTask?.(nextTask.content, nextTask.mediaItems);
     }
   };
 
@@ -213,23 +213,41 @@ function AgentActivityCard({ isProcessing: _isProcessing, onSendTask }: { isProc
     }
   };
 
-  const handleEditTask = (e: React.MouseEvent, taskId: string, content: string) => {
+  const handleEditTask = (
+    e: React.MouseEvent,
+    taskId: string,
+    content: string,
+    mediaItemCount = 0,
+  ) => {
     e.stopPropagation();
     const sid = useChatStore.getState().activeSessionId;
     if (sid) {
+      // Editing restores only the text into the input; attachments cannot follow
+      // and will be removed together with the task — confirm first.
+      if (
+        mediaItemCount > 0 &&
+        !window.confirm(t('chat.editTaskDropAttachments', { count: mediaItemCount }))
+      ) {
+        return;
+      }
       setInputValue(sid, content);
       removeFromTaskQueue(sid, taskId);
       window.dispatchEvent(new CustomEvent('chat-input-sync', { detail: { sessionId: sid, value: content } }));
     }
   };
 
-  const handleSendTask = (e: React.MouseEvent, taskId: string, content: string) => {
+  const handleSendTask = (
+    e: React.MouseEvent,
+    taskId: string,
+    content: string,
+    mediaItems?: MediaItem[],
+  ) => {
     e.stopPropagation();
     const sid = useChatStore.getState().activeSessionId;
     if (sid) {
       removeFromTaskQueue(sid, taskId);
     }
-    onSendTask?.(content);
+    onSendTask?.(content, mediaItems);
   };
 
   const handleDragStart = (index: number) => {
@@ -326,13 +344,31 @@ function AgentActivityCard({ isProcessing: _isProcessing, onSendTask }: { isProc
                   <span className="team-event-group-row__member" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {task.content}
                   </span>
+                  {(task.mediaItems?.length ?? 0) > 0 && (
+                    <span
+                      title={(task.mediaItems ?? [])
+                        .map((item) => item.filename)
+                        .filter(Boolean)
+                        .join('\n')}
+                      style={{
+                        flexShrink: 0,
+                        fontSize: '12px',
+                        color: 'var(--color-text-secondary)',
+                        background: 'var(--color-surface-hover)',
+                        borderRadius: '6px',
+                        padding: '0 6px',
+                      }}
+                    >
+                      📎{task.mediaItems?.length}
+                    </span>
+                  )}
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '4px', flexShrink: 0 }}>
                   <button
                     type="button"
                     className="chat-input-task-action chat-input-task-action--send"
                     title={t('chat.sendTask')}
-                    onClick={(e) => handleSendTask(e, task.id, task.content)}
+                    onClick={(e) => handleSendTask(e, task.id, task.content, task.mediaItems)}
                   >
                     <img src={loadSendIcon} alt="" className="w-3.5 h-3.5" />
                   </button>
@@ -340,7 +376,7 @@ function AgentActivityCard({ isProcessing: _isProcessing, onSendTask }: { isProc
                     type="button"
                     className="chat-input-task-action chat-input-task-action--edit"
                     title={t('chat.editTask')}
-                    onClick={(e) => handleEditTask(e, task.id, task.content)}
+                    onClick={(e) => handleEditTask(e, task.id, task.content, task.mediaItems?.length ?? 0)}
                   >
                     <img src={editIcon} alt="" className="w-3 h-3" />
                   </button>

--- a/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
+++ b/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
@@ -1166,27 +1166,38 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
 
   const persistMedia = useCallback(
     async (content: string, sessionId: string, mediaItems: MediaItem[]) => {
-      return request<PersistMediaResponse>('media.persist', {
-        session_id: sessionId,
-        content,
-        media_items: mediaItems as unknown as Record<string, unknown>[],
-      });
+      return request<PersistMediaResponse>(
+        'media.persist',
+        {
+          session_id: sessionId,
+          content,
+          media_items: mediaItems as unknown as Record<string, unknown>[],
+        },
+        // Multiple base64 images can exceed the 15s default timeout
+        { timeoutMs: 60_000 },
+      );
     },
     [request],
   );
 
   const persistDocuments = useCallback(
     async (content: string, sessionId: string, mediaItems: MediaItem[]) => {
-      return request<PersistMediaResponse>('document.persist', {
-        session_id: sessionId,
-        content,
-        parse: true,
-        documents: mediaItems.map((item) => ({
-          filename: item.filename,
-          mime_type: getMediaMimeType(item),
-          base64_data: item.base64_data || item.base64Data,
-        })),
-      });
+      return request<PersistMediaResponse>(
+        'document.persist',
+        {
+          session_id: sessionId,
+          content,
+          parse: true,
+          documents: mediaItems.map((item) => ({
+            filename: item.filename,
+            mime_type: getMediaMimeType(item),
+            base64_data: item.base64_data || item.base64Data,
+          })),
+        },
+        // Large documents (100+ page PDFs) take 10s+ to parse server-side; with
+        // transfer overhead this exceeds the 15s default timeout
+        { timeoutMs: 120_000 },
+      );
     },
     [request],
   );
@@ -1536,7 +1547,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
     const nextTask = runtime?.taskQueue[0];
     if (nextTask && sendMessageRef.current) {
       useChatStore.getState().removeFromTaskQueue(sessionId, nextTask.id);
-      sendMessageRef.current(nextTask.content, sessionId);
+      sendMessageRef.current(nextTask.content, sessionId, nextTask.mediaItems ?? []);
     }
   }, []);
 
@@ -2955,8 +2966,8 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
             if (nextTask && sendMessageRef.current) {
               // 从队列中移除该任务
               useChatStore.getState().removeFromTaskQueue(sessionId, nextTask.id);
-              // 发送下一个任务
-              sendMessageRef.current(nextTask.content, sessionId);
+              // Send the next task (with any attachments stashed when it was queued)
+              sendMessageRef.current(nextTask.content, sessionId, nextTask.mediaItems ?? []);
             }
           }
         }
@@ -3192,7 +3203,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
                 const nextTask = taskQueue[0];
                 if (nextTask && sendMessageRef.current) {
                   useChatStore.getState().removeFromTaskQueue(sessionId, nextTask.id);
-                  sendMessageRef.current(nextTask.content, sessionId);
+                  sendMessageRef.current(nextTask.content, sessionId, nextTask.mediaItems ?? []);
                 }
               }
             }

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/en.json
@@ -298,6 +298,8 @@
     "paused": "Paused",
     "resume": "Resume",
     "queuePausedConfirm": "You are about to send a message. Clear the {{count}} queued message(s)?\n\nClick \"OK\" to clear the queue and send; click \"Cancel\" to keep the queue (message will be added to the queue).",
+    "goalAttachmentsBlocked": "Attachments are not supported when setting a goal. Remove them first, or send the attachment in a separate message.",
+    "editTaskDropAttachments": "Editing will remove the {{count}} attachment(s) carried by this task. Continue?",
     "holdToSpeak": "Hold to speak",
     "send": "Send (Enter)",
     "stop": "Stop",

--- a/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
+++ b/jiuwenswarm/channels/web/frontend/src/i18n/locales/zh.json
@@ -299,6 +299,8 @@
     "paused": "已暂停",
     "resume": "继续执行",
     "queuePausedConfirm": "你即将发送一条消息，要清除正在排队的{{count}}条消息吗？\n\n点击「确定」清空队列并发送；点击「取消」保持队列（消息将加入队列）。",
+    "goalAttachmentsBlocked": "设为目标时不支持附件，请先移除附件，或先单独发送附件消息。",
+    "editTaskDropAttachments": "编辑将移除该任务携带的 {{count}} 个附件，是否继续？",
     "holdToSpeak": "按住说话",
     "send": "发送 (Enter)",
     "stop": "停止",

--- a/jiuwenswarm/channels/web/frontend/src/stores/chatStore.ts
+++ b/jiuwenswarm/channels/web/frontend/src/stores/chatStore.ts
@@ -22,6 +22,7 @@ import {
   ContextCompressionRuntime,
   ContextCompressionSummary,
   TodoItem,
+  MediaItem,
 } from '../types';
 import { useTodoStore } from './todoStore';
 import {
@@ -71,6 +72,8 @@ interface TaskItem {
   id: string;
   content: string;
   timestamp: number;
+  /** Persisted attachments (images/documents, incl. PDF); dispatched with the message when the queued task is sent */
+  mediaItems?: MediaItem[];
 }
 
 export interface HistoryPagerMeta {
@@ -247,7 +250,7 @@ interface ChatState {
   clearMessages: (sessionId: string) => void;
   clearCurrentTurnData: (sessionId: string, requestId?: string) => void;
   prependMessages: (sessionId: string, olderFirst: Message[]) => void;
-  addToTaskQueue: (sessionId: string, content: string) => void;
+  addToTaskQueue: (sessionId: string, content: string, mediaItems?: MediaItem[]) => void;
   clearTaskQueue: (sessionId: string) => void;
   removeFromTaskQueue: (sessionId: string, id: string) => void;
   reorderTaskQueue: (sessionId: string, fromIndex: number, toIndex: number) => void;
@@ -1415,7 +1418,7 @@ export const useChatStore = create<ChatState>()(subscribeWithSelector((set, get)
     });
   },
 
-  addToTaskQueue: (sessionId, content) => {
+  addToTaskQueue: (sessionId, content, mediaItems) => {
     set((state) => {
       const runtime = state.runtimes[sessionId];
       if (!runtime) return state;
@@ -1430,6 +1433,7 @@ export const useChatStore = create<ChatState>()(subscribeWithSelector((set, get)
                 id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
                 content,
                 timestamp: Date.now(),
+                ...(mediaItems && mediaItems.length > 0 ? { mediaItems } : {}),
               },
             ],
           },

--- a/jiuwenswarm/gateway/document_attachments.py
+++ b/jiuwenswarm/gateway/document_attachments.py
@@ -29,8 +29,8 @@ _SESSION_ID_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 _MAX_DOCUMENT_BYTES = 30 * 1024 * 1024
 _MAX_DOCUMENT_COUNT = 20
-# Office binaries that read_file cannot open directly — persist a .txt sidecar.
-_OFFICE_TEXT_SIDECAR_SUFFIXES = frozenset({".docx", ".xlsx"})
+# Binary documents that read_file cannot open directly — persist a .txt sidecar.
+_TEXT_SIDECAR_SUFFIXES = frozenset({".pdf", ".docx", ".xlsx"})
 
 _TRUE_STRINGS = frozenset({"true", "1", "yes"})
 _FALSE_STRINGS = frozenset({"false", "0", "no"})
@@ -270,10 +270,10 @@ async def _store_and_maybe_parse_item(
                 "path": str(path),
                 "size_bytes": data_size,
             }
-            # Office re-parse / sidecar: always materialize .txt for read_file.
-            need_office_txt = path.suffix.lower() in _OFFICE_TEXT_SIDECAR_SUFFIXES
-            if parse or need_office_txt:
-                await _attach_parse_and_office_txt(
+            # Binary re-parse / sidecar: always materialize .txt for read_file.
+            need_sidecar = path.suffix.lower() in _TEXT_SIDECAR_SUFFIXES
+            if parse or need_sidecar:
+                await _attach_parse_and_text_sidecar(
                     stored,
                     original_path=path,
                     parse_meta=parse,
@@ -311,9 +311,9 @@ async def _store_and_maybe_parse_item(
         "path": str(path),
         "size_bytes": len(data),
     }
-    need_office_txt = path.suffix.lower() in _OFFICE_TEXT_SIDECAR_SUFFIXES
-    if parse or need_office_txt:
-        await _attach_parse_and_office_txt(
+    need_sidecar = path.suffix.lower() in _TEXT_SIDECAR_SUFFIXES
+    if parse or need_sidecar:
+        await _attach_parse_and_text_sidecar(
             stored,
             original_path=path,
             parse_meta=parse,
@@ -322,32 +322,44 @@ async def _store_and_maybe_parse_item(
     return stored
 
 
-async def _attach_parse_and_office_txt(
+async def _attach_parse_and_text_sidecar(
     stored: dict[str, Any],
     *,
     original_path: Path,
     parse_meta: bool,
     max_chars: int,
 ) -> None:
-    """Parse ``original_path``; for docx/xlsx also write a full ``.txt`` sidecar.
+    """Parse ``original_path``; for pdf/docx/xlsx also write a full ``.txt`` sidecar.
 
     After a successful sidecar write, ``stored["path"]`` points at the ``.txt``
     so Agent ``read_file`` can open it. ``original_path`` / ``text_path`` keep both.
+    A PDF with no text layer (scanned) yields empty text — keep ``path`` on the
+    original binary so page-level tools can still work on it.
     """
     suffix = original_path.suffix.lower()
-    write_sidecar = suffix in _OFFICE_TEXT_SIDECAR_SUFFIXES
+    write_sidecar = suffix in _TEXT_SIDECAR_SUFFIXES
 
     if write_sidecar:
         # Full text on disk for read_file (no truncation).
         parsed_full = await parse_document_file(original_path, max_chars=None)
-        text_path = _write_office_text_sidecar(original_path, parsed_full.get("text") or "")
+        text = parsed_full.get("text") or ""
         stored["original_path"] = str(original_path)
-        stored["text_path"] = str(text_path)
-        # Prefer .txt for downstream read_file / chat path hints.
-        stored["path"] = str(text_path)
         stored["parser"] = parsed_full.get("parser")
         stored["char_count"] = parsed_full.get("char_count")
         stored["documents_count"] = parsed_full.get("documents_count")
+        # Only PDFs skip the empty sidecar: a scanned PDF still has page-level
+        # tools (read_pdf/vision) that need the original binary path. docx/xlsx
+        # keep the historical behavior — always write the sidecar, even empty.
+        if text.strip() or suffix != ".pdf":
+            text_path = _write_text_sidecar(original_path, text)
+            stored["text_path"] = str(text_path)
+            # Prefer .txt for downstream read_file / chat path hints.
+            stored["path"] = str(text_path)
+        else:
+            logger.info(
+                "[document.persist] no extractable text (scanned PDF?) file=%s",
+                original_path.name,
+            )
         if parse_meta:
             full_len = int(parsed_full.get("char_count") or 0)
             stored["text_truncated"] = full_len > max(1, int(max_chars))
@@ -367,13 +379,13 @@ async def _attach_parse_and_office_txt(
     )
 
 
-def _write_office_text_sidecar(original_path: Path, text: str) -> Path:
-    """Write parsed office content next to the original as ``stem.txt``."""
+def _write_text_sidecar(original_path: Path, text: str) -> Path:
+    """Write parsed document content next to the original as ``stem.txt``."""
     candidate = original_path.with_suffix(".txt")
     txt_path = _unique_path(candidate)
     txt_path.write_text(text if isinstance(text, str) else str(text or ""), encoding="utf-8")
     logger.info(
-        "[document.persist] wrote office text sidecar original=%s text=%s chars=%s",
+        "[document.persist] wrote text sidecar original=%s text=%s chars=%s",
         original_path.name,
         txt_path.name,
         len(text or ""),

--- a/jiuwenswarm/resources/config.team.distributed.leader.yaml
+++ b/jiuwenswarm/resources/config.team.distributed.leader.yaml
@@ -210,6 +210,9 @@ react:
     enable_reload: true
     enabled: true
     message_summary_offloader_config:
+      # read_pdf outputs are page-level source text; keep them verbatim like
+      # read_file so summaries are not built from doubly-compressed digests.
+      protected_tool_names: ["read_file", "read_pdf"]
       add_message_threshold_ratio: 0.1
       ttl_seconds: 300
       ttl_context_occupancy_ratio: 0.5

--- a/jiuwenswarm/resources/config.team.distributed.teammate.yaml
+++ b/jiuwenswarm/resources/config.team.distributed.teammate.yaml
@@ -214,6 +214,9 @@ react:
     enable_reload: true
     enabled: true
     message_summary_offloader_config:
+      # read_pdf outputs are page-level source text; keep them verbatim like
+      # read_file so summaries are not built from doubly-compressed digests.
+      protected_tool_names: ["read_file", "read_pdf"]
       add_message_threshold_ratio: 0.1
       ttl_seconds: 300
       ttl_context_occupancy_ratio: 0.5

--- a/jiuwenswarm/resources/config.yaml
+++ b/jiuwenswarm/resources/config.yaml
@@ -467,6 +467,9 @@ react:
     enable_reload: true
     enabled: true
     message_summary_offloader_config:
+      # read_pdf outputs are page-level source text; keep them verbatim like
+      # read_file so summaries are not built from doubly-compressed digests.
+      protected_tool_names: ["read_file", "read_pdf"]
       add_message_threshold_ratio: 0.1
       ttl_seconds: 300
       ttl_context_occupancy_ratio: 0.5

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -232,6 +232,7 @@ from jiuwenswarm.agents.harness.common.rails.skill_retrieval_prompt_rail import 
 )
 from jiuwenswarm.symphony.config import load_symphony_config
 from jiuwenswarm.agents.harness.common.tools.wiki_tools import wiki_ingest, wiki_query, wiki_lint
+from jiuwenswarm.agents.harness.common.tools.pdf_tools import read_pdf
 from jiuwenswarm.agents.harness.common.tools.acp_output_tools import get_tools as get_acp_output_tools
 from jiuwenswarm.agents.harness.common.tools.acp_chat import acp_chat
 from jiuwenswarm.agents.harness.common.tools.xiaoyi_phone_tools import (
@@ -4918,7 +4919,7 @@ class JiuWenSwarmDeepAdapter:
         """Get tool cards."""
         tool_cards = []
 
-        for wtool in [wiki_ingest, wiki_query, wiki_lint]:
+        for wtool in [wiki_ingest, wiki_query, wiki_lint, read_pdf]:
             self._register_shared_tool(wtool)
             tool_cards.append(wtool.card)
 

--- a/tests/unit_tests/agents/test_pdf_tools.py
+++ b/tests/unit_tests/agents/test_pdf_tools.py
@@ -1,0 +1,196 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jiuwenswarm.agents.harness.common.tools.pdf_tools import (
+    DEFAULT_MAX_CHARS,
+    _format_page_list,
+    _normalize_request,
+    _parse_page_ranges,
+    read_pdf,
+)
+
+
+def _pdf_page_object(index: int, font_ref: int, with_stream: bool) -> bytes:
+    """Serialize one /Page dictionary (stream object number is index-derived)."""
+    contents = f" /Contents {4 + 2 * index} 0 R" if with_stream else ""
+    return (
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]"
+        f" /Resources << /Font << /F1 {font_ref} 0 R >> >>{contents} >>"
+    ).encode("latin-1")
+
+
+def _pdf_stream_object(text: str | None) -> bytes:
+    """Serialize a content-stream object showing ``text`` (empty when None)."""
+    if text is None:
+        payload = b""
+    else:
+        shown = text.replace("\\", r"\\").replace("(", r"\(").replace(")", r"\)")
+        payload = f"BT /F1 12 Tf 72 720 Td ({shown}) Tj ET".encode("latin-1")
+    return f"<< /Length {len(payload)} >>\nstream\n".encode("latin-1") + payload + b"\nendstream"
+
+
+def _build_minimal_pdf(pages: list[str | None]) -> bytes:
+    """Hand-assemble a tiny valid PDF fixture, written from the PDF 1.4 spec.
+
+    Each ``pages`` entry is that page's text; ``None`` produces a page with no
+    content stream (no text layer). Base-14 Helvetica keeps the text
+    extractable by pdfplumber/pdfminer without embedded fonts. The xref table
+    is computed so the document is fully well-formed.
+    """
+    font_ref = 3 + 2 * len(pages)
+    kid_refs = " ".join(f"{3 + 2 * i} 0 R" for i in range(len(pages)))
+
+    bodies: list[bytes] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        f"<< /Type /Pages /Kids [{kid_refs}] /Count {len(pages)} >>".encode("latin-1"),
+    ]
+    for i, text in enumerate(pages):
+        bodies.append(_pdf_page_object(i, font_ref, with_stream=text is not None))
+        bodies.append(_pdf_stream_object(text))
+    bodies.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    chunks = [b"%PDF-1.4\n"]
+    positions: list[int] = []
+    cursor = len(chunks[0])
+    for number, body in enumerate(bodies, start=1):
+        positions.append(cursor)
+        piece = f"{number} 0 obj\n".encode("latin-1") + body + b"\nendobj\n"
+        chunks.append(piece)
+        cursor += len(piece)
+
+    # Cross-reference table: one fixed-width 20-byte line per object (spec 7.5.4).
+    table_rows = ["0000000000 65535 f "]
+    table_rows.extend(f"{position:010d} 00000 n " for position in positions)
+    chunks.append(f"xref\n0 {len(table_rows)}\n".encode("latin-1"))
+    chunks.append(("\n".join(table_rows) + "\n").encode("latin-1"))
+    chunks.append(
+        f"trailer\n<< /Size {len(table_rows)} /Root 1 0 R >>\n"
+        f"startxref\n{cursor}\n%%EOF\n".encode("latin-1")
+    )
+    return b"".join(chunks)
+
+
+def test_parse_page_ranges_variants():
+    assert _parse_page_ranges(None) is None
+    assert _parse_page_ranges("") is None
+    assert _parse_page_ranges(3) == (3,)
+    assert _parse_page_ranges("1-5") == (1, 2, 3, 4, 5)
+    assert _parse_page_ranges("1,3,8-10") == (1, 3, 8, 9, 10)
+    assert _parse_page_ranges("3, 1") == (1, 3)
+    assert _parse_page_ranges([2, "4-5"]) == (2, 4, 5)
+
+
+@pytest.mark.parametrize("bad", ["a", "5-2", "0", 0, -1, "1-", True])
+def test_parse_page_ranges_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        _parse_page_ranges(bad)
+
+
+def test_format_page_list_compresses_runs():
+    assert _format_page_list([1, 2, 3, 7]) == "1-3,7"
+    assert _format_page_list([5]) == "5"
+    assert _format_page_list([3, 1, 2, 2]) == "1-3"
+    assert _format_page_list([]) == ""
+
+
+def test_normalize_request_defaults_and_clamping():
+    req = _normalize_request({"pdf_path": "/tmp/a.pdf"})
+    assert req.pages is None
+    assert req.max_chars == DEFAULT_MAX_CHARS
+
+    req = _normalize_request({"pdf_path": "/tmp/a.pdf", "pages": "2-3", "max_chars": 10})
+    assert req.pages == (2, 3)
+    assert req.max_chars == 1_000  # floor
+
+    req = _normalize_request({"pdf_path": "/tmp/a.pdf", "max_chars": 10**9})
+    assert req.max_chars == 200_000  # ceiling
+
+    with pytest.raises(ValueError):
+        _normalize_request({})
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_extracts_pages_and_flags_blank(tmp_path: Path):
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(
+        _build_minimal_pdf(["Hello page one", "Second page text", None])
+    )
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path)}})
+    assert "total pages: 3" in result
+    assert "--- Page 1 ---" in result
+    assert "Hello page one" in result
+    assert "Second page text" in result
+    assert "no text layer" in result
+    assert "Pages without extractable text: 3" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_respects_page_selection(tmp_path: Path):
+    pytest.importorskip("pdfplumber")
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf(["Alpha", "Bravo", "Charlie"]))
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "2"}})
+    assert "Bravo" in result
+    assert "Alpha" not in result
+    assert "Charlie" not in result
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(pdf_path), "pages": "2,9"}})
+    assert "Bravo" in result
+    assert "exceed" in result  # out-of-range note for page 9
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_truncates_at_max_chars(tmp_path: Path):
+    pytest.importorskip("pdfplumber")
+    long_text = "word " * 500  # ~2500 chars on one page
+    pdf_path = tmp_path / "long.pdf"
+    pdf_path.write_bytes(_build_minimal_pdf([long_text.strip(), "Tail page"]))
+
+    result = await read_pdf.invoke(
+        {"inputs": {"pdf_path": str(pdf_path), "max_chars": 1000}}
+    )
+    assert "truncated at max_chars" in result
+    assert "Tail page" not in result
+    # Truncation must list the unread pages so the model can continue in chunks
+    assert "unread pages: 2" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_relative_path_anchors_to_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    pytest.importorskip("pdfplumber")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "docs").mkdir()
+    (workspace / "docs" / "note.pdf").write_bytes(_build_minimal_pdf(["Workspace anchored"]))
+    monkeypatch.setattr(
+        "jiuwenswarm.agents.harness.common.tools.pdf_tools.get_agent_workspace_dir",
+        lambda: workspace,
+    )
+
+    result = await read_pdf.invoke({"inputs": {"pdf_path": "docs/note.pdf"}})
+    assert "Workspace anchored" in result
+
+
+@pytest.mark.asyncio
+async def test_read_pdf_error_paths(tmp_path: Path):
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(tmp_path / "missing.pdf")}})
+    assert result.startswith("[ERROR]")
+
+    not_pdf = tmp_path / "note.txt"
+    not_pdf.write_text("hi", encoding="utf-8")
+    result = await read_pdf.invoke({"inputs": {"pdf_path": str(not_pdf)}})
+    assert result.startswith("[ERROR]")
+    assert "only accepts .pdf" in result
+
+    result = await read_pdf.invoke({"inputs": {}})
+    assert result.startswith("[ERROR]")

--- a/tests/unit_tests/gateway/test_document_attachments.py
+++ b/tests/unit_tests/gateway/test_document_attachments.py
@@ -240,6 +240,135 @@ async def test_persist_xlsx_writes_txt_sidecar_even_when_parse_false(
     assert Path(item["path"]).read_text(encoding="utf-8") == "sheet A1 value"
 
 
+@pytest.mark.asyncio
+async def test_persist_pdf_writes_txt_sidecar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+
+    async def fake_parse(file_path, *, max_chars=None, doc_id=""):
+        return {
+            "text": "parsed pdf body",
+            "truncated": False,
+            "parser": "PDFParser",
+            "file_ext": ".pdf",
+            "char_count": len("parsed pdf body"),
+            "documents_count": 1,
+        }
+
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.parse_document_file",
+        fake_parse,
+    )
+
+    payload = {
+        "documents": [
+            {
+                "filename": "paper.pdf",
+                "mime_type": "application/pdf",
+                "base64_data": base64.b64encode(b"%PDF-fake-bytes").decode("ascii"),
+            }
+        ]
+    }
+    result = await persist_and_parse_documents(payload, "sess_pdf", parse=True, max_chars=1000)
+    items = result.get("media_items") or []
+    assert len(items) == 1
+    item = items[0]
+    assert item["filename"] == "paper.pdf"
+    assert Path(item["original_path"]).suffix == ".pdf"
+    assert Path(item["original_path"]).is_file()
+    assert Path(item["text_path"]).suffix == ".txt"
+    assert item["path"] == item["text_path"]
+    assert Path(item["path"]).read_text(encoding="utf-8") == "parsed pdf body"
+    assert result["files"]["uploaded_documents"][0]["path"] == item["text_path"]
+    assert result["files"]["uploaded_documents"][0]["original_path"] == item["original_path"]
+
+
+@pytest.mark.asyncio
+async def test_persist_pdf_without_text_layer_keeps_original_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Scanned PDFs (no text layer) must keep path on the original binary."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+
+    async def fake_parse(file_path, *, max_chars=None, doc_id=""):
+        return {
+            "text": "",
+            "truncated": False,
+            "parser": "PDFParser",
+            "file_ext": ".pdf",
+            "char_count": 0,
+            "documents_count": 1,
+        }
+
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.parse_document_file",
+        fake_parse,
+    )
+
+    payload = {
+        "documents": [
+            {
+                "filename": "scan.pdf",
+                "mime_type": "application/pdf",
+                "base64_data": base64.b64encode(b"%PDF-fake-scan").decode("ascii"),
+            }
+        ]
+    }
+    result = await persist_and_parse_documents(payload, "sess_scan", parse=True, max_chars=1000)
+    item = (result.get("media_items") or [])[0]
+    assert Path(item["path"]).suffix == ".pdf"
+    assert item.get("text_path") is None
+    assert item["char_count"] == 0
+    # No stray empty .txt sidecar on disk.
+    upload_dir = Path(item["path"]).parent
+    assert not list(upload_dir.glob("*.txt"))
+
+
+@pytest.mark.asyncio
+async def test_persist_empty_docx_still_writes_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Empty-text guard applies to .pdf only; docx/xlsx keep writing a sidecar even when empty."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+
+    async def fake_parse(file_path, *, max_chars=None, doc_id=""):
+        return {
+            "text": "",
+            "truncated": False,
+            "parser": "FakeDocxParser",
+            "file_ext": ".docx",
+            "char_count": 0,
+            "documents_count": 1,
+        }
+
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.parse_document_file",
+        fake_parse,
+    )
+
+    payload = {
+        "documents": [
+            {
+                "filename": "empty.docx",
+                "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "base64_data": base64.b64encode(b"fake-empty-docx").decode("ascii"),
+            }
+        ]
+    }
+    result = await persist_and_parse_documents(payload, "sess_empty", parse=True, max_chars=1000)
+    item = (result.get("media_items") or [])[0]
+    assert Path(item["path"]).suffix == ".txt"
+    assert Path(item["path"]).read_text(encoding="utf-8") == ""
+
+
 def test_resolve_session_upload_path_blocks_traversal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
Paired: [GitHub #2096](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2096) ↔ [GitCode !4379](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4379)

## Problem

1. **Agents cannot read web-uploaded PDFs.** The gateway parses uploaded PDFs, but `.pdf` is missing from the `.txt` sidecar allowlist (docx/xlsx only), so the parsed text is discarded and `stored.path` still points at a binary file that `read_file` cannot open.
2. **The `read_pdf` tool does not exist.** The `wiki_tools` prompts explicitly instruct the model to use a `read_pdf` tool for chunked reading of large documents, but the tool was never implemented.
3. **The task UI rejects PDF attachments.** While the agent is processing (or a goal is active), new messages go through the task queue — but queue `TaskItem`s carry text only, so the input area blocks sending with attachments entirely.

## Implementation

**Backend**
- `document_attachments`: add `.pdf` to the `.txt` sidecar pipeline — full parsed text is written to disk and `path` points at the sidecar. A PDF with no text layer (scanned) keeps its original binary path instead of producing an empty sidecar (docx/xlsx behavior unchanged, locked by a test).
- New `pdf_tools.read_pdf` tool: page-level extraction via pdfplumber (already a transitive dependency of openjiuwen — zero new dependencies). Supports `pages` ranges (`1-5,8`) and a `max_chars` budget; on truncation it lists the unread pages so the model continues in precise chunks; pages without a text layer are flagged as likely scanned with a hint to fall back to vision tools; relative paths anchor to the agent workspace and the path is validated before importing pdfplumber, so path errors stay clear even if the dependency is missing.
- `interface_deep`: `read_pdf` registered unconditionally alongside the wiki tools (pure text extraction, no model credentials required).
- Config templates (all three): `read_pdf` added to the context engine's `protected_tool_names` alongside `read_file` — its page reads are source text and stay verbatim in context instead of being replaced by compressed digests, so summaries built from them keep full detail.

**Frontend**
- `chatStore`: `TaskItem` gains `mediaItems` — queued tasks carry their persisted attachments.
- `InputArea`: agent mode no longer blocks attachments while processing; they queue with the task. Setting a goal with attachments shows an explicit alert instead of silently dropping them.
- `useWebSocket` / `ChatPanel`: all five queue-drain paths (idle drain, auto-continue on completion, continue after interrupt, manual send, resume queue) forward `mediaItems`; queue rows show an attachment badge; editing a task with attachments asks for confirmation.
- Document hint includes the original file path next to the `.txt` sidecar path, so the model can call `read_pdf` directly instead of guessing the `.pdf` location.
- `document.persist` / `media.persist` request timeouts raised to 120s / 60s: parsing a 100+ page PDF takes 10s+ server-side, which exceeded the 15s default and made large uploads fail client-side while succeeding on the server.
- New UI strings wired through i18n (zh/en).

## Demo

**Tutorial recording** (web UI, final code, remote Gemma4-26B): the 144-page paper is uploaded and a title/author/page-100 question is answered in 21s; page 250 of the 501-page Pro Git book is pinpointed in 2.8s; a hidden marker on page 250 of a 300-page report is retrieved in 2.3s; finally, while a whole-book summarization runs as a background task, the survey paper is attached again, queues behind it, and is answered without interrupting the long task:

![tutorial demo](https://raw.githubusercontent.com/agtai/jiuwenswarm/pr-2096-assets/pdf_tutorial_gemma26b_v2.gif)

## Testing

**Unit tests** — 28 passed. `test_pdf_tools` (new): page-range parsing, truncation with unread-page hints, scanned-page flagging, workspace-relative path resolution, error paths, real pdfplumber extraction against programmatically built valid PDFs. `test_document_attachments`: PDF sidecar, scanned PDF keeps original path, empty docx unchanged. Frontend `tsc` and production build pass.

**Platforms**: macOS (full E2E) and a Windows browser client against the macOS-hosted stack — the Windows round surfaced and confirmed the upload-timeout and original-path-hint fixes. Linux is covered by CI.

**End-to-end — A/B ablation on a realistic task** (real gateway + AgentServer; local gemma4:26b via Ollama and remote Gemma4-26B via vLLM)

Task: fact-check a draft article that cites the printed 501-page Pro Git book three times — "rebasing gives a cleaner, linear history" (p. 103, true), "`git commit --amend` replaces your last commit" (p. 250, true), "`git filter-branch` rewrites history at scale" (p. 359, **deliberately wrong** — that page is about `git archive` / `export-subst`). The agent must check each cited page and quote it. This is an everyday editorial/academic scenario: page numbers naturally come from an external source (someone's draft, a printed copy, a syllabus), and the parsed sidecar `.txt` has no page markers, so answering requires a real page→content mapping.

Same prompt, 2 models × with/without `read_pdf` (the "without" runs append "Do NOT use the read_pdf tool"):

| | With `read_pdf` | Without (`read_file`/grep only) |
|---|---|---|
| Remote Gemma4-26B (vLLM) | **26s**, 4 page-ranged calls, 367K tokens — **3/3 verdicts correct**, the planted wrong citation caught (22s / 3 calls on a second run — stable) | Run 1: 91s, 37 calls, **2.39M tokens** — mismapped all three pages, false-negatived the *correct* p. 250 citation. Run 2: **aborted at ~27s** by the harness loop guard (identical tool-call loop after `grep "Page 103"` found nothing; 667K tokens burned), no answer |
| Local gemma4:26b (Ollama) | **75s**, 3 calls, 137K tokens — 3/3 correct, quotes match the actual pages | Two runs, both terminated **without producing any answer** (stuck on "which page is line 2863 on?") |

Score: `read_pdf` **100% success** (3/3 runs — remote twice, local once); baseline **0% success** (0/4 runs), failing three different ways (confident wrong verdicts, loop-guard abort, silent no-answer). The root cause is the same in all four: "page N" simply does not exist as a concept in the marker-less text, so grep either misleads the model or strands it. `read_pdf` is the only page-aware path in the system.

Side-by-side timelapse of the citation fact-check ablation (3x speed, shared clock, full-resolution panels — left: `read_pdf`, all three verdicts correct in 26s; right: baseline, tool-call loop aborted by the harness, no answer):

![read_pdf citation fact-check comparison](https://raw.githubusercontent.com/agtai/jiuwenswarm/pr-2096-assets/read_pdf_ab_citation.gif)

[MP4 version of this comparison](https://raw.githubusercontent.com/agtai/jiuwenswarm/pr-2096-assets/read_pdf_ab_citation.mp4)





## Contribution

- **Enables**: agents can now read web-uploaded PDFs at all. The new `read_pdf` tool reads any page range of a large PDF (501 pages at ~20% context peak), and PDF attachments queue with tasks while the agent is busy.
- **Speedup**: same task, **26s vs 91s** — **3.5× faster**, **6.5× fewer tokens** (367K vs 2.39M).
- **Capability**: success rate on page-anchored tasks goes from **0% to 100%** (0/4 baseline runs vs 3/3 with `read_pdf`) — without `read_pdf`, "what does page N say" is simply unanswerable, because the parsed text has no page markers.
