### PR TITLE
feat(config): ship empty model credentials in .env.template and warn at startup when no model is configured

### DIFF
--- a/jiuwenswarm/common/model_config_validation.py
+++ b/jiuwenswarm/common/model_config_validation.py
@@ -22,3 +22,36 @@ def is_placeholder_api_base(api_base: str) -> bool:
     if not host:
         return False
     return any(host == domain or host.endswith(f".{domain}") for domain in EXAMPLE_DOMAINS)
+
+
+def is_model_client_config_usable(mcc: dict) -> bool:
+    """Return True when model_client_config has real-looking API credentials."""
+    from openjiuwen.core.foundation.llm.utils.provider_utils import is_openai_account_provider
+
+    api_base = str(mcc.get("api_base", "") or "").strip()
+    if not api_base or is_placeholder_api_base(api_base):
+        return False
+
+    provider = mcc.get("client_provider", "")
+    provider = getattr(provider, "value", provider)
+    if is_openai_account_provider(str(provider or "")):
+        return True
+
+    return bool(str(mcc.get("api_key", "") or "").strip())
+
+
+def default_model_preflight_error(config: dict | None = None) -> str | None:
+    """Return a startup warning when no default model is usable, else None."""
+    from jiuwenswarm.common.config import get_default_models
+    from jiuwenswarm.common.utils import get_env_file
+
+    try:
+        models = get_default_models(config)
+    except Exception:
+        return None
+    if any(is_model_client_config_usable(m.get("model_client_config", {}) or {}) for m in models):
+        return None
+    return (
+        "No model configured. Set API_BASE / API_KEY / MODEL_NAME in "
+        f"{get_env_file()} or open the Web config panel (Model Config), then restart."
+    )

--- a/jiuwenswarm/resources/.env.template
+++ b/jiuwenswarm/resources/.env.template
@@ -1,6 +1,7 @@
-API_BASE="https://example.com/compatible-mode/v1"
-API_KEY="sk-xxxxxxxxx"
-MODEL_NAME="your-model-name"
+# Model access is unconfigured by default. Fill these in, or use the Web config panel.
+API_BASE=""
+API_KEY=""
+MODEL_NAME=""
 # or other provider like SiliconFlow, etc.
 MODEL_PROVIDER=OpenAI
 CUSTOM_HEADERS=

--- a/jiuwenswarm/server/app_agentserver.py
+++ b/jiuwenswarm/server/app_agentserver.py
@@ -145,8 +145,15 @@ async def _run(host: str, port: int) -> None:
     from jiuwenswarm.extensions.manager import ExtensionManager
     from jiuwenswarm.extensions.registry import ExtensionRegistry
     from jiuwenswarm.common.config import get_config
+    from jiuwenswarm.common.model_config_validation import default_model_preflight_error
 
     logger.info("[AgentServer] starting: ws://%s:%s", host, port)
+
+    # Warn (don't block) when no default model is configured: the Web config
+    # panel is the remediation path and needs running services.
+    preflight = default_model_preflight_error()
+    if preflight:
+        logger.warning("[AgentServer] %s", preflight)
 
     # ---------- 扩展系统初始化 ----------
     callback_framework = Runner.callback_framework

--- a/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
+++ b/jiuwenswarm/server/runtime/agent_adapter/interface_deep.py
@@ -34,7 +34,6 @@ import yaml
 from openjiuwen.core.context_engine.schema.config import ContextEngineConfig
 from openjiuwen.core.foundation.kv_cache import KVCacheAffinityConfig
 from openjiuwen.core.foundation.llm import ModelRequestConfig, ModelClientConfig, Model
-from openjiuwen.core.foundation.llm.utils.provider_utils import is_openai_account_provider
 from openjiuwen.core.foundation.store.base_embedding import EmbeddingConfig
 from openjiuwen.core.foundation.tool import ToolCard, McpServerConfig
 from openjiuwen.core.common.logging import server_logger
@@ -197,7 +196,7 @@ from jiuwenswarm.agents.harness.common.memory.config import (
     is_proactive_memory,
 )
 from jiuwenswarm.agents.harness.common.memory.external_memory_config import is_builtin_memory_allowed
-from jiuwenswarm.common.model_config_validation import is_placeholder_api_base
+from jiuwenswarm.common.model_config_validation import is_model_client_config_usable
 from jiuwenswarm.agents.harness.common.rails.permissions.tool_permission_context import TOOL_PERMISSION_CHANNEL_ID
 from jiuwenswarm.server.runtime.session.session_metadata import build_server_push_message
 from jiuwenswarm.server.runtime.session.session_history import append_history_record, load_history_records
@@ -710,17 +709,7 @@ def init_permission_engine(*_args: Any, **_kwargs: Any) -> None:
 
 def _mcc_looks_usable(mcc: dict) -> bool:
     """检查 model_client_config 是否包含有效的 API 凭据。"""
-    api_base = str(mcc.get("api_base", "") or "").strip()
-    if not api_base or is_placeholder_api_base(api_base):
-        return False
-
-    provider = mcc.get("client_provider", "")
-    provider = getattr(provider, "value", provider)
-    if is_openai_account_provider(str(provider or "")):
-        return True
-
-    api_key = str(mcc.get("api_key", "") or "").strip()
-    return bool(api_key)
+    return is_model_client_config_usable(mcc)
 
 
 def parse_int(value: Any, default: int) -> int:

--- a/jiuwenswarm/start_services.py
+++ b/jiuwenswarm/start_services.py
@@ -756,6 +756,17 @@ def _run(mode: str) -> int:
         if _sync_default_env_ports(cmd.config.ports) is not None:
             return 1
 
