### PR TITLE
fix(bug): OpenJiuwen now supports files sent in the first message of …

### DIFF
--- a/jiuwenswarm/channels/web/app_web.py
+++ b/jiuwenswarm/channels/web/app_web.py
@@ -33,6 +33,10 @@ parse_dotenv_early("jiuwenswarm-web")
 from jiuwenswarm.agents.harness.common.tools.ssl_config import get_insecure_ssl_context, get_ssl_verify
 from jiuwenswarm.agents.harness.team.bootstrap import configure_agent_teams_home
 from jiuwenswarm.common.debug_dump import install_async_dump_handler
+from jiuwenswarm.common.upload_block import (
+    strip_upload_document_blocks,
+    upload_document_names,
+)
 from jiuwenswarm.common.ws_diagnostics import describe_ws_exception, format_ws_diagnostics
 from jiuwenswarm.common.utils import get_agent_root_dir, get_logs_dir, \
     get_agent_sessions_dir, get_root_dir, get_user_workspace_dir, is_package_installation, \
@@ -716,7 +720,13 @@ class _SpaStaticHandler(SimpleHTTPRequestHandler):
             if record.get("role") == "user":
                 content = record.get("content")
                 if isinstance(content, str) and content.strip():
-                    return content.strip().replace("\n", " ")[:80]
+                    # Drop the 【上传文档】 path hint — it is appended for the agent,
+                    # not typed by the user, and must not surface as a title.
+                    typed = strip_upload_document_blocks(content).strip()
+                    if not typed:
+                        typed = ", ".join(upload_document_names(content))
+                    if typed:
+                        return typed.replace("\n", " ")[:80]
         return session_dir.name
 
     def _build_share_snapshot(

--- a/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
+++ b/jiuwenswarm/channels/web/frontend/src/hooks/useWebSocket.ts
@@ -1469,7 +1469,8 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
               }
             }
             if (documentItems.length) {
-              const persistedDocs = await persistDocuments(content, sessionId, documentItems);
+              const persistedDocs = await persistDocuments(outgoingContent, sessionId, documentItems);
+              outgoingContent = persistedDocs.content ?? persistedDocs.query ?? outgoingContent;
               if (Array.isArray(persistedDocs.media_items)) {
                 mergedItems.push(...persistedDocs.media_items);
               }

--- a/jiuwenswarm/common/upload_block.py
+++ b/jiuwenswarm/common/upload_block.py
@@ -1,0 +1,68 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""The agent-facing attachment block appended to messages that carry uploads.
+
+The web client appends this block at submit time
+(``InputArea.tsx::buildSubmitContent``) and the gateway fills in storage paths
+(``document_attachments.py``). It exists purely so the model knows where the
+uploaded files live — it is not something the user typed, so anything that
+displays or summarizes a message must strip it first.
+
+Two forms are recognized, mirroring ``documentMessage.ts::stripUploadDocumentBlocks``:
+
+- compact (current)::
+
+      【上传文档】
+      - report.pdf: /path/report.txt (original file: /path/report.pdf)
+
+- legacy per-file blocks::
+
+      【上传文档: report.pdf】
+      路径: /path/report.pdf
+"""
+
+from __future__ import annotations
+
+import re
+
+# Header of the compact form; entries follow on subsequent ``- `` lines.
+UPLOAD_BLOCK_HEADER = "【上传文档】"
+# Shared prefix of both forms — cheap guard before running the regexes.
+_UPLOAD_BLOCK_PREFIX = "【上传文档"
+
+_COMPACT_BLOCK_RE = re.compile(r"(?:^|\n+)【上传文档】(?:\n-[^\n]*)*")
+_LEGACY_BLOCK_RE = re.compile(r"(?:^|\n+)【上传文档[:：][^\n]*(?:\n(?!【)[^\n]*)*")
+_BLANK_RUN_RE = re.compile(r"\n{3,}")
+
+_COMPACT_ENTRY_RE = re.compile(r"^-\s*(?P<name>[^\n:：]+)", re.MULTILINE)
+_LEGACY_HEADER_RE = re.compile(r"【上传文档[:：]\s*(?P<name>[^\n】]+)】?")
+
+
+def strip_upload_document_blocks(content: str) -> str:
+    """Return ``content`` without its attachment blocks — i.e. what the user typed."""
+    if not content or _UPLOAD_BLOCK_PREFIX not in content:
+        return content
+    cleaned = _COMPACT_BLOCK_RE.sub("", content)
+    cleaned = _LEGACY_BLOCK_RE.sub("", cleaned)
+    return _BLANK_RUN_RE.sub("\n\n", cleaned).strip()
+
+
+def upload_document_names(content: str) -> list[str]:
+    """Return the filenames listed in ``content``'s attachment blocks, in order.
+
+    Used as a label of last resort when a message is nothing but attachments, so
+    that such a session is still identifiable rather than untitled.
+    """
+    if not content or _UPLOAD_BLOCK_PREFIX not in content:
+        return []
+    names: list[str] = []
+    for match in _COMPACT_BLOCK_RE.finditer(content):
+        for entry in _COMPACT_ENTRY_RE.finditer(match.group(0)):
+            name = entry.group("name").strip()
+            if name:
+                names.append(name)
+    for match in _LEGACY_HEADER_RE.finditer(content):
+        name = match.group("name").strip()
+        if name:
+            names.append(name)
+    return names

--- a/jiuwenswarm/gateway/document_attachments.py
+++ b/jiuwenswarm/gateway/document_attachments.py
@@ -20,6 +20,7 @@ from jiuwenswarm.common.document_parser import (
     resolve_document_suffix,
     supported_formats,
 )
+from jiuwenswarm.common.upload_block import UPLOAD_BLOCK_HEADER
 from jiuwenswarm.common.utils import get_agent_sessions_dir
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,9 @@ _TEXT_SIDECAR_SUFFIXES = frozenset({".pdf", ".docx", ".xlsx"})
 
 _TRUE_STRINGS = frozenset({"true", "1", "yes"})
 _FALSE_STRINGS = frozenset({"false", "0", "no"})
+
+# Message keys that may carry the attachment block; both are echoed by document.persist.
+_UPLOAD_BLOCK_CONTENT_KEYS = ("content", "query")
 
 
 def coerce_document_parse_flag(value: Any, *, default: bool = True) -> bool:
@@ -104,6 +108,9 @@ async def persist_and_parse_documents(
                 }
             )
 
+    # Names each stored document may be referred to by in the message body: the
+    # client's original filename, and the (sanitized, de-duplicated) stored one.
+    stored_names: list[set[str]] = []
     for index, item in enumerate(accepted_items):
         try:
             stored_item = await _store_and_maybe_parse_item(
@@ -115,6 +122,9 @@ async def persist_and_parse_documents(
             )
             if stored_item:
                 stored.append(stored_item)
+                requested_name = str(item.get("filename") or item.get("name") or "")
+                stored_name = str(stored_item.get("filename") or "")
+                stored_names.append({name for name in (requested_name, stored_name) if name})
         except Exception as exc:
             logger.exception("[document.persist] failed for item %s: %s", index, exc)
             errors.append(
@@ -151,6 +161,13 @@ async def persist_and_parse_documents(
             for item in stored
         ]
         params["files"] = files
+        # The client could not know the storage paths if it composed the message
+        # before this session existed; fill them in now that they are known.
+        entries = list(zip(stored_names, stored))
+        for content_key in _UPLOAD_BLOCK_CONTENT_KEYS:
+            raw_content = params.get(content_key)
+            if isinstance(raw_content, str) and raw_content:
+                params[content_key] = _fill_upload_block_paths(raw_content, entries)
     else:
         params.pop("documents", None)
 
@@ -212,6 +229,71 @@ def resolve_session_upload_path(path: str | Path, *, session_id: str | None) -> 
     if not resolved.is_file():
         raise FileNotFoundError(f"File not found: {resolved}")
     return resolved
+
+
+def _document_reference_line(display_name: str, record: dict[str, Any]) -> str:
+    """Render one ``UPLOAD_BLOCK_HEADER`` entry, matching the web client's format.
+
+    Binary documents with a ``.txt`` sidecar expose both paths: the sidecar (what
+    ``read_file`` opens) and the original, without which page-level tools such as
+    ``read_pdf`` have nothing to work on.
+    """
+    path = str(record.get("path") or "").strip()
+    if not path:
+        return f"- {display_name}"
+    original_path = str(record.get("original_path") or "").strip()
+    if original_path and original_path != path:
+        return f"- {display_name}: {path} (original file: {original_path})"
+    return f"- {display_name}: {path}"
+
+
+def _fill_upload_block_paths(
+    content: str, entries: list[tuple[set[str], dict[str, Any]]]
+) -> str:
+    """Rewrite ``UPLOAD_BLOCK_HEADER`` entries with the paths documents were stored at.
+
+    The web client composes this block at submit time from each attachment's
+    persisted record. On the first message of a new conversation there is no
+    session yet, so nothing is persisted at attach time and the block carries a
+    bare ``- <filename>``. The model then hands that to ``read_file``, which
+    resolves it against the agent workspace and fails. Persisting happens here,
+    so this is the first point where the real paths are known.
+
+    Entries are consumed in upload order, which is the order the client lists
+    them in, so repeated filenames still map to distinct records. Lines that
+    match no stored document are left untouched.
+    """
+    if not content or UPLOAD_BLOCK_HEADER not in content:
+        return content
+
+    rewritten: list[str] = []
+    cursor = 0
+    in_block = False
+    for line in content.split("\n"):
+        if line.strip() == UPLOAD_BLOCK_HEADER:
+            in_block = True
+            rewritten.append(line)
+            continue
+        if in_block:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                # A line the client already resolved reads "name: path"; keep only
+                # the name so such a line still consumes its entry (and is refreshed
+                # from the authoritative record) rather than shifting later lines.
+                display_name = stripped[2:].split(":", 1)[0].strip()
+                match = next(
+                    (i for i in range(cursor, len(entries)) if display_name in entries[i][0]),
+                    None,
+                )
+                if match is not None:
+                    rewritten.append(_document_reference_line(display_name, entries[match][1]))
+                    cursor = match + 1
+                    continue
+                rewritten.append(line)
+                continue
+            in_block = False
+        rewritten.append(line)
+    return "\n".join(rewritten)
 
 
 def _collect_document_items(params: dict[str, Any]) -> list[dict[str, Any]]:

--- a/jiuwenswarm/server/runtime/session/session_metadata.py
+++ b/jiuwenswarm/server/runtime/session/session_metadata.py
@@ -13,6 +13,10 @@ from pathlib import Path
 from typing import Any
 from datetime import datetime, timezone
 
+from jiuwenswarm.common.upload_block import (
+    strip_upload_document_blocks,
+    upload_document_names,
+)
 from jiuwenswarm.common.utils import get_agent_sessions_dir
 from jiuwenswarm.server.runtime.session.work_mode import (
     DEFAULT_WEB_WORK_MODE,
@@ -496,9 +500,13 @@ def _enqueue_write(
 
 def _auto_title(content: str) -> str:
     """从首条用户消息自动生成会话标题"""
-    # 先剥离所有小写 XML 注入标签，
-    # 避免将系统提示/文件注入/工具标签误识别为会话标题
-    cleaned = _INJECTED_TAG_RE.sub("", content).strip()
+    # 先剥离附件路径提示块（【上传文档】，由前端追加、网关补全路径，非用户输入），
+    # 再剥离所有小写 XML 注入标签，
+    # 避免将系统提示/文件注入/工具标签或上传路径误识别为会话标题
+    cleaned = _INJECTED_TAG_RE.sub("", strip_upload_document_blocks(content)).strip()
+    if not cleaned:
+        # 整条消息只有附件时，用文件名兜底，避免会话无标题
+        cleaned = ", ".join(upload_document_names(content))
     if not cleaned:
         return ""
     title = cleaned.replace("\n", " ")

--- a/tests/unit_tests/common/test_upload_block.py
+++ b/tests/unit_tests/common/test_upload_block.py
@@ -1,0 +1,68 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+
+"""Unit tests for the 【上传文档】 attachment-block helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwenswarm.common.upload_block import (
+    UPLOAD_BLOCK_HEADER,
+    strip_upload_document_blocks,
+    upload_document_names,
+)
+
+_COMPACT = (
+    "What is the title of this paper\n"
+    "【上传文档】\n"
+    "- DiT.pdf: /s/u/DiT.txt (original file: /s/u/DiT.pdf)"
+)
+_LEGACY = "hello\n【上传文档: old.pdf】\n路径: /s/old.pdf"
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("plain question", "plain question"),
+        ("", ""),
+        (_COMPACT, "What is the title of this paper"),
+        ("q\n【上传文档】\n- a.pdf", "q"),
+        ("q\n【上传文档】\n- a.pdf: /s/a.txt\n- b.pdf: /s/b.txt", "q"),
+        (_LEGACY, "hello"),
+        # Attachment-only message strips down to nothing.
+        ("【上传文档】\n- a.pdf: /s/a.txt", ""),
+        # The marker only delimits a block when it stands alone on its line.
+        ("what does 【上传文档】 mean?", "what does 【上传文档】 mean?"),
+    ],
+)
+def test_strip_upload_document_blocks(content: str, expected: str):
+    assert strip_upload_document_blocks(content) == expected
+
+
+def test_strip_preserves_user_text_after_the_block():
+    content = "first\n【上传文档】\n- a.pdf: /s/a.txt\nsecond"
+    # Block entries end at the first line that is not a "- " item.
+    assert strip_upload_document_blocks(content) == "first\nsecond"
+
+
+def test_strip_is_idempotent():
+    once = strip_upload_document_blocks(_COMPACT)
+    assert strip_upload_document_blocks(once) == once
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("no attachments here", []),
+        (_COMPACT, ["DiT.pdf"]),
+        ("q\n【上传文档】\n- a.pdf: /s/a.txt\n- b.pdf: /s/b.txt", ["a.pdf", "b.pdf"]),
+        ("q\n【上传文档】\n- bare.pdf", ["bare.pdf"]),
+        (_LEGACY, ["old.pdf"]),
+    ],
+)
+def test_upload_document_names(content: str, expected: list[str]):
+    assert upload_document_names(content) == expected
+
+
+def test_header_constant_matches_the_block_the_client_emits():
+    assert UPLOAD_BLOCK_HEADER in _COMPACT

