### PR TITLE
Bug: Kill signal leaves orphan processes

### DIFF
--- a/jiuwenswarm/app.py
+++ b/jiuwenswarm/app.py
@@ -8,6 +8,7 @@ Supports ``--dotenv <path>`` for multi-instance isolation.
 """
 
 from __future__ import annotations
+import signal
 import subprocess
 import sys
 import time
@@ -110,6 +111,23 @@ def main() -> None:
 
     procs: list[subprocess.Popen] = [agent] + ([gateway] if gateway else [])
 
+    # Errors on jiuwenswarm-start result in sending a SIGTERM.
+    # The default behavior is to directly kill the interpreter.
+    # We capture the signals to correctly terminate child processes. 
+    _stopping: list[int] = []
+
+    def _on_shutdown_signal(signum: int, _frame: object) -> None:
+        _stopping.append(signum)
+
+    for _sig_name in ("SIGTERM", "SIGHUP", "SIGBREAK"):
+        _sig = getattr(signal, _sig_name, None)
+        if _sig is None:
+            continue  # SIGHUP is POSIX-only, SIGBREAK is Windows-only
+        try:
+            signal.signal(_sig, _on_shutdown_signal)
+        except (ValueError, OSError):
+            continue  # not the main thread, or unsupported on this platform
+
     def _terminate_all() -> None:
         for p in procs:
             if p.poll() is None:
@@ -126,6 +144,9 @@ def main() -> None:
     exit_code = 0
     try:
         while True:
+            if _stopping:
+                exit_code = 128 + _stopping[0]
+                break
             if agent.poll() is not None:
                 exit_code = agent.returncode or 0
                 break

--- a/jiuwenswarm/start_services.py
+++ b/jiuwenswarm/start_services.py
@@ -516,26 +516,98 @@ def _start_process(
             }
         )
         env.pop("AGENT_SERVER_URL", None)
-    return subprocess.Popen(cmd, cwd=str(cwd), env=env)
+
+    # Put the child in its own process group / session to prevent them from being reparented
+    # which would prevent app.py:_terminate_all to execute correctly
+
+    if sys.platform == "win32":
+        group_kwargs: dict = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    else:
+        group_kwargs = {"start_new_session": True}
+    return subprocess.Popen(cmd, cwd=str(cwd), env=env, **group_kwargs)
+
+
+def _snapshot_descendants(proc: subprocess.Popen[bytes]) -> list:
+    """Return a child's live descendants, captured *before* it is signalled.
+
+    Order matters: once the intermediate process dies its children are
+    re-parented to init and the parent->child link is gone, so a tree walk
+    performed after termination finds nothing.
+    """
+    try:
+        import psutil
+    except ImportError:  # psutil is a hard dep, but never fail teardown on it
+        return []
+    try:
+        return psutil.Process(proc.pid).children(recursive=True)
+    except Exception:  # NoSuchProcess / AccessDenied / platform quirks
+        return []
+
+
+def _signal_group(proc: subprocess.Popen[bytes], sig: int) -> bool:
+    """Signal the child's whole process group. False if not supported here."""
+    if sys.platform == "win32":
+        return False  # no killpg; descendants are handled from the snapshot
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+        return True
+    except (OSError):
+        return False
+
+
+def _reap_descendants(trees: dict[str, list], *, force: bool) -> None:
+    """Terminate/kill descendants that outlived their parent."""
+    for name, descendants in trees.items():
+        for child in descendants:
+            try:
+                if not child.is_running():
+                    continue
+                verb = "killing" if force else "terminating"
+                logging.info(
+                    f"[start_services] {verb} orphaned {name} child (pid={child.pid})"
+                )
+                child.kill() if force else child.terminate()
+            except Exception:
+                continue  # already gone, or not ours to signal
 
 
 def _terminate_processes(processes: dict[str, subprocess.Popen[bytes]]) -> None:
-    """Terminate all running processes gracefully."""
+    """Terminate all running processes and every descendant they spawned.
+
+    Signalling only the direct children leaks grandchildren: ``app`` spawns
+    agent_server and gateway itself, so terminating ``app`` alone leaves them
+    running under init, still holding 18092/19000/19001. We signal the whole
+    process group (POSIX) and sweep a pre-captured descendant snapshot as a
+    backstop for Windows and for children that create their own session.
+    """
+    trees = {
+        name: _snapshot_descendants(proc)
+        for name, proc in processes.items()
+        if proc.poll() is None
+    }
+
     for name, proc in processes.items():
         if proc.poll() is None:
             logging.info(f"[start_services] terminating {name} (pid={proc.pid})")