+    # Warn (don't block) when no default model is configured. This process
+    # does not load the workspace .env itself, so load it non-destructively
+    # before checking.
+    from dotenv import load_dotenv
+    from jiuwenswarm.common.model_config_validation import default_model_preflight_error
+
+    load_dotenv(dotenv_path=get_env_file(), override=False)
+    preflight = default_model_preflight_error()
+    if preflight:
+        logging.info(f"[start_services] WARNING: {preflight}")
+
     commands = _build_commands(mode)
     if not commands:
         logging.info(f"[start_services] no commands to run for mode: {mode}")

--- a/tests/unit_tests/common/test_model_config_validation.py
+++ b/tests/unit_tests/common/test_model_config_validation.py
@@ -1,4 +1,8 @@
-from jiuwenswarm.common.model_config_validation import is_placeholder_api_base
+from jiuwenswarm.common.model_config_validation import (
+    default_model_preflight_error,
+    is_model_client_config_usable,
+    is_placeholder_api_base,
+)
 
 
 def test_is_placeholder_api_base_detects_documentation_domains():
@@ -12,3 +16,63 @@ def test_is_placeholder_api_base_allows_real_domains_and_empty_values():
     assert not is_placeholder_api_base("https://real.provider.test/v1")
     assert not is_placeholder_api_base("https://example.test/v1")
     assert not is_placeholder_api_base("")
+
+
+def test_is_model_client_config_usable_rejects_missing_or_placeholder_base():
+    assert not is_model_client_config_usable({})
+    assert not is_model_client_config_usable({"api_base": "", "api_key": "sk-real"})
+    assert not is_model_client_config_usable(
+        {"api_base": "https://example.com/compatible-mode/v1", "api_key": "sk-real"}
+    )
+
+
+def test_is_model_client_config_usable_requires_api_key_for_key_providers():
+    assert not is_model_client_config_usable(
+        {"api_base": "https://real.provider.test/v1", "api_key": "", "client_provider": "OpenAI"}
+    )
+    assert is_model_client_config_usable(
+        {"api_base": "https://real.provider.test/v1", "api_key": "sk-real", "client_provider": "OpenAI"}
+    )
+
+
+def test_is_model_client_config_usable_allows_openai_account_without_key():
+    assert is_model_client_config_usable(
+        {"api_base": "https://real.provider.test/v1", "api_key": "", "client_provider": "OpenAIAccount"}
+    )
+
+
+def _config_with_defaults(entries):
+    return {"models": {"defaults": entries}}
+
+
+def test_default_model_preflight_error_warns_when_no_model_usable():
+    config = _config_with_defaults(
+        [
+            {"model_client_config": {"api_base": "", "api_key": ""}},
+            {
+                "model_client_config": {
+                    "api_base": "https://example.com/compatible-mode/v1",
+                    "api_key": "sk-xxxxxxxxx",
+                }
+            },
+        ]
+    )
+    message = default_model_preflight_error(config)
+    assert message is not None
+    assert "API_BASE" in message
+
+
+def test_default_model_preflight_error_none_when_one_model_usable():
+    config = _config_with_defaults(
+        [
+            {"model_client_config": {"api_base": "", "api_key": ""}},
+            {
+                "model_client_config": {
+                    "api_base": "https://real.provider.test/v1",
+                    "api_key": "sk-real",
+                    "client_provider": "OpenAI",
+                }
+            },
+        ]
+    )
+    assert default_model_preflight_error(config) is None


### PR DESCRIPTION
Paired: [GitHub #2392](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2392) ↔ [GitCode !4536](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4536)

**What type of PR is this?**
/kind feature

**What does this PR do / why do we need it**:
* `resources/.env.template` shipped fake-but-well-formed model credentials (`API_BASE="https://example.com/compatible-mode/v1"`, `API_KEY="sk-xxxxxxxxx"`, `MODEL_NAME="your-model-name"`). A fresh install therefore looks configured everywhere (config panel, `models.list`, `config/.env`) until the first chat message fails. This PR ships empty values instead, so an unconfigured install is visibly unconfigured.
* Adds a non-blocking startup preflight: `jiuwenswarm-agentserver` and `jiuwenswarm-start` now log one clear warning when no default model is usable, e.g. `No model configured. Set API_BASE / API_KEY / MODEL_NAME in <workspace>/config/.env or open the Web config panel (Model Config), then restart.` Services still start, because the Web config panel is the main remediation path and needs running services.
* Refactor: the credential-usability check from `interface_deep._mcc_looks_usable` moves to `common/model_config_validation.is_model_client_config_usable`, so the existing request-time guard and the new startup preflight share one implementation. `is_placeholder_api_base` is unchanged: installs that still carry the old `example.com` URL in `config/.env` keep being detected, at request time and now also at startup.

**Which issue(s) this PR fixes**:
Fixes #2441 

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
* Unit tests: `tests/unit_tests/common/test_model_config_validation.py` (7 passed) covers `is_model_client_config_usable` (empty/placeholder base, key-provider without key, OpenAIAccount without key) and `default_model_preflight_error` (warns when defaults are empty/placeholder-only, silent when one model is usable). `tests/unit_tests/agentserver/test_agent_reload_scope.py` (21 passed) still passes through the refactored `_mcc_looks_usable`.
* E2E on a scratch workspace: fresh init from the new template, then `jiuwenswarm-agentserver`: the warning is logged right after "starting" and the server still reaches "ready". With real credentials in `config/.env`: no warning. With the old `https://example.com/compatible-mode/v1` values restored: the warning appears again.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2441
<!-- /bot1-related-issues -->