--- a/tests/unit_tests/gateway/test_document_attachments.py
+++ b/tests/unit_tests/gateway/test_document_attachments.py
@@ -153,6 +153,150 @@ async def test_persist_and_parse_documents(tmp_path: Path, monkeypatch: pytest.M
     assert result["files"]["uploaded_documents"][0]["path"] == items[0]["path"]
 
 
+def _markdown_document(filename: str, body: str = "# body") -> dict[str, str]:
+    return {
+        "filename": filename,
+        "mime_type": "text/markdown",
+        "base64_data": base64.b64encode(body.encode("utf-8")).decode("ascii"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_upload_block_bare_filename_gets_storage_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A new conversation has no session at attach time, so the client sends a
+    pathless entry; without a path the model calls read_file on a bare filename,
+    which resolves against its own workspace and fails."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+    payload = {
+        "content": "What is the title of this paper?\n【上传文档】\n- readme.md",
+        "documents": [_markdown_document("readme.md")],
+    }
+    result = await persist_and_parse_documents(payload, "sess_block", parse=True, max_chars=1000)
+    stored_path = result["media_items"][0]["path"]
+    assert result["content"] == (
+        "What is the title of this paper?\n【上传文档】\n" f"- readme.md: {stored_path}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_block_pdf_entry_exposes_original_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A PDF's entry must name the sidecar *and* the original: page-level tools
+    such as read_pdf cannot work on the .txt."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+
+    async def fake_parse(file_path, *, max_chars=None, doc_id=""):
+        return {
+            "text": "parsed pdf body",
+            "truncated": False,
+            "parser": "PDFParser",
+            "file_ext": ".pdf",
+            "char_count": len("parsed pdf body"),
+            "documents_count": 1,
+        }
+
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.parse_document_file",
+        fake_parse,
+    )
+    payload = {
+        "content": "summarize\n【上传文档】\n- paper.pdf",
+        "documents": [
+            {
+                "filename": "paper.pdf",
+                "mime_type": "application/pdf",
+                "base64_data": base64.b64encode(b"%PDF-fake-bytes").decode("ascii"),
+            }
+        ],
+    }
+    result = await persist_and_parse_documents(payload, "sess_pdf_block", parse=True, max_chars=1000)
+    item = result["media_items"][0]
+    assert result["content"].endswith(
+        f"- paper.pdf: {item['text_path']} (original file: {item['original_path']})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_block_repeated_filenames_map_to_distinct_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Same-named uploads are stored under de-duplicated names; entries are
+    consumed in upload order so the second line cannot point at the first file."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+    payload = {
+        "content": "compare these\n【上传文档】\n- notes.md\n- notes.md",
+        "documents": [
+            _markdown_document("notes.md", "# first"),
+            _markdown_document("notes.md", "# second"),
+        ],
+    }
+    result = await persist_and_parse_documents(payload, "sess_dupe", parse=True, max_chars=1000)
+    first, second = (item["path"] for item in result["media_items"])
+    assert first != second
+    assert result["content"].endswith(f"- notes.md: {first}\n- notes.md: {second}")
+
+
+@pytest.mark.asyncio
+async def test_upload_block_leaves_unrelated_content_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """No block, an unknown filename, and prose after the block must all survive."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+    no_block = {"content": "just a question", "documents": [_markdown_document("readme.md")]}
+    result = await persist_and_parse_documents(no_block, "sess_plain", parse=True, max_chars=1000)
+    assert result["content"] == "just a question"
+
+    mixed = {
+        "content": "q\n【上传文档】\n- readme.md\n- ghost.md\n\ntrailing prose",
+        "documents": [_markdown_document("readme.md")],
+    }
+    result = await persist_and_parse_documents(mixed, "sess_mixed", parse=True, max_chars=1000)
+    stored_path = result["media_items"][0]["path"]
+    assert result["content"] == (
+        f"q\n【上传文档】\n- readme.md: {stored_path}\n- ghost.md\n\ntrailing prose"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_block_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Re-persisting a message that already carries paths must not stack them."""
+    monkeypatch.setattr(
+        "jiuwenswarm.gateway.document_attachments.get_agent_sessions_dir",
+        lambda: tmp_path,
+    )
+    payload = {
+        "content": "q\n【上传文档】\n- readme.md",
+        "documents": [_markdown_document("readme.md")],
+    }
+    once = await persist_and_parse_documents(payload, "sess_idem", parse=True, max_chars=1000)
+    first_content = once["content"]
+    again = await persist_and_parse_documents(
+        {"content": first_content, "documents": [_markdown_document("readme.md")]},
+        "sess_idem",
+        parse=True,
+        max_chars=1000,
+    )
+    # Second upload stores a de-duplicated file, so the path is refreshed rather
+    # than appended to — one "name: path" pair, pointing at the newest copy.
+    assert again["content"].count(":") == first_content.count(":")
+    assert again["content"].endswith(f"- readme.md: {again['media_items'][0]['path']}")
+
+
 @pytest.mark.asyncio
 async def test_persist_docx_writes_txt_sidecar(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(

--- a/tests/unit_tests/test_session_metadata.py
+++ b/tests/unit_tests/test_session_metadata.py
@@ -64,6 +64,39 @@ class TestAutoTitle:
         assert _auto_title("") == ""
         assert _auto_title("   ") == ""
 
+    @staticmethod
+    def test_strips_upload_document_block():
+        """【上传文档】块由前端追加、网关补全路径，不是用户输入，不应进入标题。"""
+        from jiuwenswarm.server.runtime.session.session_metadata import _auto_title
+
+        assert _auto_title("What is the title of this paper\n【上传文档】\n- DiT.pdf") == (
+            "What is the title of this paper"
+        )
+        with_paths = (
+            "What is the title of this paper\n【上传文档】\n"
+            "- DiT.pdf: /s/u/DiT.txt (original file: /s/u/DiT.pdf)"
+        )
+        assert _auto_title(with_paths) == "What is the title of this paper"
+        multi = "compare these\n【上传文档】\n- a.pdf: /s/a.txt\n- b.pdf: /s/b.txt"
+        assert _auto_title(multi) == "compare these"
+        assert _auto_title("hello\n【上传文档: old.pdf】\n路径: /s/old.pdf") == "hello"
+
+    @staticmethod
+    def test_attachment_only_falls_back_to_filenames():
+        """只发附件不打字时，用文件名兜底，好过无标题会话。"""
+        from jiuwenswarm.server.runtime.session.session_metadata import _auto_title
+
+        only = "【上传文档】\n- DiT.pdf: /s/u/DiT.txt (original file: /s/u/DiT.pdf)"
+        assert _auto_title(only) == "DiT.pdf"
+        assert _auto_title("【上传文档】\n- a.pdf: /s/a.txt\n- b.pdf: /s/b.txt") == "a.pdf, b.pdf"
+
+    @staticmethod
+    def test_keeps_header_typed_inside_prose():
+        """用户自己在正文里提到该标记时不应被吞掉（块必须独占整行）。"""
+        from jiuwenswarm.server.runtime.session.session_metadata import _auto_title
+
+        assert _auto_title("what does 【上传文档】 mean?") == "what does 【上传文档】 mean?"
+
 
 # ===========================================================================
 # init_session_metadata


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug


**What does this PR do / why do we need it**:
* Currently, if a file is sent in the first message of the conversation, the agent can't correctly read it. That is because the path to the file is not currently included in the prompt.
* The cause is due to a couple of issues:
     *  In `InputArea.tsx` - `canPersistAttachments` is false when in a new conversation. So when uploading a file, the `persistedMediaItem` is not saved.
     * In `buildSubmitContent` on the same file, since there is no `persistedMediaItem`, the path is never included in the prompt
 
The solution consists of checking if we are in the first message and including the file paths in this case. Some additional code is needed so this modification is not included in the conversation title.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2477


**What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：
Before

<img width="1556" height="855" alt="Before" src="https://github.com/user-attachments/assets/ea3a804e-062d-4bd0-bbf7-7123376d4f61" />

After

<img width="1556" height="855" alt="After" src="https://github.com/user-attachments/assets/0c137cd9-36fd-4123-a513-5f950f02911f" />



**Self-checklist**:（**Please check carefully,and mark an x in the [] brackets. We will review your completion status.**）

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [ ] **Interface**: Does it involve changes to external interfaces? The corresponding changes have been approved by the interface review organization, and the annotation information for the API has been correctly refreshed.
+ - [ ] **Document**: Does it involve modifications to the official website documentation? If so, please submit the materials to the Doc repository in a timely manner.

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2477
<!-- /bot1-related-issues -->