-            proc.terminate()
+            if not _signal_group(proc, signal.SIGTERM):
+                proc.terminate()
+                _reap_descendants({name: trees.get(name, [])}, force=False)
 
     deadline = time.time() + 8
     while time.time() < deadline:
         if all(proc.poll() is not None for proc in processes.values()):
-            return
+            break
         time.sleep(0.2)
 
     for name, proc in processes.items():
         if proc.poll() is None:
             logging.info(f"[start_services] killing {name} (pid={proc.pid})")
-            proc.kill()
+            if not _signal_group(proc, signal.SIGKILL):
+                proc.kill()
+            proc.poll()
+
+    # Anything still breathing escaped the group (or we are on Windows).
+    _reap_descendants(trees, force=True)
 
 
 def _resolve_runtime_ports() -> dict[str, int]:

--- a/tests/unit_tests/test_start_services_ready_hint.py
+++ b/tests/unit_tests/test_start_services_ready_hint.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 import logging
 import os
+import signal
+import subprocess
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +17,7 @@ import pytest
 from jiuwenswarm.start_services import (
     _resolve_runtime_ports,
     _start_process,
+    _terminate_processes,
     _wait_for_services_ready,
 )
 
@@ -91,8 +95,8 @@ def test_start_process_passes_resolved_ports_to_child(
 
     captured: dict[str, object] = {}
 
-    def fake_popen(cmd, *, cwd, env):
-        captured.update({"cmd": cmd, "cwd": cwd, "env": env})
+    def fake_popen(cmd, *, cwd, env, **kwargs):
+        captured.update({"cmd": cmd, "cwd": cwd, "env": env, "kwargs": kwargs})
         return MagicMock()
 
     monkeypatch.setattr("jiuwenswarm.start_services.subprocess.Popen", fake_popen)
@@ -361,7 +365,7 @@ def test_cli_injected_ports_survive_stale_dotenv_override(
 
     captured: dict[str, object] = {}
 
-    def fake_popen(cmd, *, cwd, env):
+    def fake_popen(cmd, *, cwd, env, **kwargs):
         captured["env"] = env
         return MagicMock()
 
@@ -399,3 +403,98 @@ def test_cli_injected_ports_survive_stale_dotenv_override(
     assert os.environ["WEB_PORT"] == "19000"
     assert os.environ["AGENT_SERVER_PORT"] == "18092"
     assert os.environ["FRONTEND_PORT"] == "5173"
+
+
+# --- Orphaned-grandchild teardown (agent_server/gateway surviving `app`) ---
+
+
+def test_start_process_isolates_child_in_own_process_group(monkeypatch, tmp_path):
+    """Children must get their own group so teardown can signal the whole tree.
+
+    Without this, terminating `app` leaves the agent_server/gateway it spawned
+    running under init, still holding 18092/19000/19001.
+    """
+    captured: dict = {}
+
+    def fake_popen(cmd, *, cwd, env, **kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("jiuwenswarm.start_services.subprocess.Popen", fake_popen)
+    _start_process("app", ["python", "-m", "jiuwenswarm.app"], tmp_path)
+
+    if sys.platform == "win32":
+        assert captured["creationflags"] & subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        assert captured["start_new_session"] is True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+def test_terminate_processes_signals_whole_group(monkeypatch):
+    """SIGTERM must go to the process group, not just the direct child."""
+    killed: list[tuple[int, int]] = []
+
+    proc = MagicMock()
+    proc.pid = 4242
+    proc.poll.side_effect = [None, None] + [0] * 20  # alive, then reaped
+
+    monkeypatch.setattr("jiuwenswarm.start_services.os.getpgid", lambda pid: pid)
+    monkeypatch.setattr(
+        "jiuwenswarm.start_services.os.killpg",
+        lambda pgid, sig: killed.append((pgid, sig)),
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.start_services._snapshot_descendants", lambda _p: []
+    )
+
+    _terminate_processes({"app": proc})
+
+    assert (4242, signal.SIGTERM) in killed
+    proc.terminate.assert_not_called()  # group signal replaces the direct hit
+
+
+def test_terminate_processes_reaps_surviving_descendants(monkeypatch):
+    """Grandchildren that outlive the group signal are still force-killed."""
+    grandchild = MagicMock()
+    grandchild.pid = 913
+    grandchild.is_running.return_value = True
+
+    proc = MagicMock()
+    proc.pid = 910
+    proc.poll.return_value = 0  # direct child already dead
+
+    monkeypatch.setattr(
+        "jiuwenswarm.start_services._snapshot_descendants", lambda _p: [grandchild]
+    )
+    # poll() is 0 up front, so nothing is snapshotted unless we force it.
+    proc.poll.side_effect = [None] + [0] * 20
+
+    _terminate_processes({"app": proc})
+
+    grandchild.kill.assert_called_once()
+
+
+def test_snapshot_taken_before_termination(monkeypatch):
+    """The descendant walk must happen before signalling, or the link is lost.
+
+    Once the intermediate dies its children re-parent to init and a post-hoc
+    psutil tree walk returns nothing — which is how the orphans escaped.
+    """
+    order: list[str] = []
+
+    proc = MagicMock()
+    proc.pid = 910
+    proc.poll.side_effect = [None, None] + [0] * 20
+    proc.terminate.side_effect = lambda: order.append("terminate")
+
+    monkeypatch.setattr(
+        "jiuwenswarm.start_services._snapshot_descendants",
+        lambda _p: (order.append("snapshot"), [])[1],
+    )
+    monkeypatch.setattr(
+        "jiuwenswarm.start_services._signal_group", lambda _p, _s: False
+    )
+
+    _terminate_processes({"app": proc})
+
+    assert order.index("snapshot") < order.index("terminate")


### PR DESCRIPTION
Paired: [GitHub #2368](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2368) ↔ [GitCode !4527](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4527)


**What type of PR is this?**

/kind bug


**What does this PR do / why do we need it**:
* I launched `jiuwenswarm-start` without first correctly building the frontend. The process terminated as expected, but when launching again, I observed it was not launching on the default ports `18092 / 19000 / 19001/ 5173`.
* The cause of this behavior is a bug in which the teardown leaves orphan processes that stayed occupying some of the ports above.
* The root cause is the fact that when it receives a signal, the python interpreter shuts down immediately and did not run the `finally` block with the `_terminate_all` call in `app.py`
* The solution involves capturing these signals to be able to gracefully terminate the program rather than propagating it to the Python interpreter
* This problem is not limited to cases in which the frontend is inexistent. It applies to every case in which the launcher or the web receive a kill (SIGTERM) signal (see below)

**Fixes**
#2423

**How to reproduce**:

1. Run the following lines:
``` bash
jiuwenswarm-start &
LAUNCHER=$!
# wait for the stack to come up
until ss -ltn | grep -q ':19001'; do sleep 1; done; sleep 3
ps -eo pid,ppid,cmd --no-headers | grep "python3 -m jiuwenswarm" | grep -v grep
```
You should observe the following shape:
```bash
34839  34820  python3 -m jiuwenswarm.app                    <- direct child of launcher
34840  34820  python3 -m jiuwenswarm.channels.web.app_web   <- direct child of launcher
34841  34839  python3 -m jiuwenswarm.server.app_agentserver  <- grandchild, via app
34842  34839  python3 -m jiuwenswarm.gateway.app_gateway     <- grandchild, via app
```
2. Kill the web/launcher process
For the web:

```bash
WEB=$(ss -ltnpH | grep ':5173' | grep -oP 'pid=\K[0-9]+' | head -1)
kill "$WEB"
sleep 10
ps -eo pid,ppid,cmd --no-headers | grep "python3 -m jiuwenswarm" | grep -v grep
ss -ltnp | grep -E ':(18092|19000|19001|5173)'
```

For the launcher, replace `grep :5173` with `grep:19001`
We can then observe the following, which signal that the ports are still under use:

```bash
[start_services] web exited with code -15
[start_services] terminating app (pid=32105)

32107  989  python3 -m jiuwenswarm.server.app_agentserver
32108  989  python3 -m jiuwenswarm.gateway.app_gateway

LISTEN 127.0.0.1:18092  users:(("python3",pid=32107,fd=9))
LISTEN 127.0.0.1:19000  users:(("python3",pid=32108,fd=7))
LISTEN 127.0.0.1:19001  users:(("python3",pid=32108,fd=6))
```

**Note:** This is not reproducible with a direct `Ctrl+C` from the terminal because in this case the SIGINT signal is passed to the entire group of processes. This masks the bug solved in this PR

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.


<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2423
<!-- /bot1-related-issues -->
