### PR TITLE
fix(tests): repair tests/ui_e2e Web UI smoke harness

### DIFF
--- a/tests/ui_e2e/SKILL.md
+++ b/tests/ui_e2e/SKILL.md
@@ -16,7 +16,7 @@ description: 运行 JiuwenSwarm Web UI 端到端测试并收集截图、日志�
 ## 准备环境
 
 - 选择用于启动 `jiuwenswarm.app` 和 `jiuwenswarm.app_web` 的 Python 解释器。
-- 在该解释器里安装项目依赖和 `.[e2e]`。
+- 在该解释器里安装项目依赖（Playwright 已是核心依赖，随项目一起安装）。
 - 确保 `jiuwenswarm/channels/web/frontend` 已安装前端依赖。
 - 确保本机可用 Chrome/Chromium；没有时再安装 Playwright 浏览器。
 
@@ -24,7 +24,7 @@ description: 运行 JiuwenSwarm Web UI 端到端测试并收集截图、日志�
 
 ```bash
 export JIUWENSWARM_E2E_PYTHON=.venv/bin/python
-"$JIUWENSWARM_E2E_PYTHON" -m pip install -e ".[e2e]"
+"$JIUWENSWARM_E2E_PYTHON" -m pip install -e .
 "$JIUWENSWARM_E2E_PYTHON" -m playwright install chromium
 ```
 

--- a/tests/ui_e2e/cron_ui_report.py
+++ b/tests/ui_e2e/cron_ui_report.py
@@ -34,7 +34,7 @@ except ImportError:
 
 UI_E2E_ROOT = Path(__file__).resolve().parent
 REPO_ROOT = Path(__file__).resolve().parents[2]
-WEB_DIR = REPO_ROOT / "jiuwenswarm" / "channels" / "web"
+WEB_DIR = REPO_ROOT / "jiuwenswarm" / "channels" / "web" / "frontend"
 WEB_DIST_DIR = WEB_DIR / "dist"
 APP_WEB = REPO_ROOT / "jiuwenswarm" / "channels" / "web" / "app_web.py"
 DEFAULT_HOME = Path.home()
@@ -117,6 +117,20 @@ async def _wait_for_log(log_path: Path, needle: str, timeout: float = 60.0) -> N
     if log_path.exists():
         tail = "\n".join(log_path.read_text(encoding="utf-8", errors="ignore").splitlines()[-40:])
     raise RuntimeError(f"Timed out waiting for {needle!r} in {log_path}\n{tail}")
+
+
+async def _wait_for_port(port: int, timeout: float = 60.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(1.0)
+            try:
+                sock.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                pass
+        await asyncio.sleep(0.5)
+    raise RuntimeError(f"Timed out waiting for 127.0.0.1:{port} to accept connections")
 
 
 async def _send_ws_request(
@@ -216,7 +230,7 @@ async def _close_browser(browser: Browser, playwright: Any) -> None:
 
 async def _wait_for_session(page: Page) -> str:
     await page.wait_for_selector('[data-testid="app-shell"]')
-    deadline = time.time() + 30
+    deadline = time.time() + 90
     while time.time() < deadline:
         session_id = await page.locator('[data-testid="app-shell"]').get_attribute("data-session-id")
         if session_id and session_id != "new":
@@ -482,6 +496,7 @@ async def async_main() -> int:
     agent_port = args.agent_port or _pick_free_port()
     backend_port = args.backend_port or _pick_free_port()
     ui_port = args.ui_port or _pick_free_port()
+    gateway_port = _pick_free_port()
     prefix = f"cron-ui-{timestamp}"
     backend_log = report_dir / "backend.log"
     ui_log = report_dir / "ui.log"
@@ -492,7 +507,11 @@ async def async_main() -> int:
         {
             "HOME": str(Path(args.home).expanduser()),
             "AGENT_PORT": str(agent_port),
+            "AGENT_SERVER_PORT": str(agent_port),
             "WEB_PORT": str(backend_port),
+            "GATEWAY_PORT": str(gateway_port),
+            "JIUWENSWARM_CLI_PORTS": "1",
+            "PYTHONUTF8": "1",
             "PYTHONPATH": build_repo_pythonpath(REPO_ROOT, env.get("PYTHONPATH")),
         }
     )
@@ -533,7 +552,7 @@ async def async_main() -> int:
             log_path=ui_log,
             cwd=REPO_ROOT,
         )
