### PR TITLE
test: stop the unit suite failing on tests that did not cause the failure

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,3 +39,7 @@ filterwarnings =
     error
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+    # Raised from a finalizer during garbage collection, so "error" fails
+    # whichever test is running then rather than the one that leaked. Report
+    # it without failing an unrelated test.
+    default::ResourceWarning

--- a/tests/unit_tests/agentserver/test_agentserver_modes.py
+++ b/tests/unit_tests/agentserver/test_agentserver_modes.py
@@ -1699,7 +1699,11 @@ def test_deep_adapter_handle_user_answer_ignores_team_plan_approval_compat(monke
         lambda _channel_id: pytest.fail("team_plan_approval should not route via interact"),
     )
 
+    # Answer on this adapter rather than delegating to a per-session one, which
+    # handle_user_answer would otherwise build: a live agent instance and its
+    # model client, reaching the configured api_base over the network.
     adapter = JiuWenSwarmDeepAdapter()
+    adapter._is_session_scoped_adapter = True
     request = AgentRequest(
         request_id="req-answer",
         channel_id="tui",
@@ -1736,7 +1740,10 @@ def test_deep_adapter_routes_team_simplify_answer_by_evolution_meta(monkeypatch)
         async def on_reject_simplify(self, request_id: str) -> None:
             pytest.fail("team simplify approval must not use regular SkillEvolutionRail")
 
+    # Same reason as above, and it is what makes the rail below take effect:
+    # delegating would consult the session adapter's rail, not this one.
     adapter = JiuWenSwarmDeepAdapter()
+    adapter._is_session_scoped_adapter = True
     adapter._skill_evolution_rail = FailingRegularRail()
     monkeypatch.setattr(
         JiuWenSwarmDeepAdapter,

--- a/tests/unit_tests/agentserver/test_remote_member_bootstrap.py
+++ b/tests/unit_tests/agentserver/test_remote_member_bootstrap.py
@@ -728,6 +728,14 @@ async def test_bootstrap_allows_later_kickoff_for_same_member_after_task_done(mo
         fake_replace_card_after_direct_bootstrap,
     )
 
+    async def no_member_status(*args, **kwargs):
+        return None
+
+    # The real lookup builds a team agent and its model client, reaching the
+    # configured api_base over the network. It already returns None on any
+    # exception, so the status is unavailable here either way -- state it.
+    monkeypatch.setattr(_mod, "_member_status_for_session", no_member_status)
+
     processed = set()
     loop_kicked_members = set()
     kickoff_tasks = set()


### PR DESCRIPTION
Paired: [GitHub #2391](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2391) ↔ [GitCode !4535](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4535)

**What type of PR is this?**

/kind bug


**Which issue(s) this PR fixes**:

Fixes #2390


**What does this PR do / why do we need it**:


Three unit tests open a real outbound connection and never close it. The socket outlives the test, and when the garbage collector finalises it the resulting `ResourceWarning` is charged to whichever test is running at that moment. `filterwarnings = error` turns that into a failure of a test that did nothing wrong, in a different file, with no project code in the traceback.

Two commits: stop erroring on a warning that cannot be attributed, then remove the leak that produces it.

---

### 1. `test: report stray ResourceWarnings instead of failing a bystander`

```diff
 filterwarnings =
     error
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+    default::ResourceWarning
```

A `ResourceWarning` is raised inside a finalizer, which runs whenever the collector reaches the object -- not where the resource was acquired or abandoned. pytest routes it through `sys.unraisablehook`, drains the queue at each test's setup, call and teardown, and re-raises it as `PytestUnraisableExceptionWarning`; `error` then charges it to the item whose hook is currently running.

Nothing is lost by not erroring, because the attribution was never correct: the error named a victim, not a cause. `default` keeps the warning in the run's warnings summary, where it stays visible and can be traced deliberately.

`ignore` would have been the wrong choice -- that hides the signal. `default` keeps it and only stops it failing an unrelated test.

### 2. `test(agentserver): stop three unit tests reaching for the network`

`resources/.env.template` ships `API_BASE="https://example.com/compatible-mode/v1"` as a placeholder and `config.yaml` wires it through as `api_base: ${API_BASE}`. Three tests build a live model client against it:

- **Two in `test_agentserver_modes.py`** call `handle_user_answer` on an adapter whose `_is_session_scoped_adapter` is `False`, so the method delegates to a per-session adapter built on the spot -- a full agent instance and its model client -- for assertions that only check which approval branch a request takes. Answering on the adapter under test exercises the same branches without constructing any of it.

  In the second test this also makes an existing guard effective: it installs a `FailingRegularRail` on the adapter, but the delegate consults *its own* rail, so the guard could not fire as written.

- **One in `test_remote_member_bootstrap.py`** reaches `_member_status_for_session`, which builds a team agent to read one field. That lookup is already wrapped in a broad `except` returning `None`, so the status is unavailable in this test whether or not the network answers. Stubbing it states what was already true and removes the round trip.

No assertion is weakened and no implementation code changes.

---

### Behaviour changes

- A leaked resource no longer fails an unrelated test. It is reported in the warnings summary instead.
- The unit suite no longer performs name resolution or outbound connections.
- Three tests get faster: they no longer construct an agent instance and wait on a connection to an unreachable placeholder.

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

### How to test

```bash
pytest tests/unit_tests/agentserver tests/unit_tests/cli
```

`1830 passed, 2 skipped`. Before this change the same command fails one test in `cli/`, and *which* test fails varies between identical runs.

The leak was located with a socket trace over the full unit suite: six outbound connects, all from the three tests above, all to the placeholder host. After this change the same trace records none.

Checked on pytest 9.0.3 and 9.1.1, since the two differ in logging and unraisable handling.

### Manual verification

Two tests in one file reproduce the misattribution deterministically, with the repository's `pytest.ini`:

```python
import gc
import socket

_keep = {}


def test_a_leaks_a_socket():
    s = socket.socket()
    s.connect(("example.com", 80))
    _keep["sock"] = s


def test_b_is_innocent():
    _keep.clear()
    gc.collect()
    assert 1 + 1 == 2
```

`test_b_is_innocent` fails before the first commit and passes after, while the warning remains listed in the warnings summary.


**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2390
<!-- /bot1-related-issues -->
