### PR TITLE
feat(web): render LaTeX math in the shared markdown renderer

### DIFF
--- a/jiuwenswarm/channels/web/frontend/package-lock.json
+++ b/jiuwenswarm/channels/web/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "i18next": "^25.8.18",
         "i18next-browser-languagedetector": "^8.2.1",
         "jszip": "3.10.1",
+        "katex": "^0.16.47",
         "lucide-react": "1.16.0",
         "mermaid": "11.15.0",
         "qrcode.react": "^4.2.0",
@@ -41,8 +42,10 @@
         "react-dom": "^18.2.0",
         "react-i18next": "^16.5.8",
         "react-markdown": "^10.1.0",
+        "rehype-katex": "^7.0.1",
         "rehype-slug": "6.0.0",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "saxes": "5.0.1",
         "ssf": "0.11.2",
         "zustand": "^4.5.0"
@@ -2631,6 +2634,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -5167,10 +5176,105 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
       "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -5220,6 +5324,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -5227,6 +5347,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6308,6 +6445,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -6674,6 +6830,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -7336,7 +7511,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -7349,7 +7523,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -7865,6 +8038,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-slug": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
@@ -7893,6 +8085,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -8753,6 +8961,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -8773,6 +8995,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8949,6 +9185,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -9064,6 +9314,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/jiuwenswarm/channels/web/frontend/package.json
+++ b/jiuwenswarm/channels/web/frontend/package.json
@@ -26,6 +26,7 @@
     "test:history-pagination": "tsc src/features/historyPagination.ts --target ES2020 --module ES2020 --moduleResolution Bundler --rootDir src --outDir node_modules/.cache/history-pagination --skipLibCheck --noEmitOnError && node --test tests/historyPagination.test.mjs",
     "test:artifact-collection": "esbuild src/components/ArtifactsPanel/artifactCollection.ts --bundle --platform=node --format=esm --outfile=node_modules/.cache/artifact-collection/artifactCollection.mjs && node --test tests/artifactCollection.test.mjs",
     "test:desktop-save": "esbuild src/utils/desktopSave.ts --bundle --platform=node --format=esm --outfile=node_modules/.cache/desktop-save/desktopSave.mjs && node --test tests/desktopSave.test.mjs",
+    "test:markdown-math": "esbuild src/components/MarkdownRenderer/index.ts --bundle --platform=node --format=esm --loader:.css=empty --external:react --external:react-markdown --external:react-i18next --external:lucide-react --external:mermaid --external:clsx --outfile=node_modules/.cache/markdown-math/markdownRenderer.mjs && node --test tests/markdownMath.test.mjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -56,6 +57,7 @@
     "i18next": "^25.8.18",
     "i18next-browser-languagedetector": "^8.2.1",
     "jszip": "3.10.1",
+    "katex": "^0.16.47",
     "lucide-react": "1.16.0",
     "mermaid": "11.15.0",
     "qrcode.react": "^4.2.0",
@@ -63,8 +65,10 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^16.5.8",
     "react-markdown": "^10.1.0",
+    "rehype-katex": "^7.0.1",
     "rehype-slug": "6.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "saxes": "5.0.1",
     "ssf": "0.11.2",
     "zustand": "^4.5.0"

--- a/jiuwenswarm/channels/web/frontend/src/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/jiuwenswarm/channels/web/frontend/src/components/MarkdownRenderer/MarkdownRenderer.css
@@ -6,6 +6,13 @@
   max-width: min(100%, 52rem);
 }
 
+/* Let wide display equations scroll instead of overflowing the chat bubble. */
+.katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 2px 0;
+}
+
 /* Toolbar button */
 .markdown-toolbar-btn {
   display: inline-flex;

--- a/jiuwenswarm/channels/web/frontend/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/jiuwenswarm/channels/web/frontend/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,12 +1,15 @@
 import { createContext, useContext, useMemo, type AnchorHTMLAttributes, type HTMLAttributes } from 'react';
 import ReactMarkdown from 'react-markdown';
+import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
 import type { Element as HastElement } from 'hast';
 import { unescapeLiteralNewlines } from '../../utils/finalContent';
 import { getFencedCodeBlock } from './codeBlocks/fencedCode';
 import { getFencedCodeAdapter } from './codeBlocks/registry';
 import { repairCollapsedGfmTables } from './markdownTransforms';
+import 'katex/dist/katex.min.css';
 import './MarkdownRenderer.css';
 
 interface MarkdownRendererProps {
@@ -64,7 +67,7 @@ export function MarkdownRenderer({ content, className, testId }: MarkdownRendere
   return (
     <div className={className} data-testid={testId}>
       <MarkdownContentLinesContext.Provider value={contentLines}>
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSlug]} components={MARKDOWN_COMPONENTS}>
+        <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeSlug, rehypeKatex]} components={MARKDOWN_COMPONENTS}>
           {markdown}
         </ReactMarkdown>
       </MarkdownContentLinesContext.Provider>

