### PR TITLE
feat(search): gate Jina Reader fallback behind explicit switch

### DIFF
--- a/jiuwenswarm/agents/harness/common/tools/web_fetch_tools.py
+++ b/jiuwenswarm/agents/harness/common/tools/web_fetch_tools.py
@@ -22,6 +22,7 @@ _USER_AGENT = (
 _REQUEST_HEADERS = {"User-Agent": _USER_AGENT}
 _FREE_SEARCH_PROXY_URL_ENV = "FREE_SEARCH_PROXY_URL"
 _FREE_SEARCH_SSL_VERIFY_ENV = "FREE_SEARCH_SSL_VERIFY"
+_JINA_FETCH_ENABLED_ENV = "JIUWENSWARM_ENABLE_JINA_FETCH"
 _FREE_SEARCH_DEFAULT_NO_PROXY = (
     "127.0.0.1,.huawei.com,localhost,local,.local,10.155.97.247,.myhuaweicloud.com"
 )
@@ -202,7 +203,10 @@ def _fetch_via_jina_reader_sync(url: str, timeout_seconds: int) -> dict[str, str
 
 def _fetch_webpage_sync(url: str, timeout_seconds: int) -> dict[str, str | int]:
     response = _http_get(url, headers=_REQUEST_HEADERS, timeout=timeout_seconds)
-    if response.status_code in {401, 403, 429}:
+    if response.status_code in {401, 403, 429} and _env_bool(
+        _JINA_FETCH_ENABLED_ENV,
+        default=False,
+    ):
         return _fetch_via_jina_reader_sync(url, timeout_seconds)
     response.raise_for_status()
 

--- a/jiuwenswarm/resources/.env.template
+++ b/jiuwenswarm/resources/.env.template
@@ -63,6 +63,9 @@ FREE_SEARCH_SSL_VERIFY=false
 # DuckDuckGo HTML endpoint. html.duckduckgo.com is usually less likely to return
 # anti-bot pages than duckduckgo.com/html behind corporate proxies.
 FREE_SEARCH_DDG_URL=https://html.duckduckgo.com/html/
+# Allow mcp_fetch_webpage to send blocked URLs to the external Jina Reader
+# service after a direct request returns 401, 403, or 429. Disabled by default.
+JIUWENSWARM_ENABLE_JINA_FETCH=0
 
 # Browser MCP runtime (optional)
 # 0: disabled, 1: enabled

--- a/tests/unit_tests/tools/test_web_fetch_tools.py
+++ b/tests/unit_tests/tools/test_web_fetch_tools.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = (
+    _REPO_ROOT
+    / "jiuwenswarm"
+    / "agents"
+    / "harness"
+    / "common"
+    / "tools"
+    / "web_fetch_tools.py"
+)
+
+
+def _load_module():
+    if "web_fetch_tools_mod" in sys.modules:
+        return sys.modules["web_fetch_tools_mod"]
+
+    tools_pkg = sys.modules.get("jiuwenswarm.agents.harness.common.tools")
+    if tools_pkg is None:
+        tools_pkg = types.ModuleType("jiuwenswarm.agents.harness.common.tools")
+        tools_pkg.__path__ = [str(_MODULE_PATH.parent)]
+        tools_pkg.__package__ = "jiuwenswarm.agents.harness.common.tools"
+        sys.modules["jiuwenswarm.agents.harness.common.tools"] = tools_pkg
+
+    spec = importlib.util.spec_from_file_location("web_fetch_tools_mod", str(_MODULE_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["web_fetch_tools_mod"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_module()
+
+
+def _response(status_code: int, *, url: str = "https://example.com") -> Mock:
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.url = url
+    response.headers = {"Content-Type": "text/html; charset=utf-8"}
+    response.content = b"<html><title>Example</title><body>content</body></html>"
+    response.encoding = "utf-8"
+    response.apparent_encoding = "utf-8"
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"{status_code} response",
+            response=response,
+        )
+    return response
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 429])
+def test_jina_fallback_is_disabled_by_default(monkeypatch, status_code):
+    monkeypatch.delenv("JIUWENSWARM_ENABLE_JINA_FETCH", raising=False)
+    response = _response(status_code)
+
+    with (
+        patch.object(_mod, "_http_get", return_value=response),
+        patch.object(_mod, "_fetch_via_jina_reader_sync") as jina_fetch,
+        pytest.raises(requests.HTTPError),
+    ):
+        _mod._fetch_webpage_sync("https://example.com", 30)
+
+    jina_fetch.assert_not_called()
+
+
+@pytest.mark.parametrize("enabled_value", ["1", "true", "yes", "on", "enabled"])
+def test_jina_fallback_can_be_enabled(monkeypatch, enabled_value):
+    monkeypatch.setenv("JIUWENSWARM_ENABLE_JINA_FETCH", enabled_value)
+    response = _response(403)
+    fallback_result = {
+        "url": "https://example.com",
+        "status_code": 200,
+        "title": "",
+        "content": "from jina",
+    }
+
+    with (
+        patch.object(_mod, "_http_get", return_value=response),
+        patch.object(
+            _mod,
+            "_fetch_via_jina_reader_sync",
+            return_value=fallback_result,
+        ) as jina_fetch,
+    ):
+        result = _mod._fetch_webpage_sync("https://example.com", 30)
+
+    assert result == fallback_result
+    jina_fetch.assert_called_once_with("https://example.com", 30)
+
+
+def test_successful_direct_fetch_does_not_use_jina(monkeypatch):
+    monkeypatch.setenv("JIUWENSWARM_ENABLE_JINA_FETCH", "true")
+    response = _response(200)
+
+    with (
+        patch.object(_mod, "_http_get", return_value=response),
+        patch.object(_mod, "_fetch_via_jina_reader_sync") as jina_fetch,
+    ):
+        result = _mod._fetch_webpage_sync("https://example.com", 30)
+
+    assert result["status_code"] == 200
+    assert result["title"] == "Example"
+    jina_fetch.assert_not_called()


### PR DESCRIPTION
## 背景

`enterprise_dev` 与 `dev-stable` 已长期分叉，不能直接合并或批量 cherry-pick。本 PR 对 `enterprise_dev` 上的 10 个历史 PR 逐项核查，仅迁移在当前 `dev-stable` 架构中仍存在、且可小范围安全落地的行为。

基线核查时，`dev-stable` 相对共同祖先有 1,421 个独有提交，`enterprise_dev` 有 675 个独有提交；10 个原提交均不在 `dev-stable` 历史中，逐个模拟应用也都产生冲突。因此以下结论以当前行为和替代实现为准，不以提交是否存在为准。

## 本 PR 实际改动

- 为 Web Fetch 的 Jina Reader fallback 接入仓库已登记的 `JIUWENSWARM_ENABLE_JINA_FETCH`。
- 默认关闭外部 Jina fallback；只有显式启用后，直连返回 401/403/429 才会转发到 Jina Reader。
- 在 `.env.template` 中说明该开关及外部出站行为。
- 新增 9 个单元测试，覆盖默认关闭、5 种真值、401/403/429 和直连成功不走 Jina。

## 10 个历史 PR 的实际处理结论

| 原 PR | 当前结论 | 实际处理 |
| --- | --- | --- |
| [!790 MaaS GLM-5.1 tool_calls](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/790) | 不合入 | 近期运行日志没有实际 GLM-5.1 请求，当前使用 GLM-5.2。抽查 543 次工具调用未发现参数 JSON、tool-call ID 或名称异常；LLM 错误均为连接、限流、内容拦截或超时。当前 `agent-core` 也已通用处理 usage-only chunk 和 tool-call 分片合并。若未来重新启用 GLM-5.1，应先用真实 MaaS 流式报文复测。 |
| [!794 搜索环境变量开关](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/794) | 部分已有，本 PR补齐缺口 | `dev-stable` 已有 `FREE_SEARCH_DDG_ENABLED`、`FREE_SEARCH_BING_ENABLED`；本 PR 只补 Web Fetch 的 Jina fallback 显式开关，不恢复旧路径和旧默认值。 |
| [!960 子 Agent 模型与工具](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/960) | 新架构部分替代；fork 暂缓 | 当前 `agent-core` 已有 `SubAgentSpec`、`TaskTool`、同步/异步 session 工具和隔离会话，覆盖 spawn 场景。旧 `fork_agent` 的父消息继承语义会涉及上下文截取、未完成 tool-call 清理、注入顺序、上下文预算、嵌套 session、事件/取消和安全边界，属于跨 `agent-core`/`jiuwenswarm` 的大改，本 PR 不实施。 |
| [!975 子 Agent 事件发送](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/975) | 已替代，不合入 | 当前 StreamEventRail、subagent debug trace、可观测性和性能 hook 已承担事件与跟踪能力。 |
| [!978 subagent_executor 模块化](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/978) | 已淘汰，不合入 | 被重构的旧 `jiuwenclaw/agentserver/tools/subagent_executor` 包在 `dev-stable` 中已不存在。 |
| [!981 subagent execution framework 修正](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/981) | 已淘汰，不合入 | 这是旧 executor 的后续修正，没有独立迁移价值。 |
| [!1035 简化 subAgent 参数、排除 OfficeClaw 工具](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/1035) | 已替代，不合入 | 新框架通过 `SubAgentSpec` 显式声明 tools、rails、workspace，不再恢复旧式全量工具继承。 |
| [!1052 subagent minimal mode](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/1052) | 已替代，不合入 | 当前 TaskTool 使用隔离 session/workspace，子 Agent 的 prompt、工具和上下文由 spec 控制；旧 ContextEngineeringRail 路径不存在。 |
| [!1078 subAgent 禁用 SessionMemoryManager](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/1078) | 当前默认已满足，不合入 | 新 ContextProcessorRail 只有显式启用 SessionMemoryCompressor 时才创建 SessionMemoryManager，默认关闭；子 Agent 同时使用独立会话。 |
| [!1830 AgentServer 精简依赖](https://gitcode.com/openJiuwen/jiuwenswarm/merge_requests/1830) | 已替代，不合入 | 当前 `pyproject.toml` 已提供 `harmony` 可选依赖组，并有鸿蒙构建脚本；旧静态 `requirements-minimal.txt` 不再适合当前依赖结构。 |

## 风险与兼容性

- 行为变化仅限直接抓取返回 401/403/429 时：默认不再把 URL 发送给外部 Jina Reader。
- 需要原 fallback 行为的部署可设置 `JIUWENSWARM_ENABLE_JINA_FETCH=1`。
- 直接抓取成功时行为不变。
- 本 PR 不包含 `fork_agent`，也不恢复任何旧 `jiuwenclaw/...` 模块。

## 验证

- `tests/unit_tests/tools/test_search_tools.py`
- `tests/unit_tests/tools/test_web_fetch_tools.py`
- 结果：37 passed
- Ruff：通过
- `git diff --check`：通过
