### PR TITLE
fix(instance): detect port conflicts accurately and stop relocating pinned ports

### DIFF
--- a/jiuwenswarm/instance_manager/__init__.py
+++ b/jiuwenswarm/instance_manager/__init__.py
@@ -53,6 +53,7 @@ from jiuwenswarm.instance_manager.config import (
     is_port_available,
     PORT_ENV_NAMES,
     PORT_ENV_OVERRIDES,
+    pinned_port_types,
 )
 
 # YAML management from yaml
@@ -123,6 +124,7 @@ __all__ = [
     "find_available_ports",
     "PORT_ENV_NAMES",
     "PORT_ENV_OVERRIDES",
+    "pinned_port_types",
     # YAML management
     "get_instances_yaml_path",
     "get_instances_dir",

--- a/jiuwenswarm/instance_manager/config.py
+++ b/jiuwenswarm/instance_manager/config.py
@@ -158,6 +158,26 @@ def _resolved_base_port(port_type: str) -> int:
     return BASE_PORTS.get(port_type, 10000)
 
 
+def pinned_port_types() -> set[str]:
+    """Return port types whose base is set via ``JIUWENSWARM_<TYPE>_PORT``.
+
+    Only values ``_resolved_base_port`` honors count: it ignores a malformed one
+    and uses the default, so treating it as pinned would fail startup over a port
+    nobody chose. Pins the base; the effective port stays ``base + index * 1000``.
+    """
+    pinned: set[str] = set()
+    for port_type, env_key in PORT_ENV_OVERRIDES.items():
+        raw = os.getenv(env_key)
+        if not raw:
+            continue
+        try:
+            int(raw)
+        except ValueError:
+            continue
+        pinned.add(port_type)
+    return pinned
+
+
 def compute_auto_port(port_type: str, index: int) -> int:
     """Compute auto-allocated port for an instance.
 

--- a/jiuwenswarm/instance_manager/config.py
+++ b/jiuwenswarm/instance_manager/config.py
@@ -198,10 +198,17 @@ def _bind_listen_probe(host: str, port: int, family: int) -> bool | None:
         sock = socket.socket(family, socket.SOCK_STREAM)
     except OSError:
         return None
-    # Intentionally NOT setting SO_REUSEADDR: on Windows it permits multiple
-    # sockets to bind the same port, which would mask an occupied port and
-    # reproduce the very 10048 crash we are trying to avoid. The real services
-    # do not set it either.
+    # POSIX only, matching the servers: uvicorn sets it in bind_socket(),
+    # asyncio defaults reuse_address=True. Without it the probe is stricter than
+    # the bind it predicts -- a port left in TIME-WAIT by the service's own
+    # previous run reads as occupied and the launcher shifts the whole group by
+    # +1000. Not on Windows, where the flag lets two sockets share a port and
+    # would mask a real conflict (the WinError 10048 this probe exists to prevent).
+    if os.name != "nt":
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        except OSError:
+            pass
     try:
         sock.bind((host, port))
         sock.listen(1)
@@ -228,10 +235,9 @@ def _bind_listen_probe(host: str, port: int, family: int) -> bool | None:
 def is_port_available(host: str, port: int) -> bool:
     """Check if a port is available for binding on the given host.
 
-    Probes by attempting to ``bind()``+``listen()`` (without SO_REUSEADDR) and
-    immediately closing. This mirrors how the real services (AgentServer /
-    Gateway / Web / Frontend) actually acquire their ports, so it correctly
-    detects:
+    Probes by attempting to ``bind()``+``listen()`` and immediately closing,
+    with the same ``SO_REUSEADDR`` setting the real services (AgentServer /
+    Gateway / Web / Frontend) use on this platform, so it correctly detects:
 
     - A live service listening on the port (bind fails -> occupied).
     - A *stuck/zombie* listener that is in LISTENING state but no longer

--- a/jiuwenswarm/start_services.py
+++ b/jiuwenswarm/start_services.py
@@ -48,7 +48,9 @@ from jiuwenswarm.instance_manager import (
     write_pid_file,
     PORT_TYPES,
     PORT_ENV_NAMES,
+    PORT_ENV_OVERRIDES,
     compute_auto_port,
+    pinned_port_types,
 )
 
 # Runtime data root:
@@ -220,8 +222,56 @@ def _log_port_table(prefix: str, ports: dict[str, int]) -> None:
         logging.info(f"  {port_type}: {ports.get(port_type, 0)}")
 
 
-def _resolve_ports_with_fallback(cmd: InstanceCommand, scan_range: int = 10) -> int | None:
+def _reject_pinned_port_conflicts(
+    conflicts: list[tuple[str, int]],
+) -> int | None:
+    """Refuse to relocate a port group the operator pinned explicitly.
+
+    Scanning is right for auto-allocated ports -- it is what makes ``--name foo``
+    work -- but wrong for a ``JIUWENSWARM_<TYPE>_PORT``: that port was chosen
+    because something else talks to it, so shifting it yields a healthy-looking
+    process nothing can reach.
+
+    Returns:
+        1 if a pinned port is occupied (caller aborts), None if only
+        auto-allocated ports conflict and scanning may proceed.
+    """
+    pinned = pinned_port_types()
+    blocked = [(pt, port) for pt, port in conflicts if pt in pinned]
+    if not blocked:
+        return None
+
+    logging.info(
+        "[start_services] ERROR: %d explicitly pinned port(s) are already in use:",
+        len(blocked),
+    )
+    for port_type, port in blocked:
+        logging.info(
+            "  ✗ %s: %s (pinned by %s)",
+            port_type,
+            port,
+            PORT_ENV_OVERRIDES.get(port_type, "?"),
+        )
+    logging.info(
+        "[start_services] Refusing to relocate a pinned port group: a silent "
+        "shift would leave clients talking to an address nothing is listening on."
+    )
+    logging.info(
+        "[start_services] Free the port (ss -ltnp | grep <port>), change the "
+        "pinned value, or unset the variable to allow automatic allocation."
+    )
+    return 1
+
+
+def _resolve_ports_with_fallback(
+    cmd: InstanceCommand,
+    scan_range: int = 10,
+    conflicts: list[tuple[str, int]] | None = None,
+) -> int | None:
     """Resolve port conflicts by scanning for an available port group.
+
+    Aborts instead of scanning when any conflicting port was pinned through
+    ``JIUWENSWARM_<TYPE>_PORT`` (see ``_reject_pinned_port_conflicts``).
 
     Called when ``cmd.check_ports_conflicts()`` is non-empty. Scans upward from
     the instance's own index (0 for default) for the first fully-available
@@ -255,6 +305,12 @@ def _resolve_ports_with_fallback(cmd: InstanceCommand, scan_range: int = 10) -> 
     )
 
     if cmd.config is None:
+        return 1
+
+    # Reuse the caller's list; re-probing is wasteful and can disagree.
+    if conflicts is None:
+        conflicts = cmd.check_ports_conflicts()
+    if _reject_pinned_port_conflicts(conflicts) is not None:
         return 1
 
     # Determine the scan starting index: the instance's own declared index.
@@ -744,8 +800,9 @@ def _run(mode: str) -> int:
     if cmd.validate_and_load():
         return 1
 
-    if cmd.check_ports_conflicts():
-        if _resolve_ports_with_fallback(cmd) is not None:
+    conflicts = cmd.check_ports_conflicts()
+    if conflicts:
+        if _resolve_ports_with_fallback(cmd, conflicts=conflicts) is not None:
             return 1
         # Fallback already persisted the resolved ports to .env.
     else:
@@ -893,8 +950,9 @@ def _start_named_instance(name: str, mode: str) -> int:
     # Port availability: on conflict, try to fall back to a free port group
     # (persists to instances.yaml + bootstrap .env so subprocesses/TUI/CLI
     # pick up the new ports). Only hard-fail if no fallback is possible.
-    if cmd.check_ports_conflicts():
-        if _resolve_ports_with_fallback(cmd) is not None:
+    conflicts = cmd.check_ports_conflicts()
+    if conflicts:
+        if _resolve_ports_with_fallback(cmd, conflicts=conflicts) is not None:
             return 1
 
     config = cmd.config

--- a/tests/unit_tests/test_instance_manager.py
+++ b/tests/unit_tests/test_instance_manager.py
@@ -224,6 +224,31 @@ class TestPortAvailability:
             s.close()
 
     @staticmethod
+    @pytest.mark.skipif(os.name == "nt", reason="probe omits SO_REUSEADDR on Windows")
+    def test_is_port_available_true_for_a_time_wait_port():
+        """A port left in TIME-WAIT by a previous run must read as available.
+
+        Regression guard for the silent +1000 drift: a probe without
+        SO_REUSEADDR reads a restarted service's own TIME-WAIT ports as occupied,
+        so the launcher relocates the group though the servers would have bound it.
+        """
+        import socket as _socket
+
+        server = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        server.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", 0))
+        port = server.getsockname()[1]
+        server.listen(1)
+        client = _socket.create_connection(("127.0.0.1", port))
+        accepted, _ = server.accept()
+        # Closing the listening side first is what parks this port in TIME-WAIT.
+        server.close()
+        accepted.close()
+        client.close()
+
+        assert is_port_available("127.0.0.1", port) is True
+
+    @staticmethod
     def test_is_port_available_true_when_free(tmp_path):
         """A genuinely free ephemeral port is reported as available."""
         import socket as _socket
@@ -1157,10 +1182,10 @@ class TestStartServicesFallback:
 
         # Make index-1 group occupied; everything else free
         occupied = set(calculate_instance_ports(1).values())
-        real = is_port_available
-
         def fake(host, port):
-            return port not in occupied and real(host, port)
+            # Not the real machine: on a host already running instances the
+            # scan would skip past the index asserted below.
+            return port not in occupied
 
         monkeypatch.setattr(
             "jiuwenswarm.instance_manager.config.is_port_available", fake
@@ -1208,10 +1233,10 @@ class TestStartServicesFallback:
 
         # Force ONLY the index-0 group to be occupied; every higher index free.
         occupied = set(calculate_instance_ports(0).values())
-        real = is_port_available
-
         def fake(host, port):
-            return port not in occupied and real(host, port)
+            # Not the real machine: on a host already running instances the
+            # scan would skip past the index asserted below.
+            return port not in occupied
 
         monkeypatch.setattr(
             "jiuwenswarm.instance_manager.config.is_port_available", fake
@@ -1288,10 +1313,10 @@ class TestStartServicesFallback:
         # Only index-0 occupied so a fallback group IS found — but then make
         # the .env write raise so the persistence path fails.
         occupied = set(calculate_instance_ports(0).values())
-        real = is_port_available
-
         def fake_probe(host, port):
-            return port not in occupied and real(host, port)
+            # Not the real machine: on a host already running instances the
+            # scan would skip past the index asserted below.
+            return port not in occupied
 
         monkeypatch.setattr(
             "jiuwenswarm.instance_manager.config.is_port_available", fake_probe

--- a/tests/unit_tests/test_instance_manager.py
+++ b/tests/unit_tests/test_instance_manager.py
@@ -59,6 +59,7 @@ from jiuwenswarm.instance_manager import (
     PORT_ENV_NAMES,
     PORT_ENV_OVERRIDES,
     STALE_LOCK_TIMEOUT,
+    pinned_port_types,
 )
 from jiuwenswarm.instance_manager.config import (
     _format_url_hint,
@@ -1411,3 +1412,145 @@ class TestStartServicesFallback:
         # And pre-existing unrelated keys preserved.
         assert "API_KEY=sk-keep" in txt
         assert "MODEL_NAME=m-keep" in txt
+
+
+class TestPinnedPortTypes:
+    """``pinned_port_types`` must agree with what ``_resolved_base_port`` honours."""
+
+    @staticmethod
+    def test_nothing_pinned_by_default(monkeypatch):
+        for env_key in PORT_ENV_OVERRIDES.values():
+            monkeypatch.delenv(env_key, raising=False)
+        assert pinned_port_types() == set()
+
+    @staticmethod
+    def test_valid_values_are_pinned(monkeypatch):
+        for env_key in PORT_ENV_OVERRIDES.values():
+            monkeypatch.delenv(env_key, raising=False)
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["web"], "19000")
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["gateway"], "19001")
+        assert pinned_port_types() == {"web", "gateway"}
+
+    @staticmethod
+    def test_malformed_value_is_not_pinned(monkeypatch):
+        """_resolved_base_port ignores a non-int and uses the default, so this
+        must not count as pinned -- otherwise startup hard-fails over a port the
+        operator never actually chose."""
+        for env_key in PORT_ENV_OVERRIDES.values():
+            monkeypatch.delenv(env_key, raising=False)
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["web"], "not-a-port")
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["gateway"], "")
+        assert pinned_port_types() == set()
+
+
+class TestPinnedPortConflictsAbort:
+    """A pinned port that is taken must stop startup, never relocate silently."""
+
+    @staticmethod
+    def _clear(monkeypatch):
+        for env_key in PORT_ENV_OVERRIDES.values():
+            monkeypatch.delenv(env_key, raising=False)
+
+    @staticmethod
+    def test_pinned_conflict_aborts_without_scanning(monkeypatch):
+        from jiuwenswarm import start_services
+
+        TestPinnedPortConflictsAbort._clear(monkeypatch)
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["gateway"], "19001")
+
+        scanned = []
+        monkeypatch.setattr(
+            "jiuwenswarm.start_services.find_available_ports",
+            lambda **kw: scanned.append(kw) or (calculate_instance_ports(1), 1),
+        )
+
+        cmd = start_services.InstanceCommand("default")
+        assert cmd.validate_and_load() is None
+        conflicts = [("gateway", 19001)]
+
+        rc = start_services._resolve_ports_with_fallback(cmd, conflicts=conflicts)
+
+        assert rc == 1
+        assert scanned == [], "a pinned group must never be relocated"
+        # Ports left untouched, so nothing downstream can bind a shifted group.
+        assert cmd.config.ports["gateway"] == 19001
+
+    @staticmethod
+    def test_unpinned_conflict_still_scans(monkeypatch, tmp_path):
+        from jiuwenswarm import start_services
+
+        TestPinnedPortConflictsAbort._clear(monkeypatch)
+        cfg_env = tmp_path / "config" / ".env"
+        cfg_env.parent.mkdir(parents=True, exist_ok=True)
+        cfg_env.write_text("API_KEY=sk-keep\n", encoding="utf-8")
+        monkeypatch.setattr("jiuwenswarm.start_services.get_env_file", lambda: cfg_env)
+        monkeypatch.setattr(
+            "jiuwenswarm.instance_manager.collect_all_ports",
+            lambda exclude_name=None: [],
+        )
+        occupied = set(calculate_instance_ports(0).values())
+        monkeypatch.setattr(
+            "jiuwenswarm.instance_manager.config.is_port_available",
+            lambda host, port: port not in occupied,
+        )
+        monkeypatch.setattr(
+            "jiuwenswarm.start_services.is_port_available",
+            lambda host, port: port not in occupied,
+        )
+
+        cmd = start_services.InstanceCommand("default")
+        assert cmd.validate_and_load() is None
+
+        rc = start_services._resolve_ports_with_fallback(
+            cmd, conflicts=[("gateway", 19001)]
+        )
+
+        assert rc is None
+        assert cmd.config.ports["gateway"] == 20001
+
+    @staticmethod
+    def test_only_the_conflicting_type_matters(monkeypatch, tmp_path):
+        """Pinning web while gateway (auto-allocated) conflicts still scans."""
+        from jiuwenswarm import start_services
+
+        TestPinnedPortConflictsAbort._clear(monkeypatch)
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["web"], "19000")
+        cfg_env = tmp_path / "config" / ".env"
+        cfg_env.parent.mkdir(parents=True, exist_ok=True)
+        cfg_env.write_text("API_KEY=sk-keep\n", encoding="utf-8")
+        monkeypatch.setattr("jiuwenswarm.start_services.get_env_file", lambda: cfg_env)
+        monkeypatch.setattr(
+            "jiuwenswarm.instance_manager.collect_all_ports",
+            lambda exclude_name=None: [],
+        )
+        occupied = set(calculate_instance_ports(0).values())
+        monkeypatch.setattr(
+            "jiuwenswarm.instance_manager.config.is_port_available",
+            lambda host, port: port not in occupied,
+        )
+        monkeypatch.setattr(
+            "jiuwenswarm.start_services.is_port_available",
+            lambda host, port: port not in occupied,
+        )
+
+        cmd = start_services.InstanceCommand("default")
+        assert cmd.validate_and_load() is None
+
+        rc = start_services._resolve_ports_with_fallback(
+            cmd, conflicts=[("gateway", 19001)]
+        )
+
+        assert rc is None
+
+    @staticmethod
+    def test_reject_helper_is_selective(monkeypatch):
+        from jiuwenswarm import start_services
+
+        TestPinnedPortConflictsAbort._clear(monkeypatch)
+        monkeypatch.setenv(PORT_ENV_OVERRIDES["frontend"], "5173")
+
+        assert start_services._reject_pinned_port_conflicts([]) is None
+        assert (
+            start_services._reject_pinned_port_conflicts([("gateway", 19001)]) is None
+        )
+        assert start_services._reject_pinned_port_conflicts([("frontend", 5173)]) == 1


### PR DESCRIPTION
Paired: [GitHub #2374](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2374) ↔ [GitCode !4530](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4530)

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:

Fixes #2373

**What does this PR do / why do we need it**:

Port conflict handling gets two things wrong, and together they let an ordinary restart move a pinned port group to `base + 1000` and persist the move. The instance comes up healthy on ports nobody configured, and nothing reports it.

The two halves are the same decision: *is this port taken*, and *what should happen if it is*. Each is fixed in its own commit.

### 1. `fix(instance): probe ports the way the servers actually bind them`

`is_port_available` probed with `bind()` + `listen()` and omitted `SO_REUSEADDR`, justified in a comment by "The real services do not set it either". That premise does not hold:

| Component | Behaviour |
|---|---|
| uvicorn | sets `SO_REUSEADDR` unconditionally in `Config.bind_socket()` |
| asyncio `create_server` | `reuse_address=True` by default on POSIX |
| Vite / Node | set by default on POSIX |
| `browser_tools.py` in this repo | sets it |

The probe was therefore stricter than the bind it predicts. A port carrying `TIME-WAIT` entries from the service's own previous run read as occupied, so the launcher relocated the whole group even though the servers would have bound it.

The flag is now set **on POSIX only**. Windows keeps the previous behaviour and the original rationale, which is sound there: `SO_REUSEADDR` lets two sockets bind the same port outright, which would mask a real conflict and reproduce the `WinError 10048` crash this probe exists to prevent. POSIX has no such hazard — the flag still refuses to bind over a live listener, it only forgives `TIME-WAIT`.

### 2. `fix(instance): refuse to relocate explicitly pinned ports`

Scanning for a free group is right for auto-allocated ports; it is what makes `jiuwenswarm-start --name <n>` work, and that behaviour is unchanged. It is wrong for a port set through `JIUWENSWARM_<TYPE>_PORT`: that port was chosen because something else depends on it, so shifting it yields a healthy-looking process nothing can reach — and the shift is persisted, so it survives the next restart.

Startup now aborts when a conflicting port was pinned, naming the port and the variable that pinned it:

```
[start_services] ERROR: 1 explicitly pinned port(s) are already in use:
  ✗ gateway: 19001 (pinned by JIUWENSWARM_GATEWAY_PORT)
[start_services] Refusing to relocate a pinned port group: a silent shift would
leave clients talking to an address nothing is listening on.
[start_services] Free the port (ss -ltnp | grep <port>), change the pinned
value, or unset the variable to allow automatic allocation.
```

A malformed value does not count as pinned, matching `_resolved_base_port`, which ignores it and falls back to the built-in default. Failing startup over a port nobody chose would be worse than the behaviour being fixed.

Pinning applies to every instance, not only the default. The variable sets the base and the effective port remains `base + index * 1000`, but that offset is arithmetic on a deliberately chosen value, so the result is still deterministic.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

### How to test

```bash
pytest tests/unit_tests/test_instance_manager.py
```

82 tests pass. New coverage:

- `test_is_port_available_true_for_a_time_wait_port` — builds a real `TIME-WAIT` socket and asserts the probe reports it available. No test previously covered this, which is why the regression was invisible. Skipped on Windows, where the probe intentionally still omits the flag.
- `TestPinnedPortTypes` — only values `_resolved_base_port` honours count as pinned; a malformed one does not.
- `TestPinnedPortConflictsAbort` — a pinned conflict aborts without scanning; an unpinned conflict still scans; only the *conflicting* port type matters.

The existing `test_is_port_available_detects_live_listener` and `test_is_port_available_detects_ipv6_only_listener` pass unchanged: on POSIX, `SO_REUSEADDR` still refuses to bind over a live listener.

Three pre-existing tests in `TestStartServicesFallback` are also corrected. Their fake probe ended in `and real(host, port)`, consulting the actual machine, so on a host already running other instances the scan skipped past the index each test asserts — contradicting their own comment that every higher index is free.

### Manual verification

With the ports pinned, stop and immediately restart an instance inside the `TIME-WAIT` window. Before this change the launcher reports all four ports as `already in use` and falls back. After it, the launcher reports:

```
  ✓ agent_server: 18092 - available
  ✓ web: 19000 - available
  ✓ gateway: 19001 - available
  ✓ frontend: 5173 - available
```

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [ ] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2373
<!-- /bot1-related-issues -->