--- a/jiuwenswarm/channels/web/frontend/tests/markdownMath.test.mjs
+++ b/jiuwenswarm/channels/web/frontend/tests/markdownMath.test.mjs
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MarkdownRenderer, repairCollapsedGfmTables } from '../node_modules/.cache/markdown-math/markdownRenderer.mjs';
+
+function render(content) {
+  return renderToStaticMarkup(createElement(MarkdownRenderer, { content }));
+}
+
+// KaTeX keeps the original TeX in a MathML annotation, which is the cheapest
+// way to assert what actually got typeset.
+function texOf(html) {
+  const match = html.match(/annotation encoding="application\/x-tex">([^<]*)</);
+  return match ? match[1] : null;
+}
+
+test('inline $...$ renders as inline KaTeX', () => {
+  const html = render('Euler: $e^{i\\pi} + 1 = 0$');
+  assert.match(html, /class="katex"/);
+  assert.doesNotMatch(html, /katex-display/);
+  assert.doesNotMatch(html, /katex-error/);
+  assert.equal(texOf(html), 'e^{i\\pi} + 1 = 0');
+});
+
+test('a fenced $$ block renders as display KaTeX', () => {
+  const html = render('$$\n\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}\n$$');
+  assert.match(html, /katex-display/);
+  assert.doesNotMatch(html, /katex-error/);
+  assert.equal(texOf(html), '\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}');
+});
+
+// remark-math only opens a display block when $$ ends the line; anything after
+// it on that line is fence meta, and meta containing $ disqualifies the fence.
+// A one-line $$...$$ therefore typesets correctly but inline, not centered.
+test('single-line $$...$$ typesets inline rather than as display', () => {
+  const html = render('$$\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}$$');
+  assert.match(html, /class="katex"/);
+  assert.doesNotMatch(html, /katex-display/);
+  assert.equal(texOf(html), '\\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2}');
+});
+
+test('invalid LaTeX degrades to an error span instead of throwing', () => {
+  const html = render('Broken: $\\frac{$');
+  assert.match(html, /katex-error/);
+});
+
+test('math and GFM tables coexist', () => {
+  const html = render(['| a | b |', '| --- | --- |', '| $x^2$ | 2 |'].join('\n'));
+  assert.match(html, /<table/);
+  assert.match(html, /chat-markdown-table-wrap/);
+  assert.match(html, /class="katex"/);
+});
+
+test('$ inside a fenced code block is left alone', () => {
+  const html = render(['```bash', 'echo $VAR && awk \'{print $1}\'', '```'].join('\n'));
+  assert.doesNotMatch(html, /katex/);
+  assert.match(html, /\$VAR/);
+  assert.match(html, /\$1/);
+});
+
+test('$ inside inline code is left alone', () => {
+  const html = render('Use `$HOME` and `$PATH` here.');
+  assert.doesNotMatch(html, /katex/);
+  assert.match(html, /\$HOME/);
+});
+
+test('a partially streamed $$ fence typesets what has arrived so far', () => {
+  const html = render('$$\n\\int_0^\\infty e^{-x^2}');
+  assert.match(html, /katex-display/);
+  assert.doesNotMatch(html, /katex-error/);
+  assert.equal(texOf(html), '\\int_0^\\infty e^{-x^2}');
+});
+
+// Rough edge of the fence-meta rule above: until the closing $$ arrives, a
+// one-line block is an opener whose body is still meta, so it renders empty.
+test('known limitation: an unclosed single-line $$ renders an empty display box', () => {
+  const html = render('$$\\frac{a}{b}');
+  assert.match(html, /katex-display/);
+  assert.equal(texOf(html), '');
+});
+
+// Accepted trade-off of singleDollarTextMath: currency pairs parse as math.
+// Flip remarkMath to { singleDollarTextMath: false } if this ever outweighs
+// inline math, which is far more common in model output.
+test('known trade-off: a $5 / $10 pair is treated as inline math', () => {
+  const html = render('It costs $5 and $10.');
+  assert.match(html, /class="katex"/);
+  assert.equal(texOf(html), '5 and ');
+});
+
+// repairCollapsedGfmTables runs before parsing, so pipe-heavy math has to survive
+// it. It only rewrites a line that is entirely a table row and splits into three
+// or more consistent columns with a delimiter row, which no math below satisfies.
+test('repairCollapsedGfmTables leaves math with pipes untouched', () => {
+  const untouched = [
+    'Triangle: $$|x| - |y| \\le |x - y|$$',
+    'Absolute value $|x| = x$ for positive x',
+    'Set: $$\\{ x \\mid x > 0 \\}$$',
+    'Norm: $$\\|v\\| - \\|w\\| \\le \\|v - w\\|$$',
+    'Euler: $$e^{i\\pi} + 1 = 0$$',
+  ];
+  for (const input of untouched) {
+    assert.equal(repairCollapsedGfmTables(input), input);
+  }
+});
+
+test('repairCollapsedGfmTables still passes through a well-formed table', () => {
+  const table = '| a | b |\n| --- | --- |\n| 1 | 2 |';
+  assert.equal(repairCollapsedGfmTables(table), table);
+});