-        await _wait_for_log(ui_log, f"http://127.0.0.1:{ui_port}", timeout=30)
+        await _wait_for_port(ui_port, timeout=60)
         await _delete_jobs_by_prefix(backend_port, prefix)
 
         browser, playwright = await _launch_browser()

--- a/tests/ui_e2e/run_suite.py
+++ b/tests/ui_e2e/run_suite.py
@@ -13,7 +13,7 @@ except ImportError:
 
 UI_E2E_ROOT = Path(__file__).resolve().parent
 REPO_ROOT = Path(__file__).resolve().parents[2]
-WEB_DIR = REPO_ROOT / "jiuwenswarm" / "web"
+WEB_DIR = REPO_ROOT / "jiuwenswarm" / "channels" / "web" / "frontend"
 
 CASE_SCRIPTS = {
     "todo": UI_E2E_ROOT / "todo_ui_report.py",

--- a/tests/ui_e2e/test_environment.py
+++ b/tests/ui_e2e/test_environment.py
@@ -1,0 +1,36 @@
+"""Guard tests: keep the ui_e2e harness's environment assumptions valid.
+
+These tests are intentionally playwright-free so they run in environments
+without browsers installed. Do not import the case scripts here (they import
+playwright at module level); run_suite only pulls in stdlib helpers.
+"""
+from pathlib import Path
+
+import tomllib
+
+try:
+    from tests.ui_e2e import run_suite
+except ImportError:
+    import run_suite
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_web_dir_exists():
+    assert run_suite.WEB_DIR.is_dir()
+    assert (run_suite.WEB_DIR / "package.json").is_file()
+
+
+def test_case_scripts_exist():
+    for script in run_suite.CASE_SCRIPTS.values():
+        assert script.is_file()
+
+
+def test_app_web_exists():
+    assert (REPO_ROOT / "jiuwenswarm" / "channels" / "web" / "app_web.py").is_file()
+
+
+def test_playwright_is_core_dependency():
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = data["project"]["dependencies"]
+    assert any(dep.startswith("playwright") for dep in deps)

--- a/tests/ui_e2e/todo_ui_report.py
+++ b/tests/ui_e2e/todo_ui_report.py
@@ -33,7 +33,7 @@ except ImportError:
 
 UI_E2E_ROOT = Path(__file__).resolve().parent
 REPO_ROOT = Path(__file__).resolve().parents[2]
-WEB_DIR = REPO_ROOT / "jiuwenswarm" / "channels" / "web"
+WEB_DIR = REPO_ROOT / "jiuwenswarm" / "channels" / "web" / "frontend"
 WEB_DIST_DIR = WEB_DIR / "dist"
 APP_WEB = REPO_ROOT / "jiuwenswarm" / "channels" / "web" / "app_web.py"
 DEFAULT_HOME = Path.home()
@@ -116,6 +116,20 @@ async def _wait_for_log(log_path: Path, needle: str, timeout: float = 60.0) -> N
     raise RuntimeError(f"Timed out waiting for {needle!r} in {log_path}\n{tail}")
 
 
+async def _wait_for_port(port: int, timeout: float = 60.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(1.0)
+            try:
+                sock.connect(("127.0.0.1", port))
+                return
+            except OSError:
+                pass
+        await asyncio.sleep(0.5)
+    raise RuntimeError(f"Timed out waiting for 127.0.0.1:{port} to accept connections")
+
+
 async def _launch_browser() -> tuple[Browser, Any]:
     playwright = await async_playwright().start()
     chrome_path = _chrome_path()
@@ -134,7 +148,7 @@ async def _close_browser(browser: Browser, playwright: Any) -> None:
 
 async def _wait_for_session(page: Page) -> str:
     await page.wait_for_selector('[data-testid="app-shell"]')
-    deadline = time.time() + 30
+    deadline = time.time() + 90
     while time.time() < deadline:
         session_id = await page.locator('[data-testid="app-shell"]').get_attribute("data-session-id")
         if session_id and session_id != "new":
@@ -386,6 +400,7 @@ async def async_main() -> int:
     agent_port = args.agent_port or _pick_free_port()
     backend_port = args.backend_port or _pick_free_port()
     ui_port = args.ui_port or _pick_free_port()
+    gateway_port = _pick_free_port()
     backend_log = report_dir / "backend.log"
     ui_log = report_dir / "ui.log"
     runtime_info = resolve_openjiuwen_runtime(args.runtime_python, require=True)
@@ -395,7 +410,11 @@ async def async_main() -> int:
         {
             "HOME": str(Path(args.home).expanduser()),
             "AGENT_PORT": str(agent_port),
+            "AGENT_SERVER_PORT": str(agent_port),
             "WEB_PORT": str(backend_port),
+            "GATEWAY_PORT": str(gateway_port),
+            "JIUWENSWARM_CLI_PORTS": "1",
+            "PYTHONUTF8": "1",
             "PYTHONPATH": build_repo_pythonpath(REPO_ROOT, env.get("PYTHONPATH")),
         }
     )
@@ -434,7 +453,7 @@ async def async_main() -> int:
             log_path=ui_log,
             cwd=REPO_ROOT,
         )