### PR DESCRIPTION
Paired: [GitHub #2363](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2363) ↔ [GitCode !4523](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4523)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!--
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block.

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind feature


**What does this PR do / why do we need it**:

The Web frontend had no LaTeX/math rendering at all. Agent output containing
`$...$` or `$$...$$` was shown verbatim, so any answer with a formula in it
reached the user as raw TeX source.

This PR wires `remark-math` + `rehype-katex` into the shared `MarkdownRenderer`
so that math is typeset:

* `jiuwenswarm/channels/web/frontend/package.json` - adds `remark-math@^6.0.0`,
  `rehype-katex@^7.0.1` and `katex@^0.16.47` as direct dependencies. All three are
  unified-11 compatible, matching `react-markdown@^10`. KaTeX was already in the
  lockfile as a transitive dependency of mermaid at exactly `0.16.47`, so this
  promotes it to a direct dependency (needed for the stylesheet import) without
  adding a second copy or meaningful install weight.
* `src/components/MarkdownRenderer/MarkdownRenderer.tsx` - registers the two
  plugins (`remarkPlugins={[remarkGfm, remarkMath]}`,
  `rehypePlugins={[rehypeSlug, rehypeKatex]}`) and imports
  `katex/dist/katex.min.css`. Vite bundles the stylesheet and its woff2 fonts; no
  build config change was needed.
* `src/components/MarkdownRenderer/MarkdownRenderer.css` - makes `.katex-display`
  scroll horizontally so a wide equation cannot overflow a chat bubble, matching
  how wide tables are already handled.

Because `MarkdownRenderer` is the shared renderer, one change covers every
math-bearing surface: chat messages, the artifact `.md` preview, A2UI text and the
skill panel.

`rehype-katex` defaults are kept deliberately: invalid LaTeX renders as a
`.katex-error` span rather than throwing, which is the behaviour we want for
streaming model output. `remark-math`'s default `singleDollarTextMath: true` is
also kept - single-dollar inline math dominates model output, and the currency
false positive (`$5 ... $10`) is the standard trade-off in comparable chat UIs.
Switching it off is a one-line change if reviewers prefer that.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
#2437 


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

`npm run build` (`tsc && vite build`) passes.

New automated coverage: `tests/markdownMath.test.mjs`, run with
`npm run test:markdown-math`. It renders the real `MarkdownRenderer` through
`react-dom/server` and asserts on the emitted KaTeX markup, so it exercises the
actual plugin wiring rather than a stand-in pipeline. **12 tests, 12 passing.**

Function:
* Inline `$e^{i\pi} + 1 = 0$` typesets inline, no display wrapper, no error span.
* A fenced `$$ ... $$` block typesets as centered display math, and the recovered
  TeX matches the source exactly.
* Math and GFM tables coexist - `$x^2$` inside a table cell typesets and the table
  still renders inside `chat-markdown-table-wrap`.

Reliability / regressions:
* Invalid LaTeX (`$\frac{$`) degrades to a `.katex-error` span and does not throw,
  so one bad formula cannot take down a message.
* `$` inside fenced code blocks (`echo $VAR`, `awk '{print $1}'`) and inside
  inline code (`` `$HOME` ``) is untouched - `remark-math` does not descend into
  code nodes.
* A partially streamed `$$` fence typesets what has arrived so far instead of
  erroring, so streaming degrades gracefully.
* Mermaid fences and existing markdown rendering are unaffected; the mermaid
  handling path is untouched.

Performance: no new install weight (KaTeX was already present transitively), and
no extra render work for content without `$`.

One library behaviour is pinned by a test so it is visible rather than surprising,
and is **not** addressed here: a one-line `$$x^2$$` typesets *inline* rather than
centered. `remark-math` only opens a display block when `$$` ends the line - the
rest of the opening line is fence meta. The math is correct, just not centered.

`repairCollapsedGfmTables` runs before parsing, so pipe-heavy math has to survive
it. Covered by a regression test: `$$|x| - |y| \le |x - y|$$`,
`\{ x \mid x > 0 \}` and `\|v\| - \|w\| \le \|v - w\|` all pass through untouched,
and a well-formed table is still left alone.

Known follow-up, out of scope: `\(...\)` / `\[...\]` delimiters are still not
recognised - `remark-math` only parses dollar delimiters. Normalizing them safely
requires skipping code fences and inline code, which is a separate change.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [x] Whether it causes forward compatibility failure - no -->
<!-- + - [x] Whether the dependent third-party library change is involved - yes: remark-math, rehype-katex, katex promoted to direct dependencies -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2437
<!-- /bot1-related-issues -->