-        await _wait_for_log(ui_log, f"http://127.0.0.1:{ui_port}", timeout=30)
+        await _wait_for_port(ui_port, timeout=60)
 
         browser, playwright = await _launch_browser()
         page = await browser.new_page(viewport={"width": 1440, "height": 1200})


### PR DESCRIPTION
Paired: [GitHub #2429](https://github.com/openJiuwen-ai/jiuwenswarm/pull/2429) ↔ [GitCode !4562](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/4562)

**What type of PR is this?**
/kind bug

**What does this PR do / why do we need it**:

`tests/ui_e2e/` (the Playwright Web UI smoke harness) has silently rotted: pytest collects nothing there, and the scripts themselves can no longer run. This PR repairs the harness and adds a small guard test so future rot fails visibly instead of silently.

Concrete breakages fixed:

* `run_suite.py` pointed `WEB_DIR` at `jiuwenswarm/web`, a path removed in the directory restructure; `--build` died with `FileNotFoundError`. Now points at `jiuwenswarm/channels/web/frontend`.
* Both case scripts used `channels/web/dist` as the dist directory, but vite builds to `channels/web/frontend/dist` (which is also what `app_web.py` serves). Without `--build` they exited "Missing dist directory" even when a valid build existed.
* The harness's port isolation no longer worked: the app loads `~/.jiuwenswarm/config/.env` with `override=True`, clobbering the injected `AGENT_PORT`/`WEB_PORT` with pinned values (and colliding with a running jiuwenswarm instance). The case scripts now inject the full port group (`AGENT_SERVER_PORT`, `GATEWAY_PORT` included) plus `JIUWENSWARM_CLI_PORTS=1`, the mechanism introduced for launchers to keep their resolved ports.
* The UI readiness check waited for the URL banner in captured stdout, but `app_web.py` writes that banner to a file logger — the wait could never succeed. Replaced with a TCP port poll. Also set `PYTHONUTF8=1` for child processes so the Chinese backend-ready marker stays matchable on non-UTF-8 locales, and raised the session wait to 90s to cover agent prewarm.

New `tests/ui_e2e/test_environment.py` (playwright-free, safe for UT environments) asserts the referenced paths and the `e2e` extra exist, so pytest finally collects something in this directory and future path rot breaks the UT job instead of rotting invisibly.

**Which issue(s) this PR fixes**:
Fixes #2448 

**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

* `pytest tests/ui_e2e -v`: 4 guard tests pass (previously 0 collected). Full `tests/` collection introduces no new errors.
* `npm run build` in the corrected `WEB_DIR` builds to `frontend/dist`.
* Live run (`python -m tests.ui_e2e.run_suite`, Windows, headless Chromium, alongside a running jiuwenswarm instance): backend starts on isolated ports, `app_web` serves the dist, the browser connects through the ws proxy to the WebChannel. Remaining known failure: the frontend never populates `data-session-id`, so both scenarios still fail at `_wait_for_session` — the frontend/backend session handshake has drifted since the harness was written. Left as a follow-up; it is app-facing drift, not harness plumbing.

**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2448
<!-- /bot1-related-issues -->
